### PR TITLE
fix: finish print_error → emit_error migration for exit-code parity

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4206ee82-ef3f-4252-94b6-3f2578bbeb18","pid":80964,"procStart":"Tue May  5 01:50:36 2026","acquiredAt":1777949201553}

--- a/src/zotero_cli_cc/commands/collection.py
+++ b/src/zotero_cli_cc/commands/collection.py
@@ -7,7 +7,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
-from zotero_cli_cc.exit_codes import EXIT_RUNTIME
+from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
 from zotero_cli_cc.formatter import format_collections, format_items, print_error
 from zotero_cli_cc.models import ErrorInfo
 
@@ -65,15 +65,13 @@ def collection_create(ctx: click.Context, name: str, parent: str | None) -> None
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="collection",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
         )
-        return
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         key = writer.create_collection(name, parent_key=parent)
@@ -101,15 +99,13 @@ def collection_move(ctx: click.Context, item_key: str, collection_key: str) -> N
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="collection",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
         )
-        return
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.move_to_collection(item_key, collection_key)
@@ -120,6 +116,7 @@ def collection_move(ctx: click.Context, item_key: str, collection_key: str) -> N
             ErrorInfo(message=str(e), context="collection move", hint="Check item and collection keys"),
             output_json=json_out,
         )
+        ctx.exit(EXIT_RUNTIME)
 
 
 @collection_group.command("delete")
@@ -139,15 +136,13 @@ def collection_delete(ctx: click.Context, key: str, dry_run: bool) -> None:
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="collection",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
         )
-        return
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.delete_collection(key)
@@ -158,6 +153,7 @@ def collection_delete(ctx: click.Context, key: str, dry_run: bool) -> None:
             ErrorInfo(message=str(e), context="collection delete", hint="Check collection key"),
             output_json=json_out,
         )
+        ctx.exit(EXIT_RUNTIME)
 
 
 @collection_group.command("reorganize")
@@ -204,15 +200,13 @@ def collection_reorganize(ctx: click.Context, plan_file: str, dry_run: bool) -> 
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="collection reorganize",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection reorganize",
         )
-        return
 
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     created_collections: dict[str, str] = {}  # name -> key mapping for parent lookups
@@ -255,15 +249,13 @@ def collection_rename(ctx: click.Context, key: str, new_name: str) -> None:
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="collection",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
         )
-        return
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.rename_collection(key, new_name)
@@ -274,3 +266,4 @@ def collection_rename(ctx: click.Context, key: str, new_name: str) -> None:
             ErrorInfo(message=str(e), context="collection rename", hint="Check collection key"),
             output_json=json_out,
         )
+        ctx.exit(EXIT_RUNTIME)

--- a/src/zotero_cli_cc/commands/config.py
+++ b/src/zotero_cli_cc/commands/config.py
@@ -202,19 +202,17 @@ def cache_list(ctx: click.Context) -> None:
 def profile_set(name: str, config_path: str | None) -> None:
     """Set the default profile."""
     path = Path(config_path) if config_path else CONFIG_FILE
-    from zotero_cli_cc.formatter import print_error
-    from zotero_cli_cc.models import ErrorInfo
+    from zotero_cli_cc.exit_codes import emit_error
 
     profiles = list_profiles(path)
     if name not in profiles:
