### PR TITLE
Fix/pr15 pr17

### DIFF
--- a/src/zotero_cli_cc/commands/config.py
+++ b/src/zotero_cli_cc/commands/config.py
@@ -183,6 +183,7 @@ def cache_list(ctx: click.Context) -> None:
 
     json_out = ctx.obj.get("json", False) if ctx.obj else False
 
+    cache: PdfCache | None = None
     try:
         cache = PdfCache()
         rows = cache._conn.execute(
@@ -193,7 +194,8 @@ def cache_list(ctx: click.Context) -> None:
         click.echo(f"Error: Could not access cache database: {e}", err=True)
         raise SystemExit(1)
     finally:
-        cache.close()
+        if cache:
+            cache.close()
 
 
 @profile_group.command("set")

--- a/src/zotero_cli_cc/core/embedding_router.py
+++ b/src/zotero_cli_cc/core/embedding_router.py
@@ -50,8 +50,12 @@ class EmbeddingRouter:
         raise RuntimeError("No embedding provider configured")
 
     def _find_provider(self) -> EmbeddingProvider | None:
-        priority = ["aliyun", "jina"]
-        for name in priority:
+        # If user explicitly selected a provider, use only that one
+        if self.config.provider in ("jina", "aliyun"):
+            return self.providers.get(self.config.provider)
+
+        # Auto mode: respect provider registration order (jina first, then aliyun)
+        for name in ("jina", "aliyun"):
             if name in self.providers:
                 return self.providers[name]
         return None

--- a/src/zotero_cli_cc/core/embedding_router.py
+++ b/src/zotero_cli_cc/core/embedding_router.py
@@ -17,6 +17,7 @@ class EmbeddingRouter:
     def _init_providers(self) -> None:
         api_key = self.config.api_key
         model = self.config.model
+        jina_default_model = "jina-embeddings-v3"
 
         if self.config.provider in ("jina", "auto") and api_key:
             jina_url = self.config.url if "jina" in self.config.url else "https://api.jina.ai/v1/embeddings"
@@ -29,9 +30,10 @@ class EmbeddingRouter:
         if self.config.provider in ("aliyun", "auto") and (self.config.aliyun_api_key or api_key):
             aliyun_key = self.config.aliyun_api_key or api_key
             aliyun_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            aliyun_model = "text-embedding-v3" if model == jina_default_model else model
             self.providers["aliyun"] = AliyunProvider(
                 api_key=aliyun_key,
-                model=model,
+                model=aliyun_model,
                 base_url=aliyun_url,
             )
 

--- a/src/zotero_cli_cc/core/embedding_router.py
+++ b/src/zotero_cli_cc/core/embedding_router.py
@@ -26,7 +26,7 @@ class EmbeddingRouter:
                 url=jina_url,
             )
 
-        if self.config.provider in ("aliyun", "auto") and api_key:
+        if self.config.provider in ("aliyun", "auto") and (self.config.aliyun_api_key or api_key):
             aliyun_key = self.config.aliyun_api_key or api_key
             aliyun_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
             self.providers["aliyun"] = AliyunProvider(

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -170,6 +170,9 @@ def _handle_read(key: str, detail: str = "standard", library: str = "user") -> d
 
 
 def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
+    from zotero_cli_cc.config import load_pdf_config
+    from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
+
     reader = _get_reader(library)
     att = reader.get_pdf_attachment(key)
     if att is None:
@@ -185,17 +188,19 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
         end = int(parts[1]) if len(parts) > 1 else start
         page_range = (start, end)
 
+    extractor_name = load_pdf_config().extractor
+    pdf_extractor = get_extractor(extractor_name)
     cache = PdfCache()
     try:
         if page_range is None:
-            cached = cache.get(pdf_path)
+            cached = cache.get(pdf_path, extractor_name)
             if cached is not None:
                 text = cached
             else:
-                text = extract_text_from_pdf(pdf_path)
-                cache.put(pdf_path, text)
+                text = pdf_extractor.extract_text(pdf_path)
+                cache.put(pdf_path, extractor_name, text)
         else:
-            text = extract_text_from_pdf(pdf_path, pages=page_range)
+            text = pdf_extractor.extract_text(pdf_path, pages=page_range)
     except PdfExtractionError as e:
         return {"error": str(e), "context": "pdf"}
     finally:


### PR DESCRIPTION
## Summary
Fix 5 bugs found during upstream PR #15 and #17 code review.
### PR #15 Embedding Router Fixes (3 bugs)
1. **Respect explicit provider selection** (`embedding_router.py`)
   - Previously `_find_provider()` had hardcoded priority `["aliyun", "jina"]` which caused auto mode to always prefer aliyun even when only jina key was configured.
   - Now: if user explicitly selected `jina` or `aliyun`, use only that provider; if `auto`, use priority order (jina first).
2. **Register aliyun provider when only aliyun_api_key is configured** (`embedding_router.py`)
   - The aliyun registration guard used `api_key` instead of `(aliyun_api_key or api_key)`, preventing users who only set `aliyun_api_key` from using the aliyun provider.
   - Now: guard checks `(self.config.aliyun_api_key or api_key)`.
3. **Use aliyun default model when config model is jina default** (`embedding_router.py`)
   - When user configures aliyun provider without explicitly setting model, config defaults to `jina-embeddings-v3` which aliyun API rejects.
   - Now: when model equals jina default, aliyun provider uses its own default `text-embedding-v3`.
### PR #17 MCP/Cache Fixes (2 bugs)
4. **Use configured extractor for MCP `_handle_pdf`** (`mcp_server.py`)
   - MCP cached under configured extractor name but always extracted with pymupdf (via deprecated `extract_text_from_pdf()`), causing cache pollution.
   - Now: uses `load_pdf_config().extractor` + `get_extractor()` and proper 3-arg cache API.
5. **Prevent UnboundLocalError in `cache_list`** (`commands/config.py`)
   - If `PdfCache()` constructor threw a non-OperationalError, `finally: cache.close()` raised `UnboundLocalError`, masking the original error.
   - Now: initializes `cache = None` before try block and guards `close()` with `if cache`.
### Commits (5)
- `568e93e` fix: prevent UnboundLocalError in cache_list when PdfCache() fails
- `e6e97ba` fix: use configured extractor for MCP _handle_pdf instead of hardcoded pymupdf
- `f58d3ae` fix: register aliyun provider when only aliyun_api_key is configured
- `0ebf7e3` fix: respect explicit provider selection in EmbeddingRouter._find_provider
- `ccff50f` fix: use aliyun default model when config model is jina default
### Files Changed
- `src/zotero_cli_cc/core/embedding_router.py`
- `src/zotero_cli_cc/mcp_server.py`
- `src/zotero_cli_cc/commands/config.py`
---