### PR TITLE
fix: route JSON output through envelope (extracted from #17)

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -34,7 +34,7 @@ ZOT_FORMAT=table zot search foo   # force table even when piped
   "ok": true,
   "data": { "key": "ABC123", "title": "..." },
   "meta": {
-    "schema_version": "1.0.0",
+    "schema_version": "1.1.0",
     "cli_version": "0.3.0",
     "request_id": "a1b2c3d4e5f6",
     "latency_ms": 412
@@ -64,7 +64,7 @@ Mutating commands additionally set `data.sync_required: true` and may carry a `n
     "retryable": false,
     "hint": "Run 'zot search' to find valid item keys"
   },
-  "meta": { "request_id": "...", "schema_version": "1.0.0" }
+  "meta": { "request_id": "...", "schema_version": "1.1.0" }
 }
 ```
 
@@ -189,6 +189,68 @@ zot add --doi "10.1/x" --idempotency-key "ingest-2026-04-15-001"
 
 Retry guidance: check `error.retryable` first, then retry with the same `--idempotency-key`.
 
+## PDF extraction
+
+The `pdf` command supports structured content extraction:
+
+```bash
+zot pdf KEY                        # full text
+zot pdf KEY --pages 1-5           # page range
+zot pdf KEY --outline             # numbered heading outline
+zot pdf KEY --section 3           # content under 3rd heading
+zot pdf KEY --extractor pymupdf   # force specific extractor
+```
+
+JSON output envelopes the extracted content:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "key": "ABC123",
+    "pages": "all",
+    "text": "...",
+    "meta": { "extractor": "pymupdf", "cached": true }
+  },
+  "meta": { "schema_version": "1.1.0", ... }
+}
+```
+
+Outline output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "key": "ABC123",
+    "pages": "all",
+    "outline": [
+      { "number": 1, "text": "Introduction", "level": 1 },
+      { "number": 2, "text": "Related Work", "level": 1 },
+      { "number": 3, "text": "Methodology", "level": 2 }
+    ]
+  },
+  "meta": { ... }
+}
+```
+
+Section extraction:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "key": "ABC123",
+    "pages": "all",
+    "section": 3,
+    "content": "Methodology content here..."
+  },
+  "meta": { ... }
+}
+```
+
+PDF text is cached locally by (pdf_path, extractor) to avoid re-extraction. Use `zot config cache list` to inspect the cache, or `zot config cache clear` to invalidate it.
+
 ## Non-interactive operation
 
 - `zot` never prompts for input when `stdin` is not a TTY.
@@ -227,6 +289,41 @@ stdout:
 ```
 
 Agents tail stderr for liveness; stdout remains a single clean envelope.
