### PR TITLE
fix: use configured extractor for MCP _handle_pdf instead of hardcode…

### DIFF
--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -170,6 +170,9 @@ def _handle_read(key: str, detail: str = "standard", library: str = "user") -> d
 
 
 def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
+    from zotero_cli_cc.config import load_pdf_config
+    from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
+
     reader = _get_reader(library)
     att = reader.get_pdf_attachment(key)
     if att is None:
@@ -185,17 +188,19 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
         end = int(parts[1]) if len(parts) > 1 else start
         page_range = (start, end)
 
+    extractor_name = load_pdf_config().extractor
+    pdf_extractor = get_extractor(extractor_name)
     cache = PdfCache()
     try:
         if page_range is None:
-            cached = cache.get(pdf_path)
+            cached = cache.get(pdf_path, extractor_name)
             if cached is not None:
                 text = cached
             else:
-                text = extract_text_from_pdf(pdf_path)
-                cache.put(pdf_path, text)
+                text = pdf_extractor.extract_text(pdf_path)
+                cache.put(pdf_path, extractor_name, text)
         else:
-            text = extract_text_from_pdf(pdf_path, pages=page_range)
+            text = pdf_extractor.extract_text(pdf_path, pages=page_range)
     except PdfExtractionError as e:
         return {"error": str(e), "context": "pdf"}
     finally:

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -11,7 +11,6 @@ from mcp.server.fastmcp import FastMCP
 
 from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, load_embedding_config
 from zotero_cli_cc.core.pdf_cache import PdfCache
-from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, extract_text_from_pdf
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.workspace import (
     Workspace,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -201,11 +201,12 @@ class TestHandleRead:
 
 class TestHandlePdf:
     @patch("zotero_cli_cc.mcp_server.PdfCache")
-    @patch("zotero_cli_cc.mcp_server.extract_text_from_pdf")
+    @patch("zotero_cli_cc.core.pdf_extractor.get_extractor")
+    @patch("zotero_cli_cc.config.load_pdf_config")
     @patch("zotero_cli_cc.mcp_server._get_reader")
     @patch("zotero_cli_cc.mcp_server.load_config")
     @patch("zotero_cli_cc.mcp_server.get_data_dir")
-    def test_extracts_text(self, mock_data_dir, mock_config, mock_get_reader, mock_extract, mock_cache_cls):
+    def test_extracts_text(self, mock_data_dir, mock_config, mock_get_reader, mock_load_pdf, mock_get_extractor, mock_cache_cls):
         from zotero_cli_cc.mcp_server import _handle_pdf
 
         data_dir = Path("/fake/zotero")
@@ -223,7 +224,10 @@ class TestHandlePdf:
         cache = MagicMock()
         cache.get.return_value = None
         mock_cache_cls.return_value = cache
-        mock_extract.return_value = "PDF text content"
+        mock_load_pdf.return_value.extractor = "pymupdf"
+        mock_extractor = MagicMock()
+        mock_extractor.extract_text.return_value = "PDF text content"
+        mock_get_extractor.return_value = mock_extractor
 
         with patch.object(Path, "exists", return_value=True):
             result = _handle_pdf("ABC123", None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -206,7 +206,9 @@ class TestHandlePdf:
     @patch("zotero_cli_cc.mcp_server._get_reader")
     @patch("zotero_cli_cc.mcp_server.load_config")
     @patch("zotero_cli_cc.mcp_server.get_data_dir")
-    def test_extracts_text(self, mock_data_dir, mock_config, mock_get_reader, mock_load_pdf, mock_get_extractor, mock_cache_cls):
+    def test_extracts_text(
+        self, mock_data_dir, mock_config, mock_get_reader, mock_load_pdf, mock_get_extractor, mock_cache_cls
+    ):
         from zotero_cli_cc.mcp_server import _handle_pdf
 
         data_dir = Path("/fake/zotero")


### PR DESCRIPTION
Fix MCP `_handle_pdf` cache key mismatch with configured extractor using deprecated function (upstream PR #17 review comment).