-        print_error(
-            ErrorInfo(
-                message=f"Profile '{name}' not found",
-                context="config",
-                hint=f"Available profiles: {', '.join(profiles)}",
-            )
+        emit_error(
+            "not_found",
+            f"Profile '{name}' not found",
+            output_json=False,
+            hint=f"Available profiles: {', '.join(profiles)}",
+            context="config",
         )
-        return
     content = path.read_text()
     if "[default]" in content:
         content = re.sub(r'(profile\s*=\s*)"[^"]*"', f'\\1"{name}"', content)

--- a/src/zotero_cli_cc/commands/export.py
+++ b/src/zotero_cli_cc/commands/export.py
@@ -6,8 +6,7 @@ import click
 
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.formatter import print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.exit_codes import emit_error
 
 
 @click.command("export")
@@ -36,30 +35,26 @@ def export_cmd(ctx: click.Context, key: str, fmt: str) -> None:
         if fmt == "json":
             item = reader.get_item(key)
             if item is None:
-                print_error(
-                    ErrorInfo(
-                        message=f"Item '{key}' not found",
-                        context="export",
-                        hint="Run 'zot search' to find valid item keys",
-                    ),
+                emit_error(
+                    "not_found",
+                    f"Item '{key}' not found",
                     output_json=json_out,
+                    hint="Run 'zot search' to find valid item keys",
+                    context="export",
                 )
-                return
             from dataclasses import asdict
 
             click.echo(json.dumps(asdict(item), indent=2, ensure_ascii=False))
         else:
             result = reader.export_citation(key, fmt=fmt)
             if result is None:
-                print_error(
-                    ErrorInfo(
-                        message=f"Item '{key}' not found",
-                        context="export",
-                        hint="Run 'zot search' to find valid item keys",
-                    ),
+                emit_error(
+                    "not_found",
+                    f"Item '{key}' not found",
                     output_json=json_out,
+                    hint="Run 'zot search' to find valid item keys",
+                    context="export",
                 )
-                return
             click.echo(result)
     finally:
         reader.close()

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -8,8 +8,8 @@ import click
 from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
 from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.formatter import format_pdf_annotations, format_pdf_text, print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import format_pdf_annotations, format_pdf_text
 
 
 def _parse_outline(markdown: str) -> list[tuple[int, str, int]]:
@@ -107,15 +107,13 @@ def pdf_cmd(
                 raise ValueError(f"invalid range: start={start}, end={end}")
             page_range = (start, end)
         except ValueError:
-            print_error(
-                ErrorInfo(
-                    message=f"Invalid page range '{pages}'",
-                    context="pdf",
-                    hint="Use format: '1-5' or '3' for a single page",
-                ),
+            emit_error(
+                "validation_error",
+                f"Invalid page range '{pages}'",
                 output_json=json_out,
+                hint="Use format: '1-5' or '3' for a single page",
+                context="pdf",
             )
-            return
     data_dir = get_data_dir(cfg)
     db_path = data_dir / "zotero.sqlite"
     library_id = resolve_library_id(db_path, ctx.obj)
@@ -123,34 +121,30 @@ def pdf_cmd(
     try:
         att = reader.get_pdf_attachment(key)
         if att is None:
-            print_error(
-                ErrorInfo(
-                    message=f"No PDF attachment found for '{key}'",
-                    context="pdf",
-                    hint="Check item details with: zot read KEY",
-                ),
+            emit_error(
+                "not_found",
+                f"No PDF attachment found for '{key}'",
                 output_json=json_out,
+                hint="Check item details with: zot read KEY",
+                context="pdf",
             )
-            return
         pdf_path = att.path
         if not pdf_path or not pdf_path.exists():
-            print_error(
-                ErrorInfo(
-                    message=f"PDF file not found at {pdf_path or att.filename}",
-                    context="pdf",
-                    hint="The file may have been moved or the attachment path could not be resolved. Check Zotero storage directory",
-                ),
+            emit_error(
+                "not_found",
+                f"PDF file not found at {pdf_path or att.filename}",
                 output_json=json_out,
+                hint="The file may have been moved or the attachment path could not be resolved. "
+                "Check Zotero storage directory",
+                context="pdf",
             )
-            return
         if annotations:
             from zotero_cli_cc.core.pdf_extractor import extract_annotations
 
             try:
                 annots = extract_annotations(pdf_path)
             except PdfExtractionError as e:
-                print_error(ErrorInfo(message=str(e), context="pdf"), output_json=json_out)
-                return
+                emit_error("runtime_error", str(e), output_json=json_out, context="pdf")
             if not annots:
                 if json_out:
                     click.echo("[]")
@@ -191,25 +185,25 @@ def pdf_cmd(
                         raise
         except PdfExtractionError as e:
             cache.close()
-            print_error(
-                ErrorInfo(message=str(e), context="pdf", hint="The PDF may be corrupted or password-protected"),
+            emit_error(
+                "runtime_error",
+                str(e),
                 output_json=json_out,
+                hint="The PDF may be corrupted or password-protected",
+                context="pdf",
             )
-            return
         cache.close()
         if outline or section is not None:
             if section is not None:
                 content = _extract_section(text, section)
                 if not content:
-                    print_error(
-                        ErrorInfo(
-                            message=f"Section {section} not found (document has fewer than {section} headings)",
-                            context="pdf",
-                            hint="Use --outline first to see available sections",
-                        ),
+                    emit_error(
+                        "not_found",
+                        f"Section {section} not found (document has fewer than {section} headings)",
                         output_json=json_out,
+                        hint="Use --outline first to see available sections",
+                        context="pdf",
                     )
-                    return
                 click.echo(format_pdf_text(key, pages, section=section, content=content, output_json=json_out))
             else:
                 outline_data = _parse_outline(text)

--- a/src/zotero_cli_cc/commands/relate.py
+++ b/src/zotero_cli_cc/commands/relate.py
@@ -4,8 +4,7 @@ import click
 
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.formatter import format_items, print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.formatter import format_items
 
 
 @click.command("relate")
@@ -30,14 +29,13 @@ def relate_cmd(ctx: click.Context, key: str, limit: int | None) -> None:
         limit = limit if limit is not None else ctx.obj.get("limit", 20)
         items = reader.get_related_items(key, limit=limit)
         if not items:
-            print_error(
-                ErrorInfo(
-                    message=f"No related items found for '{key}'",
-                    context="relate",
-                    hint="Items need shared tags or collections to find relations",
-                ),
-                output_json=json_out,
-            )
+            # Empty result is a normal outcome, not an error — exit 0 with a friendly message.
+            if json_out:
+                click.echo("[]")
+            else:
+                click.echo(
+                    f"No related items found for '{key}'. Items need shared tags or collections to find relations."
+                )
             return
         detail = ctx.obj.get("detail", "standard")
         click.echo(format_items(items, output_json=json_out, detail=detail))

--- a/src/zotero_cli_cc/commands/summarize.py
+++ b/src/zotero_cli_cc/commands/summarize.py
@@ -6,8 +6,7 @@ import click
 
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.formatter import print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.exit_codes import emit_error
 
 
 @click.command("summarize")
@@ -31,15 +30,13 @@ def summarize_cmd(ctx: click.Context, key: str) -> None:
     try:
         item = reader.get_item(key)
         if item is None:
-            print_error(
-                ErrorInfo(
-                    message=f"Item '{key}' not found",
-                    context="summarize",
-                    hint="Run 'zot search' to find valid item keys",
-                ),
+            emit_error(
+                "not_found",
+                f"Item '{key}' not found",
                 output_json=json_out,
+                hint="Run 'zot search' to find valid item keys",
+                context="summarize",
             )
-            return
         notes = reader.get_notes(key)
         detail = ctx.obj.get("detail", "standard")
         if json_out:

--- a/src/zotero_cli_cc/commands/tag.py
+++ b/src/zotero_cli_cc/commands/tag.py
@@ -8,7 +8,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
-from zotero_cli_cc.exit_codes import EXIT_RUNTIME
+from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
 from zotero_cli_cc.formatter import print_error
 from zotero_cli_cc.models import ErrorInfo
 
@@ -46,15 +46,13 @@ def tag_cmd(
         if library_type == "group" and ctx.obj.get("group_id"):
             library_id = ctx.obj["group_id"]
         if not library_id or not api_key:
-            print_error(
-                ErrorInfo(
-                    message="Write credentials not configured",
-                    context="tag",
-                    hint="Run 'zot config init' to set up API credentials",
-                ),
+            emit_error(
+                "auth_missing",
+                "Write credentials not configured",
                 output_json=json_out,
+                hint="Run 'zot config init' to set up API credentials",
+                context="tag",
             )
-            return
         writer = ZoteroWriter(library_id=str(library_id), api_key=api_key, library_type=library_type)
         failed = []
         for key in keys:

--- a/src/zotero_cli_cc/commands/trash.py
+++ b/src/zotero_cli_cc/commands/trash.py
@@ -7,6 +7,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_items, print_error
 from zotero_cli_cc.models import ErrorInfo
 
@@ -82,15 +83,13 @@ def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool) 
     if library_type == "group" and ctx.obj.get("group_id"):
         library_id = ctx.obj["group_id"]
     if not library_id or not api_key:
-        print_error(
-            ErrorInfo(
-                message="Write credentials not configured",
-                context="trash restore",
-                hint="Run 'zot config init' to set up API credentials",
-            ),
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
             output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="trash restore",
         )
-        return
 
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     any_success = False

--- a/src/zotero_cli_cc/commands/workspace.py
+++ b/src/zotero_cli_cc/commands/workspace.py
@@ -34,8 +34,8 @@ from zotero_cli_cc.core.workspace import (
     workspaces_dir,
 )
 from zotero_cli_cc.exit_codes import emit_error
-from zotero_cli_cc.formatter import format_items, format_workspace_list, format_workspace_query, print_error
-from zotero_cli_cc.models import Collection, ErrorInfo, Item
+from zotero_cli_cc.formatter import format_items, format_workspace_list, format_workspace_query
+from zotero_cli_cc.models import Collection, Item
 
 
 @click.group("workspace")
@@ -60,15 +60,13 @@ def workspace_new(ctx: click.Context, name: str, description: str) -> None:
             context="workspace new",
         )
     if workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' already exists",
-                context="workspace new",
-                hint=f"Use 'zot workspace show {name}' to view it",
-            ),
+        emit_error(
+            "conflict",
+            f"Workspace '{name}' already exists",
             output_json=json_out,
+            hint=f"Use 'zot workspace show {name}' to view it",
+            context="workspace new",
         )
-        return
     ws = Workspace(
         name=name,
         created=datetime.now(timezone.utc).isoformat(),
@@ -86,15 +84,13 @@ def workspace_delete(ctx: click.Context, name: str, yes: bool) -> None:
     """Delete a workspace."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace delete",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace delete",
         )
-        return
     no_interaction = ctx.obj.get("no_interaction", False)
     if not yes and not no_interaction:
         if not click.confirm(f"Delete workspace '{name}'?"):
@@ -112,15 +108,13 @@ def workspace_add(ctx: click.Context, name: str, keys: tuple[str, ...]) -> None:
     """Add items to a workspace by Zotero key."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace add",
-                hint="Use 'zot workspace new' to create it first",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace new' to create it first",
+            context="workspace add",
         )
-        return
 
     cfg = load_config(profile=ctx.obj.get("profile"))
     data_dir = get_data_dir(cfg)
@@ -153,15 +147,13 @@ def workspace_remove(ctx: click.Context, name: str, keys: tuple[str, ...]) -> No
     """Remove items from a workspace by key."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace remove",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace remove",
         )
-        return
     ws = load_workspace(name)
     removed = 0
     for key in keys:
@@ -193,15 +185,13 @@ def workspace_show(ctx: click.Context, name: str) -> None:
     limit = ctx.obj.get("limit", 50)
 
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace show",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace show",
         )
-        return
 
     ws = load_workspace(name)
     if not ws.items:
@@ -244,15 +234,13 @@ def workspace_export(ctx: click.Context, name: str, fmt: str) -> None:
     """Export workspace items for external use."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace export",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace export",
         )
-        return
 
     ws = load_workspace(name)
     if not ws.items:
@@ -320,26 +308,22 @@ def workspace_import_cmd(
     """Bulk import items into a workspace from collection, tag, or search."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace import",
-                hint="Use 'zot workspace new' to create it first",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace new' to create it first",
+            context="workspace import",
         )
-        return
 
     if not collection and not tag and not search_query:
-        print_error(
-            ErrorInfo(
-                message="Must specify at least one of --collection, --tag, or --search",
-                context="workspace import",
-                hint="Example: zot workspace import my-ws --search 'attention'",
-            ),
+        emit_error(
+            "validation_error",
+            "Must specify at least one of --collection, --tag, or --search",
             output_json=json_out,
+            hint="Example: zot workspace import my-ws --search 'attention'",
+            context="workspace import",
         )
-        return
 
     cfg = load_config(profile=ctx.obj.get("profile"))
     data_dir = get_data_dir(cfg)
@@ -354,15 +338,13 @@ def workspace_import_cmd(
             # Resolve collection name to key
             col_key = _resolve_collection_key(reader, collection)
             if col_key is None:
-                print_error(
-                    ErrorInfo(
-                        message=f"Collection '{collection}' not found",
-                        context="workspace import",
-                        hint="Use 'zot collections' to list available collections",
-                    ),
+                emit_error(
+                    "not_found",
+                    f"Collection '{collection}' not found",
                     output_json=json_out,
+                    hint="Use 'zot collections' to list available collections",
+                    context="workspace import",
                 )
-                return
             items_to_import.extend(reader.get_collection_items(col_key))
 
         if tag:
@@ -412,15 +394,13 @@ def workspace_search(ctx: click.Context, query: str, ws_name: str) -> None:
     limit = ctx.obj.get("limit", 50)
 
     if not workspace_exists(ws_name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{ws_name}' not found",
-                context="workspace search",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{ws_name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace search",
         )
-        return
 
     ws = load_workspace(ws_name)
     if not ws.items:
@@ -492,15 +472,13 @@ def workspace_index(ctx: click.Context, name: str, force: bool, extractor: str |
 
         extractor = load_pdf_config().extractor
     if not workspace_exists(name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{name}' not found",
-                context="workspace index",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace index",
         )
-        return
 
     ws = load_workspace(name)
     if not ws.items:
@@ -706,27 +684,23 @@ def workspace_query(ctx: click.Context, question: str, ws_name: str, top_k: int,
     """Query workspace papers with natural language."""
     json_out = ctx.obj.get("json", False)
     if not workspace_exists(ws_name):
-        print_error(
-            ErrorInfo(
-                message=f"Workspace '{ws_name}' not found",
-                context="workspace query",
-                hint="Use 'zot workspace list' to see available workspaces",
-            ),
+        emit_error(
+            "not_found",
+            f"Workspace '{ws_name}' not found",
             output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="workspace query",
         )
-        return
 
     idx_path = workspaces_dir() / f"{ws_name}.idx.sqlite"
     if not idx_path.exists():
-        print_error(
-            ErrorInfo(
-                message=f"No index found for workspace '{ws_name}'",
-                context="workspace query",
-                hint=f"Run 'zot workspace index {ws_name}' first",
-            ),
+        emit_error(
+            "not_found",
+            f"No index found for workspace '{ws_name}'",
             output_json=json_out,
+            hint=f"Run 'zot workspace index {ws_name}' first",
+            context="workspace query",
         )
-        return
 
     idx = RagIndex(idx_path)
     if not json_out:

--- a/tests/test_cli_p2.py
+++ b/tests/test_cli_p2.py
@@ -46,7 +46,8 @@ def test_pdf_no_attachment(test_db_path):
         ["pdf", "DEEP003"],
         env={"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"},
     )
-    assert result.exit_code == 0
+    # Exit 4 (NOT_FOUND) per the agent contract.
+    assert result.exit_code == 4
     assert "no pdf" in result.output.lower() or "not found" in result.output.lower()
 
 
@@ -57,7 +58,8 @@ def test_pdf_invalid_page_range_non_numeric(test_db_path):
         ["pdf", "--pages", "abc", "DEEP003"],
         env={"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"},
     )
-    assert result.exit_code == 0
+    # Exit 3 (VALIDATION) per the agent contract.
+    assert result.exit_code == 3
     assert "invalid page range" in result.output.lower()
 
 
@@ -68,7 +70,7 @@ def test_pdf_invalid_page_range_reversed(test_db_path):
         ["pdf", "--pages", "5-2", "DEEP003"],
         env={"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"},
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 3
     assert "invalid page range" in result.output.lower()
 
 
@@ -79,5 +81,5 @@ def test_pdf_invalid_page_range_zero(test_db_path):
         ["pdf", "--pages", "0-3", "DEEP003"],
         env={"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"},
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 3
     assert "invalid page range" in result.output.lower()

--- a/tests/test_extractor_fallback.py
+++ b/tests/test_extractor_fallback.py
@@ -112,7 +112,8 @@ class TestMinerUFallback:
             with patch("zotero_cli_cc.commands.pdf.get_extractor", side_effect=get_extractor_side_effect):
                 result = _invoke(["pdf", "ATTN001", "--extractor", "mineru"])
 
-            assert result.exit_code == 0, result.output
+            # Exit 1 (RUNTIME) — both extractors failed.
+            assert result.exit_code == 1, result.output
             assert "pymupdf also failed" in result.output
 
     def test_fallback_with_page_range(self):

--- a/tests/test_pdf_integration.py
+++ b/tests/test_pdf_integration.py
@@ -106,7 +106,8 @@ class TestPdfCmdWithExtractors:
         with patch("zotero_cli_cc.core.pdf_cache.PdfCache"):
             result = _invoke(["pdf", "NOTFOUND", "--extractor", "pymupdf"])
 
-        assert result.exit_code == 0
+        # Exit 4 (NOT_FOUND) per the agent contract.
+        assert result.exit_code == 4
         assert "no pdf attachment" in result.output.lower()
 
     def test_pdf_json_output(self):
@@ -220,5 +221,6 @@ class TestPdfAndWorkspaceIntegration:
         with patch("zotero_cli_cc.core.pdf_cache.PdfCache"):
             result = _invoke(["pdf", "NONEXISTENT", "--extractor", "pymupdf"])
 
-        assert result.exit_code == 0
+        # Exit 4 (NOT_FOUND) per the agent contract.
+        assert result.exit_code == 4
         assert "no pdf attachment" in result.output.lower() or "not found" in result.output.lower()


### PR DESCRIPTION
## Summary

PR #19 fixed ~10 known-broken error paths (those covered by failing tests). This finishes the migration: every \`print_error(ErrorInfo(...)); return\` pattern that emitted an error message but silently exited 0 — breaking the agent contract's typed-exit promise from \`docs/agent-interface.md\` — is now \`emit_error(...)\` with the right typed code.

## Production changes

Across \`commands/\`, error paths now emit:

| Code | Exit | Where |
|---|---|---|
| \`not_found\` | 4 | item/PDF/workspace/collection/profile/index/section missing |
| \`validation_error\` | 3 | bad page range, missing required source flag |
| \`auth_missing\` | 2 | tag/trash/collection write commands without credentials |
| \`conflict\` | 6 | workspace already exists |
| \`runtime_error\` | 1 | PDF extraction failures, caught ZoteroWriteError |

Batch-write commands (\`tag\` for multi-key, \`trash restore\` multi-key, \`collection reorganize\`) keep their existing warn-and-continue-then-summarise pattern — their exit codes were already correct.

\`zot relate KEY\` returning 0 results is reclassified as a normal outcome (exit 0 + friendly message), matching \`zot search\`'s behavior on empty results.

## Test plan

- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run mypy src/zotero_cli_cc/\` — clean
- [x] \`uv run pytest tests/\` — 549 passed, 1 skipped
- [ ] CI confirms across 3.10–3.13
- [ ] Smoke: \`zot cite NONEXIST\` exits 4, \`zot pdf X --pages abc\` exits 3, \`zot tag K1 --add x\` (no creds) exits 2, \`zot workspace new existing\` exits 6