### PR TITLE
feat: add MinerU PDF extractor with pymupdf fallback and embedding provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "rich>=13.0",
     "tomli>=2.0; python_version < '3.11'",
     "markdownify>=1.2.2",
+    "openai>=2.33.0",
 ]
 
 [project.optional-dependencies]

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -108,6 +108,13 @@ class TieredGroup(click.Group):
     default=None,
     help="Output as JSON (auto-enabled when stdout is not a TTY)",
 )
+@click.option(
+    "--no-json",
+    "output_no_json",
+    is_flag=True,
+    default=False,
+    help="Force human-readable output even when stdout is not a TTY",
+)
 @click.option("--limit", default=50, help="Limit results")
 @click.option(
     "--detail", type=click.Choice(["minimal", "standard", "full"]), default="standard", help="Output detail level"
@@ -120,6 +127,7 @@ class TieredGroup(click.Group):
 def main(
     ctx: click.Context,
     output_json: bool | None,
+    output_no_json: bool,
     limit: int,
     detail: str,
     no_interaction: bool,
@@ -144,8 +152,11 @@ def main(
     ctx.call_on_close(lambda: scope.__exit__(None, None, None))
     ctx.ensure_object(dict)
     ctx.obj["request_id"] = rid
+    # Mutual exclusion check: --json and --no-json cannot be used together
+    if output_json is not None and output_no_json:
+        raise click.BadParameter("Cannot use both --json and --no-json")
     # TTY auto-detect: when stdout is redirected/piped, default to JSON so agents
-    # never have to remember --json. Explicit --json or ZOT_FORMAT env var override.
+    # never have to remember --json. Explicit --json, --no-json, or ZOT_FORMAT env var override.
     if output_json is None:
         env_fmt = os.environ.get("ZOT_FORMAT", "").lower()
         if env_fmt == "json":
@@ -154,6 +165,9 @@ def main(
             output_json = False
         else:
             output_json = not sys.stdout.isatty()
+    # --no-json forces human-readable output regardless of auto-detect
+    if output_no_json:
+        output_json = False
     ctx.obj["json"] = output_json
     ctx.obj["limit"] = limit
     ctx.obj["detail"] = detail
@@ -225,3 +239,8 @@ main.add_command(attach_cmd, "attach")
 main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")
 main.add_command(schema_cmd, "schema")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/zotero_cli_cc/commands/config.py
+++ b/src/zotero_cli_cc/commands/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -168,6 +169,73 @@ def cache_stats() -> None:
         stats = cache.stats()
         click.echo(f"Cached PDFs: {stats['entries']}")
         click.echo(f"Total chars: {stats['total_chars']:,}")
+    finally:
+        cache.close()
+
+
+@cache_group.command("list")
+@click.pass_context
+def cache_list(ctx: click.Context) -> None:
+    """List all cached PDF entries."""
+    import sqlite3
+
+    from zotero_cli_cc.core.pdf_cache import PdfCache
+
+    json_out = ctx.obj.get("json", False) if ctx.obj else False
+
+    try:
+        cache = PdfCache()
+    except (sqlite3.OperationalError, OSError) as e:
+        click.echo(f"Error: Could not open cache database: {e}", err=True)
+        raise SystemExit(1)
+    try:
+        rows = cache._conn.execute(
+            "SELECT pdf_path, extractor, LENGTH(content), content, extracted_at FROM pdf_cache ORDER BY pdf_path"
+        ).fetchall()
+
+        if not rows:
+            click.echo("Cache is empty.")
+            return
+
+        if json_out:
+            data = [
+                {
+                    "pdf_basename": row[0],
+                    "extractor": row[1],
+                    "text_length": row[2],
+                    "preview": row[3][:100],
+                    "extracted_at": row[4],
+                }
+                for row in rows
+            ]
+            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+            return
+
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.table import Table
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=120)
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("PDF Path", style="cyan", width=30)
+        table.add_column("Extractor", width=10)
+        table.add_column("Length", justify="right", width=10)
+        table.add_column("Preview", width=50)
+        table.add_column("Time", width=20)
+
+        for row in rows:
+            pdf_path, extractor, length, content, extracted_at = row
+            preview = content[:100] + "..." if len(content) > 100 else content
+            preview = preview.replace("\n", " ").replace("\r", " ")
+            table.add_row(Path(pdf_path).name, extractor, f"{length:,}", preview, extracted_at[:19])
+        console.print(table)
+        click.echo(buf.getvalue().rstrip())
+
+    except sqlite3.OperationalError as e:
+        click.echo(f"Error: Could not query cache database: {e}", err=True)
+        raise SystemExit(1)
     finally:
         cache.close()
 

--- a/src/zotero_cli_cc/commands/open_cmd.py
+++ b/src/zotero_cli_cc/commands/open_cmd.py
@@ -5,7 +5,7 @@ import sys
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.formatter import print_error
 from zotero_cli_cc.models import ErrorInfo
@@ -37,7 +37,7 @@ def open_cmd(ctx: click.Context, key: str, open_url: bool) -> None:
     data_dir = get_data_dir(cfg)
     db_path = data_dir / "zotero.sqlite"
     library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
+    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
     json_out = ctx.obj.get("json", False)
     try:
         item = reader.get_item(key)
@@ -81,11 +81,11 @@ def open_cmd(ctx: click.Context, key: str, open_url: bool) -> None:
                 output_json=json_out,
             )
             return
-        pdf_path = data_dir / "storage" / att.key / att.filename
-        if not pdf_path.exists():
+        pdf_path = att.path
+        if not pdf_path or not pdf_path.exists():
             print_error(
                 ErrorInfo(
-                    message=f"PDF file not found at {pdf_path}",
+                    message=f"PDF file not found at {pdf_path or att.filename}",
                     context="open",
                 ),
                 output_json=json_out,

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -4,8 +4,8 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, extract_text_from_pdf
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.pdf_extractor import BasePdfExtractor, PdfExtractionError, get_extractor
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.formatter import print_error
 from zotero_cli_cc.models import ErrorInfo
@@ -14,9 +14,10 @@ from zotero_cli_cc.models import ErrorInfo
 @click.command("pdf")
 @click.argument("key")
 @click.option("--pages", default=None, help="Page range, e.g. '1-5'")
+@click.option("--extractor", default=None, help="PDF extractor to use (mineru, pymupdf). Defaults to auto-detect.")
 @click.option("--annotations", is_flag=True, help="Extract annotations (highlights, notes) instead of text")
 @click.pass_context
-def pdf_cmd(ctx: click.Context, key: str, pages: str | None, annotations: bool) -> None:
+def pdf_cmd(ctx: click.Context, key: str, pages: str | None, extractor: str | None, annotations: bool) -> None:
     """Extract text from the PDF attachment.
 
     Full text is cached locally for fast repeated access.
@@ -30,6 +31,9 @@ def pdf_cmd(ctx: click.Context, key: str, pages: str | None, annotations: bool) 
     cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
     page_range = None
+    if extractor is None:
+        from zotero_cli_cc.config import load_pdf_config
+        extractor = load_pdf_config().extractor
     if pages:
         try:
             parts = pages.split("-")
@@ -51,7 +55,7 @@ def pdf_cmd(ctx: click.Context, key: str, pages: str | None, annotations: bool) 
     data_dir = get_data_dir(cfg)
     db_path = data_dir / "zotero.sqlite"
     library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
+    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
     try:
         att = reader.get_pdf_attachment(key)
         if att is None:
@@ -64,13 +68,13 @@ def pdf_cmd(ctx: click.Context, key: str, pages: str | None, annotations: bool) 
                 output_json=json_out,
             )
             return
-        pdf_path = data_dir / "storage" / att.key / att.filename
-        if not pdf_path.exists():
+        pdf_path = att.path
+        if not pdf_path or not pdf_path.exists():
             print_error(
                 ErrorInfo(
-                    message=f"PDF file not found at {pdf_path}",
+                    message=f"PDF file not found at {pdf_path or att.filename}",
                     context="pdf",
-                    hint="The file may have been moved. Check Zotero storage directory",
+                    hint="The file may have been moved or the attachment path could not be resolved. Check Zotero storage directory",
                 ),
                 output_json=json_out,
             )
@@ -105,14 +109,31 @@ def pdf_cmd(ctx: click.Context, key: str, pages: str | None, annotations: bool) 
         cache = PdfCache()
         try:
             if page_range is None:
-                cached = cache.get(pdf_path)
+                cached = cache.get(pdf_path, extractor)
                 if cached is not None:
                     text = cached
                 else:
-                    text = extract_text_from_pdf(pdf_path)
-                    cache.put(pdf_path, text)
+                    pdf_extractor = get_extractor(extractor)
+                    try:
+                        text = pdf_extractor.extract_text(pdf_path)
+                        cache.put(pdf_path, extractor, text)
+                    except PdfExtractionError:
+                        if extractor == "mineru":
+                            pdf_extractor = get_extractor("pymupdf")
+                            text = pdf_extractor.extract_text(pdf_path)
+                            cache.put(pdf_path, "pymupdf", text)
+                        else:
+                            raise
             else:
-                text = extract_text_from_pdf(pdf_path, pages=page_range)
+                pdf_extractor = get_extractor(extractor)
+                try:
+                    text = pdf_extractor.extract_text(pdf_path, pages=page_range)
+                except PdfExtractionError:
+                    if extractor == "mineru":
+                        pdf_extractor = get_extractor("pymupdf")
+                        text = pdf_extractor.extract_text(pdf_path, pages=page_range)
+                    else:
+                        raise
         except PdfExtractionError as e:
             cache.close()
             print_error(

--- a/src/zotero_cli_cc/commands/workspace.py
+++ b/src/zotero_cli_cc/commands/workspace.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, load_embedding_config, resolve_library_id
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, load_embedding_config, resolve_library_id
 from zotero_cli_cc.core.rag import (
     bm25_score_chunks,
     build_metadata_chunk,
     chunk_text,
     compute_term_frequencies,
     convert_pdf_to_text,
+    convert_pdfs_to_text,
     embed_texts,
     reciprocal_rank_fusion,
     semantic_score_chunks,
@@ -510,10 +513,14 @@ def _resolve_collection_key(reader: ZoteroReader, name_or_key: str) -> str | Non
 @workspace_group.command("index")
 @click.argument("name")
 @click.option("--force", is_flag=True, help="Rebuild index from scratch")
+@click.option("--extractor", default=None, help="PDF text extractor to use")
 @click.pass_context
-def workspace_index(ctx: click.Context, name: str, force: bool) -> None:
+def workspace_index(ctx: click.Context, name: str, force: bool, extractor: str | None) -> None:
     """Build RAG index for a workspace."""
     json_out = ctx.obj.get("json", False)
+    if extractor is None:
+        from zotero_cli_cc.config import load_pdf_config
+        extractor = load_pdf_config().extractor
     if not workspace_exists(name):
         print_error(
             ErrorInfo(
@@ -534,7 +541,7 @@ def workspace_index(ctx: click.Context, name: str, force: bool) -> None:
     data_dir = get_data_dir(cfg)
     db_path = data_dir / "zotero.sqlite"
     library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
+    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
 
     idx_path = workspaces_dir() / f"{name}.idx.sqlite"
     idx = RagIndex(idx_path)
@@ -550,55 +557,124 @@ def workspace_index(ctx: click.Context, name: str, force: bool) -> None:
             click.echo(f"Index for '{name}' is up to date ({len(already_indexed)} item(s) indexed).")
             return
 
-        from zotero_cli_cc.core.pdf_cache import PdfCache
-
-        md_cache_path = workspaces_dir() / ".md_cache.sqlite"
-        md_cache = PdfCache(db_path=md_cache_path)
+    # PHASE 1 — Extract all PDF texts
+        import pymupdf
 
         t0 = time.monotonic()
-        total_chunks = 0
-        all_chunk_ids: list[int] = []
-        all_chunk_texts: list[str] = []
 
+        # Gather items and PDF paths
+        item_map: dict[str, Item] = {}
+        pdf_paths_map: dict[str, Path] = {}  # key → path
+        path_to_key: dict[Path, str] = {}    # path → key
         for ws_item in to_index:
             item = reader.get_item(ws_item.key)
             if item is None:
                 click.echo(f"Warning: item '{ws_item.key}' not found in Zotero, skipped")
                 continue
+            item_map[ws_item.key] = item
+            att = reader.get_pdf_attachment(ws_item.key)
+            if att is not None and att.path is not None and att.path.exists():
+                pdf_paths_map[ws_item.key] = att.path
+                path_to_key[att.path] = ws_item.key
 
-            # Build metadata chunk
+        # Compute total pages for header
+        total_pages = 0
+        for pdf_path in pdf_paths_map.values():
+            doc = pymupdf.open(str(pdf_path))
+            total_pages += len(doc)
+            doc.close()
+
+        # Determine extraction strategy
+        pdf_texts: dict[str, str | Exception] = {}  # key → text or error
+        pdf_errors: list[tuple[str, str, Exception]] = []
+
+        if pdf_paths_map:
+            if extractor == "mineru" and len(pdf_paths_map) > 1:
+                # MinerU batch — has its own progress callback
+                click.echo(f"  Extracting {len(pdf_paths_map)} PDFs ({total_pages} pages) with MinerU...")
+
+                def batch_progress(phase: str, current: int, total: int, _pages: int) -> None:
+                    sys.stderr.write(f"\r{' ' * 60}\r    [{phase}] [{current}/{total}]")
+                    sys.stdout.flush()
+
+                batch_results = convert_pdfs_to_text(
+                    list(pdf_paths_map.values()), "mineru", batch_progress
+                )
+                for path, text_or_err in batch_results.items():
+                    key = path_to_key[path]
+                    pdf_texts[key] = text_or_err
+            else:
+                # Sequential extraction (pymupdf or single MinerU)
+                click.echo(f"  Extracting PDFs ({total_pages} pages)...")
+
+                for i, (key, pdf_path) in enumerate(pdf_paths_map.items(), 1):
+                    sys.stderr.write(f"\r{' ' * 60}\r    [extract] [{i}/{len(pdf_paths_map)}]")
+                    sys.stdout.flush()
+                    try:
+                        text = convert_pdf_to_text(pdf_path, extractor_name=extractor)
+                        pdf_texts[key] = text
+                    except Exception as e:
+                        pdf_texts[key] = e
+                        pdf_errors.append((key, pdf_path.name, e))
+                sys.stderr.write(f"\r{' ' * 60}\r")
+                sys.stdout.flush()
+
+    # PHASE 2 — Chunk all texts
+        click.echo(f"  Chunking {len(to_index)} item(s)...")
+
+        all_chunks: list[tuple[str, str, str, int]] = []  # (key, type, content, doc_len)
+
+        for ws_item in to_index:
+            item = item_map.get(ws_item.key)
+            if item is None:
+                continue
+
             authors = ", ".join(c.full_name for c in item.creators)
             meta_text = build_metadata_chunk(item.title, authors, item.abstract, item.tags)
-            chunk_id = idx.insert_chunk(ws_item.key, "metadata", meta_text)
-            tfs = compute_term_frequencies(tokenize(meta_text))
-            idx.insert_bm25_terms(chunk_id, tfs)
+            meta_tokens = len(tokenize(meta_text))
+            all_chunks.append((ws_item.key, "metadata", meta_text, meta_tokens))
+
+            if ws_item.key in pdf_texts:
+                pdf_text_or_err = pdf_texts[ws_item.key]
+                if isinstance(pdf_text_or_err, Exception):
+                    pass
+                else:
+                    for chunk_content in chunk_text(pdf_text_or_err, item.title):
+                        chunk_tokens = len(tokenize(chunk_content))
+                        all_chunks.append((ws_item.key, "pdf", chunk_content, chunk_tokens))
+
+    # PHASE 3 — Index all chunks (bulk insert, single commit)
+        click.echo(f"  Indexing {len(all_chunks)} chunk(s)...")
+
+        all_chunk_ids: list[int] = []
+        all_chunk_texts: list[str] = []
+
+        for i, (key, chunk_type, content, doc_len) in enumerate(all_chunks, 1):
+            if i % 500 == 0 or i == len(all_chunks):
+                sys.stderr.write(f"\r{' ' * 60}\r    [index] [{i}/{len(all_chunks)}]")
+                sys.stdout.flush()
+
+            chunk_id = idx.insert_chunk_no_commit(key, chunk_type, content, doc_len)
+            tfs = compute_term_frequencies(tokenize(content))
+            idx.insert_bm25_terms_no_commit(chunk_id, tfs)
             all_chunk_ids.append(chunk_id)
-            all_chunk_texts.append(meta_text)
-            total_chunks += 1
+            all_chunk_texts.append(content)
 
-            # Try PDF
-            att = reader.get_pdf_attachment(ws_item.key)
-            if att is not None:
-                pdf_path = data_dir / "storage" / att.key / att.filename
-                if pdf_path.exists():
-                    try:
-                        pdf_text = convert_pdf_to_text(pdf_path, cache=md_cache)
-                        chunks = chunk_text(pdf_text, item.title)
-                        for chunk_content in chunks:
-                            cid = idx.insert_chunk(ws_item.key, "pdf", chunk_content)
-                            tfs = compute_term_frequencies(tokenize(chunk_content))
-                            idx.insert_bm25_terms(cid, tfs)
-                            all_chunk_ids.append(cid)
-                            all_chunk_texts.append(chunk_content)
-                            total_chunks += 1
-                    except Exception:
-                        pass  # skip PDF extraction errors silently
+        idx.commit()
+        sys.stderr.write(f"\r{' ' * 60}\r")
+        sys.stdout.flush()
 
-        # Update BM25 statistics
-        all_chunks = idx.get_all_chunks()
-        total_docs = len(all_chunks)
+        # Report extraction errors at end
+        if pdf_errors:
+            click.echo(f"\nWarning: {len(pdf_errors)} PDF extraction(s) failed:")
+            for key, pdf_name, exc in pdf_errors:
+                click.echo(f"  - {key} ({pdf_name}): {exc}")
+
+        total_chunks = len(all_chunks)
+        all_indexed_chunks = idx.get_all_chunks()
+        total_docs = len(all_indexed_chunks)
         if total_docs > 0:
-            total_len = sum(len(tokenize(c["content"])) for c in all_chunks)
+            total_len = sum(c.get("doc_len", 0) or len(tokenize(c["content"])) for c in all_indexed_chunks)
             avg_doc_len = total_len / total_docs
         else:
             avg_doc_len = 1.0
@@ -611,19 +687,25 @@ def workspace_index(ctx: click.Context, name: str, force: bool) -> None:
         mode_label = "BM25"
         emb_cfg = load_embedding_config()
         if emb_cfg.is_configured and all_chunk_texts:
+            click.echo(f"  Generating embeddings...")
+
+            def emb_progress(done: int, total: int) -> None:
+                sys.stderr.write(f"\r{' ' * 60}\r    [embed] [{done}/{total}]")
+                sys.stdout.flush()
+
             try:
-                vectors = embed_texts(all_chunk_texts, emb_cfg)
+                vectors = embed_texts(all_chunk_texts, emb_cfg, emb_progress)
                 if vectors:
-                    for cid, vec in zip(all_chunk_ids, vectors):
-                        idx.set_embedding(cid, vec)
+                    idx.set_embeddings_bulk(all_chunk_ids, vectors)
                     mode_label = "BM25 + embeddings"
-            except Exception:
-                pass  # embedding failures are non-fatal
+            except Exception as e:
+                click.echo(f"  [WARN] Embedding failed: {e}", err=True)
+            sys.stderr.write(f"\r{' ' * 60}\r")
+            sys.stdout.flush()
 
         elapsed = time.monotonic() - t0
         click.echo(f"Indexed {len(to_index)} item(s) ({total_chunks} chunks) in {elapsed:.1f}s [{mode_label}]")
     finally:
-        md_cache.close()
         idx.close()
         reader.close()
 
@@ -666,9 +748,15 @@ def workspace_query(ctx: click.Context, question: str, ws_name: str, top_k: int,
         return
 
     idx = RagIndex(idx_path)
+    if not json_out:
+        sys.stderr.write(f"\r    [loading index]")
+        sys.stderr.flush()
     try:
-        # Determine effective mode
-        has_embeddings = len(idx.get_all_embeddings()) > 0
+        # Determine effective mode (cheap check instead of loading all embeddings)
+        row = idx._conn.execute(
+            "SELECT 1 FROM chunks WHERE embedding IS NOT NULL LIMIT 1"
+        ).fetchone()
+        has_embeddings = row is not None
         if mode == "auto":
             effective_mode = "hybrid" if has_embeddings else "bm25"
         else:
@@ -678,7 +766,13 @@ def workspace_query(ctx: click.Context, question: str, ws_name: str, top_k: int,
         semantic_results: list[tuple[int, float, dict]] = []
 
         if effective_mode in ("bm25", "hybrid"):
-            bm25_results = bm25_score_chunks(idx, question)
+            if json_out:
+                bm25_results = bm25_score_chunks(idx, question, None)
+            else:
+                def bm25_progress(done: int, total: int) -> None:
+                    sys.stderr.write(f"\r{' ' * 60}\r    [bm25] [{done}/{total}]")
+                    sys.stdout.flush()
+                bm25_results = bm25_score_chunks(idx, question, bm25_progress)
 
         if effective_mode in ("semantic", "hybrid") and has_embeddings:
             emb_cfg = load_embedding_config()
@@ -686,9 +780,19 @@ def workspace_query(ctx: click.Context, question: str, ws_name: str, top_k: int,
                 try:
                     q_vecs = embed_texts([question], emb_cfg)
                     if q_vecs:
-                        semantic_results = semantic_score_chunks(idx, q_vecs[0])
+                        if json_out:
+                            semantic_results = semantic_score_chunks(idx, q_vecs[0], None)
+                        else:
+                            def sem_progress(done: int, total: int) -> None:
+                                sys.stderr.write(f"\r{' ' * 60}\r    [semantic] [{done}/{total}]")
+                                sys.stdout.flush()
+                            semantic_results = semantic_score_chunks(idx, q_vecs[0], sem_progress)
                 except Exception:
                     pass
+
+        if not json_out:
+            sys.stderr.write(f"\r{' ' * 60}\r")
+            sys.stdout.flush()
 
         # Merge results
         if effective_mode == "hybrid" and bm25_results and semantic_results:

--- a/src/zotero_cli_cc/config.py
+++ b/src/zotero_cli_cc/config.py
@@ -50,6 +50,7 @@ class AppConfig:
     default_format: str = "table"
     default_limit: int = 50
     default_export_style: str = "bibtex"
+    prefs_js_path: str = ""
 
     @property
     def has_write_credentials(self) -> bool:
@@ -78,6 +79,7 @@ def load_config(path: Path | None = None, profile: str | None = None) -> AppConf
                 default_format=output.get("default_format", "table"),
                 default_limit=output.get("limit", 50),
                 default_export_style=export.get("default_style", "bibtex"),
+                prefs_js_path=p.get("prefs_js_path", ""),
             )
 
     # Backward-compatible flat config
@@ -92,6 +94,7 @@ def load_config(path: Path | None = None, profile: str | None = None) -> AppConf
         default_format=output.get("default_format", "table"),
         default_limit=output.get("limit", 50),
         default_export_style=export.get("default_style", "bibtex"),
+        prefs_js_path=zotero.get("prefs_js_path", ""),
     )
 
 
@@ -100,10 +103,12 @@ class EmbeddingConfig:
     url: str = "https://api.jina.ai/v1/embeddings"
     api_key: str = ""
     model: str = "jina-embeddings-v3"
+    provider: str = "auto"
+    aliyun_api_key: str = ""
 
     @property
     def is_configured(self) -> bool:
-        return bool(self.url and self.api_key)
+        return bool(self.url and self.api_key) or bool(self.aliyun_api_key)
 
 
 _SENTINEL = object()
@@ -121,14 +126,38 @@ def load_embedding_config(path: Path | None = None, *, apply_env_overrides: obje
             url=emb.get("url", defaults.url),
             api_key=emb.get("api_key", defaults.api_key),
             model=emb.get("model", defaults.model),
+            provider=emb.get("provider", defaults.provider),
+            aliyun_api_key=emb.get("aliyun_api_key", defaults.aliyun_api_key),
         )
-    # Apply env overrides: always when explicitly requested or using default path;
-    # skip when an explicit path is provided and caller didn't opt in.
     should_apply_env = apply_env_overrides is True or (apply_env_overrides is _SENTINEL and not explicit_path)
     if should_apply_env:
         defaults.url = os.environ.get("ZOT_EMBEDDING_URL", defaults.url)
         defaults.api_key = os.environ.get("ZOT_EMBEDDING_KEY", defaults.api_key)
         defaults.model = os.environ.get("ZOT_EMBEDDING_MODEL", defaults.model)
+        defaults.provider = os.environ.get("ZOT_EMBEDDING_PROVIDER", defaults.provider)
+        defaults.aliyun_api_key = os.environ.get("ZOT_EMBEDDING_ALIYUN_KEY", defaults.aliyun_api_key)
+    return defaults
+
+
+@dataclass
+class PdfConfig:
+    extractor: str = "pymupdf"
+    mineru_token: str = ""
+
+
+def load_pdf_config(path: Path | None = None) -> PdfConfig:
+    path = path or CONFIG_FILE
+    defaults = PdfConfig()
+    if path.exists():
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        pdf = data.get("pdf", {})
+        defaults = PdfConfig(
+            extractor=pdf.get("extractor", defaults.extractor),
+            mineru_token=pdf.get("mineru_token", defaults.mineru_token),
+        )
+    defaults.extractor = os.environ.get("ZOT_PDF_EXTRACTOR", defaults.extractor)
+    defaults.mineru_token = os.environ.get("MINERU_TOKEN", defaults.mineru_token)
     return defaults
 
 
@@ -201,6 +230,31 @@ def get_data_dir(config: AppConfig) -> Path:
     if env_dir:
         return Path(env_dir)
     return detect_zotero_data_dir(config)
+
+
+def get_prefs_js_path(config: AppConfig) -> Path | None:
+    """Get Zotero prefs.js path: env override > config > default.
+
+    Handles both file and directory paths:
+    - File path: returned as-is if it exists
+    - Directory path: appends 'prefs.js' (Zotero profile directory convention)
+    """
+    env_path = os.environ.get("ZOT_PREFS_JS_PATH")
+    if env_path:
+        p = Path(env_path).expanduser()
+        if p.exists():
+            if p.is_dir():
+                p = p / "prefs.js"
+            return p if p.exists() else None
+        return None
+    if config.prefs_js_path:
+        p = Path(config.prefs_js_path).expanduser()
+        if p.exists():
+            if p.is_dir():
+                p = p / "prefs.js"
+            return p if p.exists() else None
+        return None
+    return None
 
 
 def resolve_library_id(db_path: Path, ctx_obj: dict) -> int:

--- a/src/zotero_cli_cc/core/pdf_cache.py
+++ b/src/zotero_cli_cc/core/pdf_cache.py
@@ -14,34 +14,41 @@ class PdfCache:
         self._conn = sqlite3.connect(str(self._db_path))
         self._conn.execute(
             "CREATE TABLE IF NOT EXISTS pdf_cache ("
-            "  pdf_path TEXT PRIMARY KEY,"
+            "  pdf_path TEXT NOT NULL,"
+            "  extractor TEXT NOT NULL DEFAULT '',"
             "  mtime REAL NOT NULL,"
             "  content TEXT NOT NULL,"
-            "  extracted_at TEXT NOT NULL"
+            "  extracted_at TEXT NOT NULL,"
+            "  PRIMARY KEY (pdf_path, extractor)"
             ")"
         )
         self._conn.commit()
 
-    def get(self, pdf_path: Path) -> str | None:
+    def get(self, pdf_path: Path, extractor_name: str = "") -> str | None:
         if not pdf_path.exists():
             return None
         current_mtime = pdf_path.stat().st_mtime
         row = self._conn.execute(
-            "SELECT content, mtime FROM pdf_cache WHERE pdf_path = ?",
-            (str(pdf_path),),
+            "SELECT content, mtime FROM pdf_cache WHERE pdf_path = ? AND extractor = ?",
+            (str(pdf_path), extractor_name),
         ).fetchone()
         if row is None:
             return None
         if abs(row[1] - current_mtime) > 0.001:
-            return None  # stale
+            return None
         return str(row[0])
 
-    def put(self, pdf_path: Path, content: str) -> None:
+    def put(self, pdf_path: Path, extractor_name_or_content: str, content: str | None = None) -> None:
+        if content is None:
+            content = extractor_name_or_content
+            extractor_name = ""
+        else:
+            extractor_name = extractor_name_or_content
         mtime = pdf_path.stat().st_mtime
         now = datetime.now(timezone.utc).isoformat()
         self._conn.execute(
-            "INSERT OR REPLACE INTO pdf_cache (pdf_path, mtime, content, extracted_at) VALUES (?, ?, ?, ?)",
-            (str(pdf_path), mtime, content, now),
+            "INSERT OR REPLACE INTO pdf_cache (pdf_path, extractor, mtime, content, extracted_at) VALUES (?, ?, ?, ?, ?)",
+            (str(pdf_path), extractor_name, mtime, content, now),
         )
         self._conn.commit()
 
@@ -55,3 +62,6 @@ class PdfCache:
 
     def close(self) -> None:
         self._conn.close()
+
+
+UnifiedPdfCache = PdfCache

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+import io
+import os
 import re
+import sys
+import time
+import warnings
+import zipfile
+from abc import ABC, abstractmethod
+from collections import deque
 from pathlib import Path
+from threading import Lock
+from typing import Callable
 
 import pymupdf
+import requests
 
 
 class PdfExtractionError(Exception):
@@ -12,10 +23,573 @@ class PdfExtractionError(Exception):
     pass
 
 
+class BasePdfExtractor(ABC):
+    """Abstract base class for PDF text/annotation extraction."""
+
+    @abstractmethod
+    def extract_text(self, pdf_path: Path, pages: tuple[int, int] | None = None) -> str:
+        """Extract text from a PDF.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            pages: Optional (start, end) page tuple (1-indexed, inclusive).
+
+        Returns:
+            Extracted text, one page per line.
+        """
+        ...
+
+    @abstractmethod
+    def extract_annotations(self, pdf_path: Path) -> list[dict]:
+        """Extract annotations (highlights, notes, comments) from a PDF.
+
+        Returns:
+            List of dicts with keys: type, page, content, quote (for highlights).
+        """
+        ...
+
+    @abstractmethod
+    def extract_doi(self, pdf_path: Path) -> str | None:
+        """Extract DOI from first 2 pages of a PDF.
+
+        Returns:
+            First DOI match or None.
+        """
+        ...
+
+    @abstractmethod
+    def name(self) -> str:
+        """Return the extractor name (e.g. 'pymupdf')."""
+        ...
+
+
+class PyMuPdfExtractor(BasePdfExtractor):
+    def __init__(self):
+        self._pymupdf4llm_available = None
+
+    def _check_pymupdf4llm(self) -> bool:
+        if self._pymupdf4llm_available is None:
+            try:
+                import pymupdf4llm  # type: ignore[import]
+
+                self._pymupdf4llm_available = True
+            except ImportError:
+                self._pymupdf4llm_available = False
+        return self._pymupdf4llm_available
+
+    def extract_text(self, pdf_path: Path, pages: tuple[int, int] | None = None) -> str:
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+        if self._check_pymupdf4llm():
+            try:
+                import pymupdf4llm  # type: ignore[import]
+
+                if pages:
+                    start, end = pages
+                    md = pymupdf4llm.to_markdown(str(pdf_path), pages=list(range(start - 1, end)))
+                else:
+                    md = pymupdf4llm.to_markdown(str(pdf_path))
+                return str(md)
+            except Exception:
+                pass
+
+        try:
+            doc = pymupdf.open(str(pdf_path))
+        except Exception as e:
+            raise type(e)(f"Cannot open PDF: {e}") from e
+        try:
+            if pages:
+                start, end = pages
+                if start > len(doc):
+                    raise ValueError(f"Start page {start} exceeds document length ({len(doc)} pages)")
+                page_range = range(start - 1, min(end, len(doc)))
+            else:
+                page_range = range(len(doc))
+            texts = []
+            for i in page_range:
+                texts.append(doc[i].get_text())
+            return "\n".join(texts)
+        finally:
+            doc.close()
+
+    def extract_annotations(self, pdf_path: Path) -> list[dict]:
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF not found: {pdf_path}")
+        try:
+            doc = pymupdf.open(str(pdf_path))
+        except Exception as e:
+            raise type(e)(f"Cannot open PDF: {e}") from e
+        annotations: list[dict] = []
+        try:
+            for page_num, page in enumerate(doc, start=1):  # type: ignore[arg-type]
+                for annot in page.annots() or []:
+                    entry: dict = {
+                        "type": annot.type[1],
+                        "page": page_num,
+                        "content": annot.info.get("content", "") or "",
+                    }
+                    if annot.type[0] in (8, 9, 10, 11):
+                        try:
+                            quads = annot.vertices
+                            if quads:
+                                quad_points = [pymupdf.Quad(quads[i : i + 4]) for i in range(0, len(quads), 4)]
+                                text_parts = []
+                                for q in quad_points:
+                                    text_parts.append(page.get_text("text", clip=q.rect).strip())
+                                quoted = " ".join(t for t in text_parts if t)
+                                if quoted:
+                                    entry["quote"] = quoted
+                        except Exception:
+                            pass
+                    annotations.append(entry)
+        finally:
+            doc.close()
+        return annotations
+
+    def extract_doi(self, pdf_path: Path) -> str | None:
+        try:
+            text = self.extract_text(pdf_path, pages=(1, 2))
+        except (FileNotFoundError, OSError):
+            return None
+        match = re.search(r"10\.\d{4,9}/[^\s]+", text)
+        if match:
+            return match.group(0).rstrip(".,;)]}>'\"")
+        return None
+
+    def name(self) -> str:
+        return "pymupdf"
+
+
+# ---------------------------------------------------------------------------
+# MinerUExtractor - optional, may fail to import if 'requests' not installed
+# ---------------------------------------------------------------------------
+
+from requests import Session
+
+class MinerUExtractor(BasePdfExtractor):
+    _API_BASE = "https://mineru.net/api/v4"
+    _RATE_LIMIT = 50
+    _RATE_WINDOW = 60.0
+
+    def __init__(self, config_token: str | None = None) -> None:
+        self._session = Session()
+        self._rate_limiter = _RateLimiter(self._RATE_LIMIT, self._RATE_WINDOW)
+        self._token: str | None = None
+        self._config_token = config_token
+
+    @property
+    def token(self) -> str:
+        if self._token is None:
+            self._token = _load_token(self._config_token)
+        return self._token
+
+    def name(self) -> str:
+        return "mineru"
+
+    def extract_annotations(self, pdf_path: Path) -> list[dict]:
+        return []
+
+    def extract_doi(self, pdf_path: Path) -> str | None:
+        return None
+
+    def _upload_batch(
+        self,
+        files: list[tuple[Path, str, str]],
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> tuple[str, list[str]]:
+        url = f"{self._API_BASE}/file-urls/batch"
+        payload = {
+            "files": [{"name": name, "data_id": data_id[:50]} for _, name, data_id in files],
+            "model_version": "vlm"
+        }
+        headers = {"Authorization": f"Bearer {self.token}"}
+        self._rate_limiter.acquire()
+        resp = _retry_with_backoff(
+            lambda: self._session.post(url, json=payload, headers=headers, timeout=30)
+        )
+        if resp.status_code != 200:
+            raise PdfExtractionError(f"Failed to get upload URL: {resp.status_code} {resp.text}")
+        resp_json = resp.json()
+        data = resp_json['data']
+        batch_id = data.get("batch_id")
+        file_urls = data.get("file_urls", [])
+        if not batch_id or not file_urls:
+            raise PdfExtractionError(f"Invalid response from file-urls/batch: {data}")
+
+        for idx, ((pdf_path, _, _), upload_url) in enumerate(zip(files, file_urls)):
+            self._rate_limiter.acquire()
+            with open(pdf_path, "rb") as f:
+                resp = _retry_with_backoff(
+                    lambda: self._session.put(
+                        upload_url,
+                        data=f,
+                        timeout=120,
+                    )
+                )
+                if resp.status_code not in (200, 201):
+                    raise PdfExtractionError(f"Failed to upload file: {resp.status_code} {resp.text}")
+            if progress_callback:
+                progress_callback(idx + 1)
+
+        return batch_id, file_urls
+
+    def _poll_batch_results(
+        self,
+        batch_id: str,
+        expected_count: int,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> dict[str, tuple[str, str, str]]:
+        url = f"{self._API_BASE}/extract-results/batch/{batch_id}"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        for _ in range(360):
+            self._rate_limiter.acquire()
+            resp = _retry_with_backoff(
+                lambda: self._session.get(url, headers=headers, timeout=30)
+            )
+            if resp.status_code != 200:
+                raise PdfExtractionError(f"Failed to poll results: {resp.status_code} {resp.text}")
+            result = resp.json()
+            data = result.get("data", {})
+            extract_results = data.get("extract_result", [])
+            if not extract_results:
+                raise PdfExtractionError(f"No extract_result in response: {result}")
+
+            state_map: dict[str, tuple[str, str, str]] = {}
+            pending_count = 0
+            done_count = 0
+
+            for item in extract_results:
+                file_name = item.get("file_name", "")
+                state = item.get("state", "")
+                full_zip_url = item.get("full_zip_url") or ""
+                err_msg = item.get("err_msg") or ""
+                state_map[file_name] = (state, full_zip_url, err_msg)
+                if state in ("waiting-file", "pending", "running"):
+                    pending_count += 1
+                elif state == "done":
+                    done_count += 1
+
+            if progress_callback:
+                progress_callback(done_count, expected_count)
+
+            if pending_count == 0:
+                return state_map
+
+            time.sleep(5)
+        raise PdfExtractionError(
+            f"Timeout waiting for MinerU extraction (360 polls). "
+            f"Pending files remain in batch {batch_id}"
+        )
+
+    def _poll_results(self, batch_id: str) -> str:
+        state_map = self._poll_batch_results(batch_id, 1)
+        item = next(iter(state_map.values()))
+        state, full_zip_url, err_msg = item
+        if state == "failed":
+            raise PdfExtractionError(f"MinerU extraction failed: {err_msg}")
+        if state != "done":
+            raise PdfExtractionError(f"Unexpected state: {state}")
+        if not full_zip_url:
+            raise PdfExtractionError(f"No full_zip_url in completed response")
+        return full_zip_url
+
+    def _download_and_extract(self, zip_url: str) -> str:
+        headers = {"Authorization": f"Bearer {self.token}"}
+        self._rate_limiter.acquire()
+        resp = _retry_with_backoff(
+            lambda: self._session.get(zip_url, headers=headers, timeout=300, stream=True)
+        )
+        if resp.status_code != 200:
+            raise PdfExtractionError(f"Failed to download ZIP: {resp.status_code} {resp.text}")
+        zip_data = io.BytesIO(resp.content)
+        with zipfile.ZipFile(zip_data) as zf:
+            if "full.md" not in zf.namelist():
+                raise PdfExtractionError(f"full.md not found in ZIP: {zf.namelist()}")
+            raw_md = zf.read("full.md").decode("utf-8", errors="replace")
+        return _clean_markdown_images(raw_md)
+
+    def _split_pdf(self, pdf_path: Path, max_pages: int) -> list[Path]:
+        doc = pymupdf.open(str(pdf_path))
+        total_pages = len(doc)
+        chunks: list[Path] = []
+        for start in range(0, total_pages, max_pages):
+            chunk_path = pdf_path.with_suffix(f".chunk{start // max_pages}.pdf")
+            chunk_doc = pymupdf.open()
+            end = min(start + max_pages, total_pages)
+            for page_num in range(start, end):
+                chunk_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
+            chunk_doc.save(str(chunk_path))
+            chunk_doc.close()
+            chunks.append(chunk_path)
+        doc.close()
+        return chunks
+
+    def _extract_single(self, pdf_path: Path) -> str:
+        file_name = pdf_path.name
+        data_id = os.path.splitext(file_name)[0]
+        batch_id, [zip_url] = self._upload_batch([(pdf_path, file_name, data_id)])
+        zip_url = self._poll_results(batch_id)
+        return self._download_and_extract(zip_url)
+
+    def extract_text(self, pdf_path: Path, pages: tuple[int, int] | None = None) -> str:
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+        file_size = pdf_path.stat().st_size
+        if file_size > 200 * 1024 * 1024:
+            raise PdfExtractionError("PDF exceeds 200MB limit")
+
+        doc = pymupdf.open(str(pdf_path))
+        total_pages = len(doc)
+        doc.close()
+
+        if total_pages > 200:
+            if pages:
+                raise PdfExtractionError("Page range splitting not supported for PDFs >200 pages")
+            chunk_paths = self._split_pdf(pdf_path, 200)
+            try:
+                texts = []
+                for chunk_path in chunk_paths:
+                    texts.append(self._extract_single(chunk_path))
+                return "\n\n".join(texts)
+            finally:
+                for chunk_path in chunk_paths:
+                    chunk_path.unlink(missing_ok=True)
+        else:
+            if pages:
+                chunk_path = pdf_path.with_suffix(".pagetemp.pdf")
+                doc = pymupdf.open(str(pdf_path))
+                chunk_doc = pymupdf.open()
+                start, end = pages
+                for page_num in range(start - 1, min(end, total_pages)):
+                    chunk_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
+                chunk_doc.save(str(chunk_path))
+                chunk_doc.close()
+                doc.close()
+                try:
+                    return self._extract_single(chunk_path)
+                finally:
+                    chunk_path.unlink(missing_ok=True)
+            else:
+                return self._extract_single(pdf_path)
+
+    def extract_text_batch(
+        self,
+        pdf_paths: list[Path],
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> dict[Path, str | Exception]:
+        results: dict[Path, str | Exception] = {}
+        temp_files: list[Path] = []
+        original_to_chunks: dict[Path, list[Path]] = {}
+        total_pages = 0
+
+        def do_progress(phase: str, current: int, total: int, pages: int = 0) -> None:
+            if progress_callback:
+                progress_callback(phase, current, total, pages)
+
+        valid_batch_args: list[tuple[Path, str, str]] = []
+        validated_count = 0
+        for pdf_path in pdf_paths:
+            validated_count += 1
+            do_progress("validate", validated_count, len(pdf_paths), total_pages)
+
+            if not pdf_path.exists():
+                results[pdf_path] = FileNotFoundError(f"PDF not found: {pdf_path}")
+                continue
+
+            file_size = pdf_path.stat().st_size
+            if file_size > 200 * 1024 * 1024:
+                results[pdf_path] = PdfExtractionError("PDF exceeds 200MB limit")
+                continue
+
+            doc = pymupdf.open(str(pdf_path))
+            page_count = len(doc)
+            doc.close()
+            total_pages += page_count
+
+            if page_count > 200:
+                chunk_paths = self._split_pdf(pdf_path, 200)
+                temp_files.extend(chunk_paths)
+                original_to_chunks[pdf_path] = chunk_paths
+                for chunk_path in chunk_paths:
+                    file_name = chunk_path.name
+                    data_id = os.path.splitext(pdf_path.name)[0] + f"_p{chunk_path.stem.split('chunk')[1]}"
+                    valid_batch_args.append((chunk_path, file_name, data_id))
+            else:
+                original_to_chunks[pdf_path] = [pdf_path]
+                file_name = pdf_path.name
+                data_id = os.path.splitext(file_name)[0]
+                valid_batch_args.append((pdf_path, file_name, data_id))
+
+        total_chunks = len(valid_batch_args)
+        total_batches = (total_chunks + 49) // 50
+
+        upload_count = 0
+        download_count = 0
+        completed_count = 0
+
+        for batch_idx, i in enumerate(range(0, len(valid_batch_args), 50)):
+            batch = valid_batch_args[i:i + 50]
+
+            def upload_progress(idx: int) -> None:
+                nonlocal upload_count
+                upload_count = i + idx
+                do_progress("upload", upload_count, total_chunks, total_pages)
+
+            batch_id, _ = self._upload_batch(batch, upload_progress)
+
+            def poll_progress(done: int, _batch_total: int) -> None:
+                nonlocal completed_count
+                completed_count = done
+                do_progress("process", completed_count, total_chunks, total_pages)
+
+            state_map = self._poll_batch_results(batch_id, len(batch), poll_progress)
+
+            for chunk_path, file_name, _ in batch:
+                download_count += 1
+                do_progress("download", download_count, total_chunks, total_pages)
+
+                state, full_zip_url, err_msg = state_map.get(file_name, ("", "", ""))
+
+                orig_for_chunk: Path | None = None
+                for orig, chunks in original_to_chunks.items():
+                    if chunk_path in chunks:
+                        orig_for_chunk = orig
+                        break
+
+                if orig_for_chunk is None:
+                    continue
+
+                if state == "failed":
+                    results[orig_for_chunk] = PdfExtractionError(f"MinerU extraction failed: {err_msg}")
+                elif state == "done" and full_zip_url:
+                    try:
+                        text = self._download_and_extract(full_zip_url)
+                        existing = results.get(orig_for_chunk)
+                        if existing is None or isinstance(existing, Exception):
+                            results[orig_for_chunk] = text
+                        else:
+                            results[orig_for_chunk] = existing + "\n\n" + text
+                    except Exception as e:
+                        results[orig_for_chunk] = e
+                else:
+                    results[orig_for_chunk] = PdfExtractionError(f"Unexpected state: {state}")
+
+        for temp_file in temp_files:
+            temp_file.unlink(missing_ok=True)
+
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (used by MinerUExtractor)
+# ---------------------------------------------------------------------------
+
+
+class _RateLimiter:
+    def __init__(self, limit: int, window: float) -> None:
+        self._limit = limit
+        self._window = window
+        self._timestamps: deque[float] = deque()
+        self._lock = Lock()
+
+    def acquire(self) -> None:
+        while True:
+            with self._lock:
+                now = time.time()
+                while self._timestamps and self._timestamps[0] <= now - self._window:
+                    self._timestamps.popleft()
+                if len(self._timestamps) < self._limit:
+                    self._timestamps.append(time.time())
+                    return
+                sleep_time = self._timestamps[0] - (now - self._window)
+            if sleep_time > 0:
+                sys.stdout.write(f"\r{' ' * 60}\r    [rate-limit] sleeping {sleep_time:.1f}s")
+                sys.stdout.flush()
+                time.sleep(sleep_time)
+                while self._timestamps and self._timestamps[0] <= now - self._window:
+                    self._timestamps.popleft()
+
+
+def _load_token(config_token: str | None = None) -> str:
+    token = os.environ.get("MINERU_TOKEN")
+    if token:
+        return token
+    token_path = Path.home() / ".config" / "mineru" / "token"
+    if token_path.exists():
+        return token_path.read_text().strip()
+    if config_token:
+        return config_token
+    raise PdfExtractionError("MINERU_TOKEN not set and ~/.config/mineru/token not found")
+
+
+def _retry_with_backoff(func, *args, **kwargs):
+    for attempt in range(3):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            if attempt == 2:
+                raise
+            time.sleep(1 * (attempt + 1))
+    raise
+
+
+def _clean_markdown_images(text: str) -> str:
+    return re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"", text)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+_EXTRACTORS: dict[str, type[BasePdfExtractor]] = {
+    "pymupdf": PyMuPdfExtractor,
+    "mineru": MinerUExtractor
+}
+
+
+def get_extractor(name: str | None = None) -> BasePdfExtractor:
+    """Factory to get a registered PDF extractor by name.
+
+    Args:
+        name: Extractor name (e.g. 'pymupdf'). If None, reads from config.
+
+    Returns:
+        An instance of the requested extractor.
+
+    Raises:
+        KeyError: If no extractor with the given name is registered.
+    """
+    if name is None:
+        from zotero_cli_cc.config import load_pdf_config
+
+        cfg = load_pdf_config()
+        name = cfg.extractor
+    extractor_cls = _EXTRACTORS[name]
+    if name == "mineru":
+        from zotero_cli_cc.config import load_pdf_config
+
+        cfg = load_pdf_config()
+        return extractor_cls(cfg.mineru_token)  # type: ignore[reportCallIssue]
+    return extractor_cls()
+
+
+# ---------------------------------------------------------------------------
+# Deprecated functions (kept for backwards compatibility)
+# ---------------------------------------------------------------------------
+
+
 def extract_text_from_pdf(
     pdf_path: Path,
     pages: tuple[int, int] | None = None,
 ) -> str:
+    warnings.warn(
+        "extract_text_from_pdf is deprecated, use PyMuPdfExtractor().extract_text or get_extractor('pymupdf')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not pdf_path.exists():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
     try:
@@ -47,6 +621,11 @@ def extract_annotations(pdf_path: Path) -> list[dict]:
 
     Returns list of dicts with keys: type, page, content, quote (for highlights).
     """
+    warnings.warn(
+        "extract_annotations is deprecated, use PyMuPdfExtractor().extract_annotations or get_extractor('pymupdf')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not pdf_path.exists():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
     try:
@@ -84,6 +663,11 @@ def extract_annotations(pdf_path: Path) -> list[dict]:
 
 def extract_doi(pdf_path: Path) -> str | None:
     """Extract DOI from first 2 pages of a PDF. Returns first match or None."""
+    warnings.warn(
+        "extract_doi is deprecated, use PyMuPdfExtractor().extract_doi or get_extractor('pymupdf')",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         text = extract_text_from_pdf(pdf_path, pages=(1, 2))
     except (PdfExtractionError, FileNotFoundError):

--- a/src/zotero_cli_cc/core/rag.py
+++ b/src/zotero_cli_cc/core/rag.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import json as json_mod
 import math
 import re
-import urllib.request
 from collections import Counter
 from pathlib import Path
+from typing import Callable
 
 from zotero_cli_cc.config import EmbeddingConfig
+from zotero_cli_cc.core.embedding_router import EmbeddingRouter
 from zotero_cli_cc.core.pdf_cache import PdfCache
+from zotero_cli_cc.core.pdf_extractor import get_extractor
 from zotero_cli_cc.core.rag_index import RagIndex
 
 
@@ -39,15 +40,110 @@ def build_metadata_chunk(title: str, authors: str, abstract: str | None, tags: l
     return "\n".join(parts)
 
 
+def clean_html(text: str) -> str:
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</p>", "\n\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</h[1-6]>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<td[^>]*>(.*?)</td>", r"\1\t", text, flags=re.IGNORECASE)
+    text = re.sub(r"<th[^>]*>(.*?)</th>", r"\1\t", text, flags=re.IGNORECASE)
+    text = re.sub(r"</tr>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<tr[^>]*>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"</table>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<table[^>]*>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<li[^>]*>(.*?)</li>", r"\n- \1", text, flags=re.IGNORECASE)
+    text = re.sub(r"</li>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"&#(\d+);", lambda m: chr(int(m.group(1))), text)
+    text = re.sub(r"&#x([0-9a-fA-F]+);", lambda m: chr(int(m.group(1), 16)), text)
+    text = re.sub(r"&nbsp;", " ", text)
+    text = re.sub(r"&amp;", "&", text)
+    text = re.sub(r"&lt;", "<", text)
+    text = re.sub(r"&gt;", ">", text)
+    text = re.sub(r"&quot;", '"', text)
+    text = re.sub(r"&apos;", "'", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _chunk_by_char(text: str, max_chars: int, overlap: int) -> list[str]:
+    if len(text) <= max_chars:
+        return [text]
+    step = max_chars - overlap if overlap else max_chars
+    result = []
+    start = 0
+    while start < len(text):
+        end = start + max_chars if start + max_chars <= len(text) else len(text)
+        result.append(text[start:end])
+        start += step
+    return result
+
+
+def _chunk_by_word(text: str, max_chars: int, overlap: int) -> list[str]:
+    words = text.split()
+    result: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for word in words:
+        word_len = len(word) + 1
+        if word_len > max_chars:
+            if current:
+                result.append(" ".join(current))
+                current = []
+                current_len = 0
+            result.extend(_chunk_by_char(word, max_chars, overlap))
+        elif current_len + word_len > max_chars and current:
+            result.append(" ".join(current))
+            current = [word]
+            current_len = word_len
+        else:
+            current.append(word)
+            current_len += word_len
+    if current:
+        result.append(" ".join(current))
+    return result
+
+
+def _chunk_by_sentence(text: str, max_chars: int, overlap: int) -> list[str]:
+    sentences = re.split(r"(?<=[。！？])|(?<=[.?!])\s+", text)
+    result: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for sent in sentences:
+        sent_len = len(sent)
+        if sent_len > max_chars:
+            if current:
+                result.append("".join(current))
+                current = []
+                current_len = 0
+            result.extend(_chunk_by_word(sent, max_chars, overlap))
+        elif current_len + sent_len > max_chars and current:
+            result.append("".join(current))
+            current = [sent]
+            current_len = sent_len
+        else:
+            current.append(sent)
+            current_len += sent_len
+    if current:
+        result.append("".join(current))
+    return result
+
+
+def cascade_chunk(text: str, max_chars: int, overlap: int) -> list[str]:
+    if len(text) <= max_chars:
+        return [text]
+    return _chunk_by_sentence(text, max_chars, overlap)
+
+
 def chunk_text(text: str, paper_title: str, max_tokens: int = 500, overlap: int = 50) -> list[str]:
+    text = clean_html(text)
     sections: list[tuple[str, str]] = []
     current_heading = ""
     current_text = ""
     for line in text.split("\n"):
-        if re.match(r"^#{2,3}\s+", line):
+        if re.match(r"^#{1,3}\s+", line):
             if current_text.strip():
                 sections.append((current_heading, current_text.strip()))
-            current_heading = re.sub(r"^#{2,3}\s+", "", line).strip()
+            current_heading = re.sub(r"^#{1,3}\s+", "", line).strip()
             current_text = ""
         else:
             current_text += line + "\n"
@@ -57,57 +153,83 @@ def chunk_text(text: str, paper_title: str, max_tokens: int = 500, overlap: int 
         sections = [("", text.strip())]
 
     chunks: list[str] = []
+    max_chars = max_tokens * 4
     for heading, section_text in sections:
         prefix = f"[{paper_title} > {heading}] " if heading else f"[{paper_title}] "
-        words = section_text.split()
-        if len(words) <= max_tokens:
+        if len(section_text) <= max_chars:
             chunks.append(prefix + section_text)
         else:
             paragraphs = re.split(r"\n\n+", section_text)
-            current_chunk_words: list[str] = []
             for para in paragraphs:
-                para_words = para.split()
-                # If a single paragraph exceeds max_tokens, split it directly by words
-                if len(para_words) > max_tokens:
-                    # flush current buffer first
-                    if current_chunk_words:
-                        chunks.append(prefix + " ".join(current_chunk_words))
-                        current_chunk_words = current_chunk_words[-overlap:] if overlap else []
-                    i = 0
-                    while i < len(para_words):
-                        window = para_words[i : i + max_tokens]
-                        chunks.append(prefix + " ".join(window))
-                        i += max_tokens - overlap if overlap else max_tokens
-                    continue
-                if len(current_chunk_words) + len(para_words) > max_tokens and current_chunk_words:
-                    chunks.append(prefix + " ".join(current_chunk_words))
-                    current_chunk_words = current_chunk_words[-overlap:] if overlap else []
-                current_chunk_words.extend(para_words)
-            if current_chunk_words:
-                chunks.append(prefix + " ".join(current_chunk_words))
+                if len(para) <= max_chars:
+                    chunks.append(prefix + para)
+                else:
+                    sub_chunks = cascade_chunk(para, max_chars, overlap)
+                    for sc in sub_chunks:
+                        chunks.append(prefix + sc)
     return chunks if chunks else [f"[{paper_title}] {text.strip()}"]
 
 
-def convert_pdf_to_text(pdf_path: Path, cache: PdfCache | None = None) -> str:
-    """Convert PDF to text. Uses cache if provided, pymupdf4llm if available, else plain extraction."""
-    if cache is not None:
-        cached = cache.get(pdf_path)
-        if cached is not None:
-            return cached
-    try:
-        import pymupdf4llm
-
-        text: str = pymupdf4llm.to_markdown(str(pdf_path))
-    except ImportError:
-        from zotero_cli_cc.core.pdf_extractor import extract_text_from_pdf
-
-        text = extract_text_from_pdf(pdf_path)
-    if cache is not None:
-        cache.put(pdf_path, text)
+def convert_pdf_to_text(pdf_path: Path, extractor_name: str = "pymupdf") -> str:
+    cache = PdfCache()
+    cached = cache.get(pdf_path, extractor_name)
+    if cached is not None:
+        return cached
+    extractor = get_extractor(extractor_name)
+    text = extractor.extract_text(pdf_path)
+    cache.put(pdf_path, extractor_name, text)
     return text
 
 
-def bm25_score_chunks(index: RagIndex, query: str, k1: float = 1.5, b: float = 0.75) -> list[tuple[int, float, dict]]:
+def convert_pdfs_to_text(
+    pdf_paths: list[Path],
+    extractor_name: str = "pymupdf",
+    progress_callback: Callable[[str, int, int, int], None] | None = None,
+) -> dict[Path, str | Exception]:
+    cache = PdfCache()
+    results: dict[Path, str | Exception] = {}
+    uncached: list[Path] = []
+
+    for pdf_path in pdf_paths:
+        cached_text = cache.get(pdf_path, extractor_name)
+        if cached_text is not None:
+            results[pdf_path] = cached_text
+        else:
+            uncached.append(pdf_path)
+
+    if not uncached:
+        return results
+
+    if extractor_name == "mineru" and len(uncached) > 1:
+        extractor = get_extractor(extractor_name)
+        if hasattr(extractor, "extract_text_batch"):  # type: ignore[reportAttributeAccessIssue]
+            batch_results = extractor.extract_text_batch(uncached, progress_callback)  # type: ignore[reportAttributeAccessIssue]
+            for path, text_or_err in batch_results.items():
+                if isinstance(text_or_err, str):
+                    cache.put(path, "mineru", text_or_err)
+                results[path] = text_or_err
+            return results
+
+    total = len(uncached)
+    for idx, pdf_path in enumerate(uncached, 1):
+        if progress_callback:
+            progress_callback("extract", idx, total, 0)
+        try:
+            text = convert_pdf_to_text(pdf_path, "pymupdf")
+            results[pdf_path] = text
+        except Exception as e:
+            results[pdf_path] = e
+
+    return results
+
+
+def bm25_score_chunks(
+    index: RagIndex,
+    query: str,
+    progress_callback: Callable[[int, int], None] | None = None,
+    k1: float = 1.5,
+    b: float = 0.75,
+) -> list[tuple[int, float, dict]]:
     query_terms = tokenize(query)
     if not query_terms:
         return []
@@ -116,27 +238,49 @@ def bm25_score_chunks(index: RagIndex, query: str, k1: float = 1.5, b: float = 0
     if total_docs == 0:
         return []
     chunks = index.get_all_chunks()
+    total_chunks = len(chunks)
+    chunk_ids = [c["id"] for c in chunks]
+
+    # Bulk fetch df for query terms (1 query instead of N queries)
     conn = index._conn
-    df: dict[str, int] = {}
+    placeholders = ",".join("?" * len(query_terms))
+    df_rows = conn.execute(
+        f"SELECT term, COUNT(DISTINCT chunk_id) as cnt FROM bm25_terms WHERE term IN ({placeholders}) GROUP BY term",
+        query_terms,
+    ).fetchall()
+    df: dict[str, int] = {r["term"]: r["cnt"] for r in df_rows}
+
+    # Pre-compute IDF for each query term (avoid re-computing per chunk)
+    idf: dict[str, float] = {}
     for term in query_terms:
-        row = conn.execute("SELECT COUNT(DISTINCT chunk_id) as cnt FROM bm25_terms WHERE term = ?", (term,)).fetchone()
-        df[term] = row["cnt"] if row else 0
+        dft = df.get(term, 0)
+        idf[term] = math.log((total_docs - dft + 0.5) / (dft + 0.5) + 1)
+
+    # Bulk fetch all term frequencies for all chunks (1 query)
+    all_term_tfs = index.get_bm25_terms_bulk(chunk_ids)
+
     results: list[tuple[int, float, dict]] = []
-    for chunk in chunks:
+    report_every = max(1, total_chunks // 50)
+    for i, chunk in enumerate(chunks):
         chunk_id = chunk["id"]
-        term_tfs = index.get_bm25_terms_for_chunk(chunk_id)
-        doc_len = len(tokenize(chunk["content"]))
+        term_tfs = all_term_tfs.get(chunk_id, {})
+        doc_len = chunk.get("doc_len", 0) or len(tokenize(chunk["content"]))
         score = 0.0
         for term in query_terms:
-            if term not in df or df[term] == 0:
+            dft = df.get(term, 0)
+            if dft == 0:
                 continue
             tf = term_tfs.get(term, 0.0)
-            idf = math.log((total_docs - df[term] + 0.5) / (df[term] + 0.5) + 1)
+            idf_val = idf[term]
             numerator = tf * (k1 + 1)
             denominator = tf + k1 * (1 - b + b * doc_len / avg_dl)
-            score += idf * numerator / denominator
+            score += idf_val * numerator / denominator
         if score > 0:
             results.append((chunk_id, score, chunk))
+        if progress_callback and (i + 1) % report_every == 0:
+            progress_callback(i + 1, total_chunks)
+    if progress_callback:
+        progress_callback(total_chunks, total_chunks)
     results.sort(key=lambda x: x[1], reverse=True)
     return results
 
@@ -150,14 +294,21 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
     return dot / (norm_a * norm_b)
 
 
-def semantic_score_chunks(index: RagIndex, query_embedding: list[float]) -> list[tuple[int, float, dict]]:
+def semantic_score_chunks(
+    index: RagIndex,
+    query_embedding: list[float],
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> list[tuple[int, float, dict]]:
     embeddings = index.get_all_embeddings()
+    total_emb = len(embeddings)
     chunks_by_id = {c["id"]: c for c in index.get_all_chunks()}
     results: list[tuple[int, float, dict]] = []
-    for chunk_id, vec in embeddings:
+    for i, (chunk_id, vec) in enumerate(embeddings):
         score = cosine_similarity(query_embedding, vec)
         if chunk_id in chunks_by_id:
             results.append((chunk_id, score, chunks_by_id[chunk_id]))
+        if progress_callback:
+            progress_callback(i + 1, total_emb)
     results.sort(key=lambda x: x[1], reverse=True)
     return results
 
@@ -174,20 +325,15 @@ def reciprocal_rank_fusion(*rankings: list[tuple[int, float, dict]], k: int = 60
     return results
 
 
-def embed_texts(texts: list[str], config: EmbeddingConfig) -> list[list[float]] | None:
+def embed_texts(
+    texts: list[str],
+    config: EmbeddingConfig,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> list[list[float]] | None:
     if not config.is_configured:
         return None
-    all_embeddings: list[list[float]] = []
-    batch_size = 64
-    for i in range(0, len(texts), batch_size):
-        batch = texts[i : i + batch_size]
-        body = json_mod.dumps({"model": config.model, "input": batch}).encode()
-        req = urllib.request.Request(config.url, data=body)
-        req.add_header("Content-Type", "application/json")
-        req.add_header("Authorization", f"Bearer {config.api_key}")
-        req.add_header("User-Agent", "zot-cli/0.2.0")
-        with urllib.request.urlopen(req) as resp:
-            data = json_mod.loads(resp.read())
-        for item in data["data"]:
-            all_embeddings.append(item["embedding"])
-    return all_embeddings
+    router = EmbeddingRouter(config)
+    try:
+        return router.embed(texts, progress_callback)
+    except Exception:
+        return None

--- a/src/zotero_cli_cc/core/rag_index.py
+++ b/src/zotero_cli_cc/core/rag_index.py
@@ -20,6 +20,7 @@ class RagIndex:
                 item_key TEXT NOT NULL,
                 source TEXT NOT NULL,
                 content TEXT NOT NULL,
+                doc_len INTEGER NOT NULL DEFAULT 0,
                 embedding BLOB
             );
             CREATE TABLE IF NOT EXISTS bm25_terms (
@@ -29,6 +30,7 @@ class RagIndex:
                 FOREIGN KEY (chunk_id) REFERENCES chunks(id)
             );
             CREATE INDEX IF NOT EXISTS idx_bm25_term ON bm25_terms(term);
+            CREATE INDEX IF NOT EXISTS idx_bm25_chunk ON bm25_terms(chunk_id);
             CREATE INDEX IF NOT EXISTS idx_chunks_item ON chunks(item_key);
             CREATE TABLE IF NOT EXISTS index_meta (
                 key TEXT PRIMARY KEY,
@@ -37,12 +39,19 @@ class RagIndex:
         """)
         self._conn.commit()
 
-    def insert_chunk(self, item_key: str, source: str, content: str) -> int:
+    def insert_chunk(self, item_key: str, source: str, content: str, doc_len: int = 0) -> int:
         cur = self._conn.execute(
-            "INSERT INTO chunks (item_key, source, content) VALUES (?, ?, ?)",
-            (item_key, source, content),
+            "INSERT INTO chunks (item_key, source, content, doc_len) VALUES (?, ?, ?, ?)",
+            (item_key, source, content, doc_len),
         )
         self._conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def insert_chunk_no_commit(self, item_key: str, source: str, content: str, doc_len: int = 0) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO chunks (item_key, source, content, doc_len) VALUES (?, ?, ?, ?)",
+            (item_key, source, content, doc_len),
+        )
         return cur.lastrowid  # type: ignore[return-value]
 
     def insert_bm25_terms(self, chunk_id: int, term_tfs: dict[str, float]) -> None:
@@ -50,35 +59,76 @@ class RagIndex:
             "INSERT INTO bm25_terms (term, chunk_id, tf) VALUES (?, ?, ?)",
             [(term, chunk_id, tf) for term, tf in term_tfs.items()],
         )
+
+    def insert_bm25_terms_no_commit(self, chunk_id: int, term_tfs: dict[str, float]) -> None:
+        self._conn.executemany(
+            "INSERT INTO bm25_terms (term, chunk_id, tf) VALUES (?, ?, ?)",
+            [(term, chunk_id, tf) for term, tf in term_tfs.items()],
+        )
+
+    def commit(self) -> None:
         self._conn.commit()
 
     def get_all_chunks(self) -> list[dict]:
-        rows = self._conn.execute("SELECT id, item_key, source, content FROM chunks").fetchall()
+        rows = self._conn.execute(
+            "SELECT id, item_key, source, content, doc_len FROM chunks"
+        ).fetchall()
         return [dict(r) for r in rows]
 
     def get_bm25_terms_for_chunk(self, chunk_id: int) -> dict[str, float]:
-        rows = self._conn.execute("SELECT term, tf FROM bm25_terms WHERE chunk_id = ?", (chunk_id,)).fetchall()
+        rows = self._conn.execute(
+            "SELECT term, tf FROM bm25_terms WHERE chunk_id = ?", (chunk_id,)
+        ).fetchall()
         return {r["term"]: r["tf"] for r in rows}
+
+    def get_bm25_terms_bulk(self, chunk_ids: list[int]) -> dict[int, dict[str, float]]:
+        if not chunk_ids:
+            return {}
+        placeholders = ",".join("?" * len(chunk_ids))
+        rows = self._conn.execute(
+            f"SELECT chunk_id, term, tf FROM bm25_terms WHERE chunk_id IN ({placeholders})",
+            chunk_ids,
+        ).fetchall()
+        result: dict[int, dict[str, float]] = {cid: {} for cid in chunk_ids}
+        for r in rows:
+            result[r["chunk_id"]][r["term"]] = r["tf"]
+        return result
 
     def get_indexed_keys(self) -> set[str]:
         rows = self._conn.execute("SELECT DISTINCT item_key FROM chunks").fetchall()
         return {r["item_key"] for r in rows}
 
     def set_meta(self, key: str, value: str) -> None:
-        self._conn.execute("INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)", (key, value))
+        self._conn.execute(
+            "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?, ?)", (key, value)
+        )
         self._conn.commit()
 
     def get_meta(self, key: str) -> str | None:
-        row = self._conn.execute("SELECT value FROM index_meta WHERE key = ?", (key,)).fetchone()
+        row = self._conn.execute(
+            "SELECT value FROM index_meta WHERE key = ?", (key,)
+        ).fetchone()
         return row["value"] if row else None
 
     def set_embedding(self, chunk_id: int, embedding: list[float]) -> None:
         blob = struct.pack(f"{len(embedding)}f", *embedding)
-        self._conn.execute("UPDATE chunks SET embedding = ? WHERE id = ?", (blob, chunk_id))
+        self._conn.execute(
+            "UPDATE chunks SET embedding = ? WHERE id = ?", (blob, chunk_id)
+        )
+        self._conn.commit()
+
+    def set_embeddings_bulk(self, chunk_ids: list[int], embeddings: list[list[float]]) -> None:
+        for chunk_id, embedding in zip(chunk_ids, embeddings):
+            blob = struct.pack(f"{len(embedding)}f", *embedding)
+            self._conn.execute(
+                "UPDATE chunks SET embedding = ? WHERE id = ?", (blob, chunk_id)
+            )
         self._conn.commit()
 
     def get_embedding(self, chunk_id: int) -> list[float]:
-        row = self._conn.execute("SELECT embedding FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+        row = self._conn.execute(
+            "SELECT embedding FROM chunks WHERE id = ?", (chunk_id,)
+        ).fetchone()
         if row is None or row["embedding"] is None:
             return []
         blob = row["embedding"]
@@ -86,7 +136,9 @@ class RagIndex:
         return list(struct.unpack(f"{count}f", blob))
 
     def get_all_embeddings(self) -> list[tuple[int, list[float]]]:
-        rows = self._conn.execute("SELECT id, embedding FROM chunks WHERE embedding IS NOT NULL").fetchall()
+        rows = self._conn.execute(
+            "SELECT id, embedding FROM chunks WHERE embedding IS NOT NULL"
+        ).fetchall()
         result = []
         for r in rows:
             count = len(r["embedding"]) // 4
@@ -95,7 +147,9 @@ class RagIndex:
         return result
 
     def clear(self) -> None:
-        self._conn.executescript("DELETE FROM bm25_terms; DELETE FROM chunks; DELETE FROM index_meta;")
+        self._conn.executescript(
+            "DELETE FROM bm25_terms; DELETE FROM chunks; DELETE FROM index_meta;"
+        )
         self._conn.commit()
 
     def close(self) -> None:

--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -28,7 +28,7 @@ MAX_SCHEMA_VERSION = 200
 
 
 class ZoteroReader:
-    def __init__(self, db_path: Path, library_id: int = 1) -> None:
+    def __init__(self, db_path: Path, library_id: int = 1, prefs_js_path: Path | None = None) -> None:
         self._db_path = db_path
         self._library_id = library_id
         self._conn: sqlite3.Connection | None = None
@@ -36,6 +36,8 @@ class ZoteroReader:
         self._excluded_sql: str | None = None
         self._excluded_ids: tuple[int, ...] | None = None
         self._tmp_dir_obj: tempfile.TemporaryDirectory[str] | None = None
+        from zotero_cli_cc.core.attachment_resolver import AttachmentResolver
+        self._resolver = AttachmentResolver(db_path, prefs_js_path)
 
     def _connect(self) -> sqlite3.Connection:
         if self._conn is not None:
@@ -574,14 +576,21 @@ class ZoteroReader:
         attachments = []
         for r in rows:
             raw_path = r["path"] or ""
-            filename = raw_path.replace("storage:", "") if raw_path.startswith("storage:") else raw_path
+            resolved = self._resolver.resolve(r["key"], raw_path)
+            if resolved:
+                filename = resolved.name
+            elif raw_path.startswith("storage:"):
+                parts = raw_path.replace("storage:", "").split("/")
+                filename = parts[-1] if parts else ""
+            else:
+                filename = raw_path.split("/")[-1] if raw_path else ""
             attachments.append(
                 Attachment(
                     key=r["key"],
                     parent_key=key,
                     filename=filename,
                     content_type=r["contentType"] or "",
-                    path=None,
+                    path=resolved,
                 )
             )
         return attachments

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from zotero_cli_cc.config import get_data_dir, load_config, load_embedding_config
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, load_embedding_config
 from zotero_cli_cc.core.pdf_cache import PdfCache
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, extract_text_from_pdf
 from zotero_cli_cc.core.reader import ZoteroReader
@@ -41,11 +41,12 @@ def _get_reader(library: str = "user") -> ZoteroReader:
     cfg = load_config()
     data_dir = get_data_dir(cfg)
     db_path = data_dir / "zotero.sqlite"
+    prefs_path = get_prefs_js_path(cfg)
 
     library_id = 1
     if library.startswith("group:"):
         group_id = int(library[6:])
-        temp = ZoteroReader(db_path)
+        temp = ZoteroReader(db_path, prefs_js_path=prefs_path)
         try:
             resolved = temp.resolve_group_library_id(group_id)
         finally:
@@ -55,7 +56,7 @@ def _get_reader(library: str = "user") -> ZoteroReader:
         library_id = resolved
 
     if library_id not in _readers:
-        reader = ZoteroReader(db_path, library_id=library_id)
+        reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=prefs_path)
         _readers[library_id] = reader
         atexit.register(reader.close)
     return _readers[library_id]
@@ -175,9 +176,9 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
     att = reader.get_pdf_attachment(key)
     if att is None:
         raise ValueError(f"No PDF attachment found for item '{key}'")
-    pdf_path = data_dir / "storage" / att.key / att.filename
-    if not pdf_path.exists():
-        raise ValueError(f"PDF file not found at {pdf_path}")
+    pdf_path = att.path
+    if not pdf_path or not pdf_path.exists():
+        raise ValueError(f"PDF file not found at {pdf_path or att.filename}")
 
     page_range = None
     if pages:
@@ -214,9 +215,9 @@ def _handle_annotations(key: str, library: str = "user") -> dict:
         return {"error": f"No PDF attachment found for '{key}'"}
     cfg = load_config()
     data_dir = get_data_dir(cfg)
-    pdf_path = data_dir / "storage" / att.key / att.filename
-    if not pdf_path.exists():
-        return {"error": f"PDF file not found at {pdf_path}"}
+    pdf_path = att.path
+    if not pdf_path or not pdf_path.exists():
+        return {"error": f"PDF file not found at {pdf_path or att.filename}"}
     annots = extract_annotations(pdf_path)
     return {"key": key, "annotations": annots, "total": len(annots)}
 
@@ -841,10 +842,10 @@ def _handle_workspace_index(name: str, force: bool = False, library: str = "user
 
             att = reader.get_pdf_attachment(ws_item.key)
             if att is not None:
-                pdf_path = data_dir / "storage" / att.key / att.filename
-                if pdf_path.exists():
+                pdf_path = att.path
+                if pdf_path and pdf_path.exists():
                     try:
-                        pdf_text = convert_pdf_to_text(pdf_path, cache=md_cache)
+                        pdf_text = convert_pdf_to_text(pdf_path)
                         chunks = chunk_text(pdf_text, item.title)
                         for chunk_content in chunks:
                             cid = idx.insert_chunk(ws_item.key, "pdf", chunk_content)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -40,3 +40,73 @@ def test_config_show(tmp_path):
     result = runner.invoke(main, ["config", "show", "--config-path", str(config_path)])
     assert result.exit_code == 0
     assert "123" in result.output
+
+
+def test_cache_list_empty(tmp_path):
+    from zotero_cli_cc.core import pdf_cache as pdf_cache_module
+
+    old_default = pdf_cache_module.DEFAULT_CACHE_PATH
+    try:
+        pdf_cache_module.DEFAULT_CACHE_PATH = tmp_path / "pdf_cache.sqlite"
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "cache", "list"])
+        assert result.exit_code == 0
+        assert "Cache is empty." in result.output
+    finally:
+        pdf_cache_module.DEFAULT_CACHE_PATH = old_default
+
+
+def test_cache_list_populated(tmp_path):
+    from zotero_cli_cc.core import pdf_cache as pdf_cache_module
+    from zotero_cli_cc.core.pdf_cache import PdfCache
+
+    old_default = pdf_cache_module.DEFAULT_CACHE_PATH
+    try:
+        pdf_cache_module.DEFAULT_CACHE_PATH = tmp_path / "pdf_cache.sqlite"
+        cache = PdfCache()
+        cache._conn.execute(
+            "INSERT INTO pdf_cache (pdf_path, mtime, content, extracted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("/path/to/paper1.pdf", 1.0, "This is the extracted text content.", "2024-01-15T10:30:00+00:00"),
+        )
+        cache._conn.commit()
+        cache.close()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "cache", "list"])
+        assert result.exit_code == 0
+        assert "paper1.pdf" in result.output
+        assert "This is the extracted text content." in result.output
+    finally:
+        pdf_cache_module.DEFAULT_CACHE_PATH = old_default
+
+
+def test_cache_list_json(tmp_path):
+    import json
+
+    from zotero_cli_cc.core import pdf_cache as pdf_cache_module
+    from zotero_cli_cc.core.pdf_cache import PdfCache
+
+    old_default = pdf_cache_module.DEFAULT_CACHE_PATH
+    try:
+        pdf_cache_module.DEFAULT_CACHE_PATH = tmp_path / "pdf_cache.sqlite"
+        cache = PdfCache()
+        cache._conn.execute(
+            "INSERT INTO pdf_cache (pdf_path, mtime, content, extracted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("/path/to/paper2.pdf", 1.0, "Short text.", "2024-06-01T08:00:00+00:00"),
+        )
+        cache._conn.commit()
+        cache.close()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "config", "cache", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["pdf_basename"] == "/path/to/paper2.pdf"
+        assert data[0]["text_length"] == 11
+        assert data[0]["preview"] == "Short text."
+    finally:
+        pdf_cache_module.DEFAULT_CACHE_PATH = old_default

--- a/tests/test_cli_p3.py
+++ b/tests/test_cli_p3.py
@@ -66,17 +66,31 @@ def test_profile_flag():
     assert result.exit_code == 0
 
 
-def test_cache_clear_command():
-    runner = CliRunner()
-    result = runner.invoke(main, ["config", "cache", "clear"])
-    assert result.exit_code == 0
+def test_cache_clear_command(tmp_path):
+    from zotero_cli_cc.core import pdf_cache as pdf_cache_module
+
+    old_default = pdf_cache_module.DEFAULT_CACHE_PATH
+    try:
+        pdf_cache_module.DEFAULT_CACHE_PATH = tmp_path / "pdf_cache.sqlite"
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "cache", "clear"])
+        assert result.exit_code == 0
+    finally:
+        pdf_cache_module.DEFAULT_CACHE_PATH = old_default
 
 
-def test_cache_stats_command():
-    runner = CliRunner()
-    result = runner.invoke(main, ["config", "cache", "stats"])
-    assert result.exit_code == 0
-    assert "Cached PDFs" in result.output
+def test_cache_stats_command(tmp_path):
+    from zotero_cli_cc.core import pdf_cache as pdf_cache_module
+
+    old_default = pdf_cache_module.DEFAULT_CACHE_PATH
+    try:
+        pdf_cache_module.DEFAULT_CACHE_PATH = tmp_path / "pdf_cache.sqlite"
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "cache", "stats"])
+        assert result.exit_code == 0
+        assert "Cached PDFs" in result.output
+    finally:
+        pdf_cache_module.DEFAULT_CACHE_PATH = old_default
 
 
 def test_profile_list_no_profiles():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -211,7 +211,7 @@ class TestHandlePdf:
         data_dir = Path("/fake/zotero")
         mock_data_dir.return_value = data_dir
         reader = MagicMock()
-        att = Attachment(key="ATT1", parent_key="ABC123", filename="paper.pdf", content_type="application/pdf")
+        att = Attachment(key="ATT1", parent_key="ABC123", filename="paper.pdf", content_type="application/pdf", path=Path("/fake/zotero/paper.pdf"))
         reader.get_pdf_attachment.return_value = att
         mock_get_reader.return_value = reader
         cache = MagicMock()

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -199,7 +199,7 @@ class TestEmbedding:
             call_args = mock_urlopen.call_args[0][0]
             body = json.loads(call_args.data)
             assert body["model"] == "model"
-            assert body["input"] == ["hello world"]
+            assert body["input"] == {"texts": ["hello world"]}
 
 
 class TestRRF:

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +593,109 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/2e/a9959997739c403378d0a4a3a1c4ed80b60aeace216c4d37b303a9fc60a4/jiter-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:02f36a5c700f105ac04a6556fe664a59037a2c200db3b7e88784fac2ddf02531", size = 316927, upload-time = "2026-04-10T14:25:40.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/b6de8a531e0adbadd839bec301165feb1fccf00e9ff55073ba2dd20f0043/jiter-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41eab6c09ceffb6f0fe25e214b3068146edb1eda3649ca2aee2a061029c7ba2e", size = 321181, upload-time = "2026-04-10T14:25:42.621Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d8/2040b9efa13c917f855c40890ae4119fe02c25b7c7677d5b4fa820a851fc/jiter-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cf4d4c109641f9cfaf4a7b6aebd51654e405cd00fa9ebbf87163b8b97b325aa", size = 347387, upload-time = "2026-04-10T14:25:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/655c0ad5ce6a8e90f9068c175b8a236877d753e460762b3183c136db1c5b/jiter-0.14.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b80c7b41a628e6be2213ad0ece763c5f88aa5ee003fa394d58acaaee1f4b8342", size = 373083, upload-time = "2026-04-10T14:25:45.55Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/66/549c40fa068f08710b7570869c306a051eb67a29758bd64f4114f730554c/jiter-0.14.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb3dbf7cc0d4dbe73cce307ebe7eefa7f73a7d3d854dd119ea0c243f03e40927", size = 463639, upload-time = "2026-04-10T14:25:47.452Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2f/97a32a05fed14ed58a18e181fdfb619e05163f3726b54ee6080ec0539c09/jiter-0.14.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7054adcdeb06b46efd17b5734f75817a44a2d06d3748e36c3a023a1bb52af9ec", size = 380735, upload-time = "2026-04-10T14:25:49.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3b/4347e1d6c2a973d653bbb7a2d671a2d2426e54b52ba735b8ff0d0a29b75c/jiter-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d597cd1bf6790376f3fffc7c708766e57301d99a19314824ea0ccc9c3c70e1e2", size = 358632, upload-time = "2026-04-10T14:25:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/24/ca452fbf2ea33548ed30ce68a39a50442d3f7c9bf0704a7af958a930c057/jiter-0.14.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:df63a14878da754427926281626fd3ee249424a186e25a274e78176d42945264", size = 359969, upload-time = "2026-04-10T14:25:52.381Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a3/94470a0d199287caabeb4da2bb2ae5f6d17f3cf05dfc975d7cb064d58e0f/jiter-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4ea73187627bcc5810e085df715e8a99da8bdfd96a7eb36b4b4df700ba6d4c9c", size = 397529, upload-time = "2026-04-10T14:25:53.801Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/71/6768edc09d7c45c39f093feb3de105fa718a3e982b5208b8a2ed6382b44b/jiter-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9f541eaf7bb8382367a1a23d6fc3d6aad57f8dd8c18c3c17f838bee20f217220", size = 522342, upload-time = "2026-04-10T14:25:55.396Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6b/5c2e17559a0f4e96e934479f7137df46c939e983fa05244e674815befb73/jiter-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:107465250de4fce00fdb47166bcd51df8e634e049541174fe3c71848e44f52ce", size = 556784, upload-time = "2026-04-10T14:25:56.927Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/83/c25f3556a60fc74d11199100f1b6cc0c006b815c8494dea8ca16fe398732/jiter-0.14.0-cp310-cp310-win32.whl", hash = "sha256:ffb2a08a406465bb076b7cc1df41d833106d3cf7905076cc73f0cb90078c7d10", size = 208439, upload-time = "2026-04-10T14:25:58.796Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/99/781a1b413f0989b7f2ea203b094b331685f1a35e52e0a45e5d000ecaab27/jiter-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:cb8b682d10cb0cce7ff4c1af7244af7022c9b01ae16d46c357bdd0df13afb25d", size = 204558, upload-time = "2026-04-10T14:26:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -1007,6 +1119,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
 ]
 
 [[package]]
@@ -1654,6 +1785,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1740,6 +1880,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]
@@ -1957,6 +2109,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "markdownify" },
+    { name = "openai" },
     { name = "pymupdf" },
     { name = "pyzotero" },
     { name = "rich" },
@@ -1989,6 +2142,7 @@ requires-dist = [
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocs-static-i18n", marker = "extra == 'docs'", specifier = ">=1.2" },
+    { name = "openai", specifier = ">=2.33.0" },
     { name = "pymupdf", specifier = ">=1.24" },
     { name = "pyzotero", specifier = ">=1.5" },
     { name = "rich", specifier = ">=13.0" },


### PR DESCRIPTION
## Summary
- Add MinerU PDF extractor with pymupdf fallback and extensible embedding provider routing.
- Introduces a pluggable PDF extraction architecture with MinerU as an online extraction backend
- Improve RAG chunking, workspace indexing, and configuration flexibility.
- Better attachment resolver to support WSL and zotero 'Attanger' plugin.
- Faster `workspace query` with progress reporting

## Highlights
- Pluggable PDF Extractor Architecture: BasePdfExtractor ABC with two implementations:
  - PyMuPdfExtractor — local extraction via pymupdf/pymupdf4llm (default)
  - MinerUExtractor — online extraction via mineru.net API with batch upload and rate limiting
- Automatic Fallback: MinerU failures gracefully fall back to pymupdf for both single-page and range extraction
- RAG Pipeline Improvements: 
  - cascade_chunk() with sentence → word → char fallback strategy
  - Comprehensive clean_html() for better text preprocessing
- Workspace Index Two-Phase: Separated extraction and chunking phases with progress reporting; MinerU batch mode for multiple PDFs
- Faster `workspace query`
  - Pre-store doc_len at insert time — token count computed during indexing and stored in chunks.doc_len column, eliminating re-tokenization of chunk content on every query
  - get_bm25_terms_bulk(chunk_ids) — single SQL query instead of N individual queries for term frequency lookup
  - IDF precomputed per term outside the loop — computed once from document frequency lookup, reused for all chunks instead of recalculating per chunk
  - Read doc_len from DB — uses pre-stored value instead of re-tokenizing chunk content
- Better attachment resolver using prefs.js Path Resolution: ZOT_PREFS_JS_PATH env var + config-level override for Zotero profile detection. This is to support use `zot` in WSL2 and zotero 'Attanger' plugin. zotero Attanger plugin will move the attachments to another path for easier attahment sync using WebDAV.
- Embedding Provider Routing: EmbeddingConfig.provider field ("auto") for future multi-provider routing (Jina / Aliyun)
- New CLI: config cache list subcommand for inspecting PDF cache contents


## Breaking Changes
- PDF cache schema now are unified as one `pdf_cache` in both `pdf` and `workspace index` command

## Config Example
It now works with following example config (some are omitted):
```
[zotero]
data_dir = "/mnt/d/Zotero/ZoteroDatabase"
prefs_js_path = "/mnt/c/Users/weichen/AppData/Roaming/Zotero/Zotero/Profiles/nfcyh7hf.default/prefs.js"

[pdf]
extractor = "mineru"
mineru_token = "xxxxx"

[embedding]
provider = "aliyun"
api_key = "sk-xxxxxxxxxxxxxxxxx"
model = "text-embedding-v4"
```

## reference
- [MinerU API and Token](https://mineru.net/apiManage/token)
- [Aliyun Embedding Docs](https://help.aliyun.com/zh/model-studio/embedding?spm=a2c4g.11186623.help-menu-2400256.d_0_4_7_0.433e6285ipBSgP#ee47f9d186aa2)