+
+## Workspace RAG
+
+Workspaces support hybrid BM25 + semantic search via embeddings:
+
+```bash
+zot workspace index my-workspace           # BM25 only
+zot workspace index my-workspace --force  # rebuild index
+zot workspace query "reward hacking" --workspace my-workspace
+zot workspace query "reward hacking" --workspace my-workspace --mode hybrid
+zot workspace query "reward hacking" --workspace my-workspace --mode bm25
+```
+
+Query JSON output:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "mode": "hybrid",
+    "results": [
+      { "rank": 1, "score": 0.8942, "item_key": "ABC123", "source": "pdf", "content": "..." },
+      { "rank": 2, "score": 0.8123, "item_key": "DEF456", "source": "metadata", "content": "..." }
+    ]
+  },
+  "meta": { "schema_version": "1.1.0", ... }
+}
+```
+
+The `mode` field indicates what retrieval was used:
+- `bm25`: keyword search only
+- `semantic`: embedding similarity only
+- `hybrid`: reciprocal rank fusion of both
+
+When `--mode auto` is used (default), the system automatically selects `hybrid` if embeddings exist for the workspace, otherwise `bm25`.
 
 ## Auth delegation
 

--- a/src/zotero_cli_cc/commands/config.py
+++ b/src/zotero_cli_cc/commands/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import re
 from pathlib import Path
 
@@ -15,6 +14,7 @@ from zotero_cli_cc.config import (
     load_config,
     save_config,
 )
+from zotero_cli_cc.formatter import format_cache_list
 
 
 @click.group("config")
@@ -185,56 +185,12 @@ def cache_list(ctx: click.Context) -> None:
 
     try:
         cache = PdfCache()
-    except (sqlite3.OperationalError, OSError) as e:
-        click.echo(f"Error: Could not open cache database: {e}", err=True)
-        raise SystemExit(1)
-    try:
         rows = cache._conn.execute(
             "SELECT pdf_path, extractor, LENGTH(content), content, extracted_at FROM pdf_cache ORDER BY pdf_path"
         ).fetchall()
-
-        if not rows:
-            click.echo("Cache is empty.")
-            return
-
-        if json_out:
-            data = [
-                {
-                    "pdf_basename": row[0],
-                    "extractor": row[1],
-                    "text_length": row[2],
-                    "preview": row[3][:100],
-                    "extracted_at": row[4],
-                }
-                for row in rows
-            ]
-            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
-            return
-
-        from io import StringIO
-
-        from rich.console import Console
-        from rich.table import Table
-
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=False, width=120)
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("PDF Path", style="cyan", width=30)
-        table.add_column("Extractor", width=10)
-        table.add_column("Length", justify="right", width=10)
-        table.add_column("Preview", width=50)
-        table.add_column("Time", width=20)
-
-        for row in rows:
-            pdf_path, extractor, length, content, extracted_at = row
-            preview = content[:100] + "..." if len(content) > 100 else content
-            preview = preview.replace("\n", " ").replace("\r", " ")
-            table.add_row(Path(pdf_path).name, extractor, f"{length:,}", preview, extracted_at[:19])
-        console.print(table)
-        click.echo(buf.getvalue().rstrip())
-
+        click.echo(format_cache_list(rows, output_json=json_out))
     except sqlite3.OperationalError as e:
-        click.echo(f"Error: Could not query cache database: {e}", err=True)
+        click.echo(f"Error: Could not access cache database: {e}", err=True)
         raise SystemExit(1)
     finally:
         cache.close()

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -8,7 +8,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
 from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.formatter import print_error
+from zotero_cli_cc.formatter import format_pdf_annotations, format_pdf_text, print_error
 from zotero_cli_cc.models import ErrorInfo
 
 
@@ -157,16 +157,7 @@ def pdf_cmd(
                 else:
                     click.echo("No annotations found.")
                 return
-            if json_out:
-                click.echo(json.dumps(annots, ensure_ascii=False, indent=2))
-            else:
-                for a in annots:
-                    line = f"[p.{a['page']}] {a['type']}"
-                    if a.get("quote"):
-                        line += f': "{a["quote"]}"'
-                    if a.get("content"):
-                        line += f" -- {a['content']}"
-                    click.echo(line)
+            click.echo(format_pdf_annotations(annots, output_json=json_out))
             return
         from zotero_cli_cc.core.pdf_cache import PdfCache
 
@@ -219,14 +210,7 @@ def pdf_cmd(
                         output_json=json_out,
                     )
                     return
-                if json_out:
-                    click.echo(
-                        json.dumps(
-                            {"key": key, "pages": pages, "section": section, "content": content}, ensure_ascii=False
-                        )
-                    )
-                else:
-                    click.echo(content)
+                click.echo(format_pdf_text(key, pages, section=section, content=content, output_json=json_out))
             else:
                 outline_data = _parse_outline(text)
                 if not outline_data:
@@ -235,17 +219,9 @@ def pdf_cmd(
                     else:
                         click.echo("No headings found in document.")
                     return
-                if json_out:
-                    outline_json = [{"number": n, "text": t, "level": lvl} for n, t, lvl in outline_data]
-                    click.echo(json.dumps({"key": key, "pages": pages, "outline": outline_json}, ensure_ascii=False))
-                else:
-                    for num, heading_text, level in outline_data:
-                        indent = "  " * (level - 1)
-                        click.echo(f"{num}. {indent}{heading_text}")
+                outline_json = [{"number": n, "text": t, "level": lvl} for n, t, lvl in outline_data]
+                click.echo(format_pdf_text(key, pages, outline=outline_json, output_json=json_out))
             return
-        if json_out:
-            click.echo(json.dumps({"key": key, "pages": pages, "text": text}, ensure_ascii=False))
-        else:
-            click.echo(text)
+        click.echo(format_pdf_text(key, pages, text=text, output_json=json_out))
     finally:
         reader.close()

--- a/src/zotero_cli_cc/commands/workspace.py
+++ b/src/zotero_cli_cc/commands/workspace.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 import time
 from collections.abc import Callable
@@ -35,7 +34,7 @@ from zotero_cli_cc.core.workspace import (
     workspaces_dir,
 )
 from zotero_cli_cc.exit_codes import emit_error
-from zotero_cli_cc.formatter import format_items, print_error
+from zotero_cli_cc.formatter import format_items, format_workspace_list, format_workspace_query, print_error
 from zotero_cli_cc.models import Collection, ErrorInfo, Item
 
 
@@ -181,37 +180,7 @@ def workspace_list(ctx: click.Context) -> None:
     if not workspaces:
         click.echo("No workspaces found. Create one with: zot workspace new <name>")
         return
-    if json_out:
-        data = [
-            {
-                "name": ws.name,
-                "description": ws.description,
-                "items": len(ws.items),
-                "created": ws.created,
-            }
-            for ws in workspaces
-        ]
-        click.echo(json.dumps(data, indent=2, ensure_ascii=False))
-        return
-
-    from io import StringIO
-
-    from rich.console import Console
-    from rich.table import Table
-
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, width=120)
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Name", style="cyan", width=20)
-    table.add_column("Description", width=50)
-    table.add_column("Items", justify="right", width=8)
-    table.add_column("Created", width=20)
-    for ws in workspaces:
-        desc = ws.description[:47] + "..." if len(ws.description) > 50 else ws.description
-        created = ws.created[:10] if len(ws.created) >= 10 else ws.created
-        table.add_row(ws.name, desc, str(len(ws.items)), created)
-    console.print(table)
-    click.echo(buf.getvalue().rstrip())
+    click.echo(format_workspace_list(workspaces, output_json=json_out))
 
 
 @workspace_group.command("show")
@@ -825,22 +794,6 @@ def workspace_query(ctx: click.Context, question: str, ws_name: str, top_k: int,
                 click.echo("No results found.")
             return
 
-        if json_out:
-            data = [
-                {
-                    "rank": i + 1,
-                    "score": round(score, 4),
-                    "item_key": chunk["item_key"],
-                    "source": chunk["source"],
-                    "content": chunk["content"][:500],
-                }
-                for i, (_cid, score, chunk) in enumerate(top)
-            ]
-            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
-        else:
-            for i, (_cid, score, chunk) in enumerate(top):
-                preview = chunk["content"][:120].replace("\n", " ")
-                click.echo(f"[{i + 1}] Score: {score:.2f} | {chunk['item_key']} | {chunk['source']}")
-                click.echo(f"    {preview}...")
+        click.echo(format_workspace_query(top, mode=effective_mode, output_json=json_out))
     finally:
         idx.close()

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import asdict
 from io import StringIO
+from pathlib import Path
 from typing import Any
 
 from rich.console import Console
@@ -17,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)
@@ -225,6 +226,139 @@ def format_duplicates(groups: list[DuplicateGroup], output_json: bool = False) -
         title = g.items[0].title if g.items else ""
         table.add_row(str(i), keys, title, g.match_type, f"{g.score:.2f}")
     console.print(table)
+    return buf.getvalue()
+
+
+def format_pdf_annotations(annots: list[dict], output_json: bool = False) -> str:
+    if output_json:
+        return _dump(envelope_ok(annots, meta={"count": len(annots)}))
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    for a in annots:
+        line = f"[p.{a['page']}] {a['type']}"
+        if a.get("quote"):
+            line += f': "{a["quote"]}"'
+        if a.get("content"):
+            line += f" -- {a['content']}"
+        console.print(line)
+    return buf.getvalue()
+
+
+def format_pdf_text(
+    key: str,
+    pages: str | None,
+    text: str | None = None,
+    outline: list[dict] | None = None,
+    section: int | None = None,
+    content: str | None = None,
+    output_json: bool = False,
+) -> str:
+    if output_json:
+        data: dict[str, Any] = {"key": key, "pages": pages or "all"}
+        if section is not None:
+            data["section"] = section
+            data["content"] = content or ""
+        elif outline is not None:
+            data["outline"] = outline
+        else:
+            data["text"] = text or ""
+        return _dump(envelope_ok(data))
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    if section is not None:
+        console.print(content or "")
+    elif outline is not None:
+        for item in outline:
+            indent = "  " * (item["level"] - 1)
+            console.print(f"{item['number']}. {indent}{item['text']}")
+    else:
+        console.print(text or "")
+    return buf.getvalue()
+
+
+def format_cache_list(rows: list[tuple], output_json: bool = False) -> str:
+    if not rows:
+        if output_json:
+            return _dump(envelope_ok([], meta={"count": 0}))
+        return "Cache is empty."
+    if output_json:
+        data = [
+            {
+                "pdf_basename": row[0],
+                "extractor": row[1],
+                "text_length": row[2],
+                "preview": row[3][:100] if row[3] else "",
+                "extracted_at": row[4],
+            }
+            for row in rows
+        ]
+        return _dump(envelope_ok(data, meta={"count": len(rows)}))
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("PDF Path", style="cyan", width=30)
+    table.add_column("Extractor", width=10)
+    table.add_column("Length", justify="right", width=10)
+    table.add_column("Preview", width=50)
+    table.add_column("Time", width=20)
+    for row in rows:
+        pdf_path, extractor, length, content, extracted_at = row
+        preview = content[:100] + "..." if content and len(content) > 100 else (content or "")
+        preview = preview.replace("\n", " ").replace("\r", " ")
+        table.add_row(Path(pdf_path).name, extractor, f"{length:,}", preview, extracted_at[:19] if extracted_at else "")
+    console.print(table)
+    return buf.getvalue()
+
+
+def format_workspace_list(workspaces: list, output_json: bool = False) -> str:
+    if output_json:
+        data = [
+            {
+                "name": ws.name,
+                "description": ws.description,
+                "items": len(ws.items),
+                "created": ws.created,
+            }
+            for ws in workspaces
+        ]
+        return _dump(envelope_ok(data, meta={"count": len(workspaces)}))
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan", width=20)
+    table.add_column("Description", width=50)
+    table.add_column("Items", justify="right", width=8)
+    table.add_column("Created", width=20)
+    for ws in workspaces:
+        desc = ws.description[:47] + "..." if len(ws.description) > 50 else ws.description
+        created = ws.created[:10] if len(ws.created) >= 10 else ws.created
+        table.add_row(ws.name, desc, str(len(ws.items)), created)
+    console.print(table)
+    return buf.getvalue()
+
+
+def format_workspace_query(results: list, mode: str, output_json: bool = False) -> str:
+    if output_json:
+        data = {
+            "mode": mode,
+            "results": [
+                {
+                    "rank": i + 1,
+                    "score": round(r[1], 4),
+                    "item_key": r[2]["item_key"],
+                    "source": r[2]["source"],
+                    "content": r[2]["content"][:500],
+                }
+                for i, r in enumerate(results)
+            ],
+        }
+        return _dump(envelope_ok(data))
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    for i, (cid, score, chunk) in enumerate(results):
+        preview = chunk["content"][:120].replace("\n", " ")
+        console.print(f"[{i + 1}] Score: {score:.2f} | {chunk['item_key']} | {chunk['source']}")
+        console.print(f"    {preview}...")
     return buf.getvalue()
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -100,7 +100,8 @@ def test_cache_list_json(tmp_path):
         runner = CliRunner()
         result = runner.invoke(main, ["--json", "config", "cache", "list"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # `config cache list --json` is now routed through the agent envelope.
+        data = json.loads(result.output)["data"]
         assert isinstance(data, list)
         assert len(data) == 1
         assert data[0]["pdf_basename"] == "/path/to/paper2.pdf"

--- a/tests/test_pdf_integration.py
+++ b/tests/test_pdf_integration.py
@@ -123,7 +123,8 @@ class TestPdfCmdWithExtractors:
                 result = _invoke(["pdf", "ATTN001", "--extractor", "pymupdf"], json_output=True)
 
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # `pdf --json` is now routed through the agent envelope.
+        data = json.loads(result.output)["data"]
         assert "key" in data
         assert data["key"] == "ATTN001"
         assert "text" in data

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -208,8 +208,8 @@ class TestWorkspaceCLI:
         with patch("zotero_cli_cc.core.workspace.workspaces_dir", return_value=tmp_path):
             _invoke(["workspace", "new", "ws-json"])
             result = _invoke(["workspace", "list"], json_output=True)
-        # `workspace list` outputs a raw list, not an envelope.
-        data = json.loads(result.output)
+        # `workspace list --json` is routed through the agent envelope.
+        data = json.loads(result.output)["data"]
         assert len(data) == 1
         assert data[0]["name"] == "ws-json"
 

--- a/tests/test_workspace_rag.py
+++ b/tests/test_workspace_rag.py
@@ -89,11 +89,13 @@ class TestWorkspaceQuery:
                 ["workspace", "query", "attention", "--workspace", "test-q"],
                 json_output=True,
             )
-        # `workspace query --json` outputs a raw list, not an envelope.
-        data = json.loads(result.output)
-        assert isinstance(data, list)
-        assert len(data) > 0
-        assert "item_key" in data[0]
+        # `workspace query --json` is routed through the envelope: data has
+        # `mode` and `results`, where `results` is the per-chunk list.
+        data = json.loads(result.output)["data"]
+        results = data["results"]
+        assert isinstance(results, list)
+        assert len(results) > 0
+        assert "item_key" in results[0]
 
     def test_query_irrelevant(self, tmp_path):
         with _patch_ws_dir(tmp_path):


### PR DESCRIPTION
## Summary

Cherry-pick of the two unique commits from #17 that aren't already on main:

1. **\`fix: bump SCHEMA_VERSION to 1.1.0 and update agent-interface.md docs\`** — Bump for the new envelope routing.
2. **\`fix: route JSON output through formatter envelope for pdf outline/section, workspace list/query, and config cache list\`** — Wraps these commands' \`--json\` output in the standard \`{ok, data, meta}\` envelope.

Plus a small test alignment commit so the test suite expects the new shape.

## Why this and not #17 directly

#17's branch was opened from before #13 was merged, so its file diff against the new main is mostly *deletions* of #13's modules (\`attachment_resolver\`, \`embedding_router\`, \`providers/\`, \`path_utils\`, etc.). Merging it as-is would tear out those features. This PR keeps only the parts that are actually new vs main.

#17 should be closed as superseded by this once merged.

## Behavioral change

These commands' \`--json\` output now wraps in the envelope:

- \`zot pdf KEY --json\` (incl. \`--outline\` / \`--section\`)
- \`zot workspace list --json\`
- \`zot workspace query --json\` — \`data\` becomes \`{mode, results}\` rather than the bare results list
- \`zot config cache list --json\`

Other \`--json\` commands (\`search\`, \`read\`, \`update\`, etc.) were already enveloped — this aligns the rest.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run mypy src/zotero_cli_cc/\` — clean
- [x] \`uv run pytest tests/\` — 549 passed, 1 skipped (Python 3.11)
- [ ] CI confirms across 3.10–3.13