### PR TITLE
fix(mcp): mirror mineru→pymupdf fallback from CLI in `_handle_pdf`

### DIFF
--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -205,7 +205,18 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
         else:
             text = pdf_extractor.extract_text(pdf_path, pages=page_range)
     except PdfExtractionError as e:
-        return {"error": str(e), "context": "pdf"}
+        if extractor_name == "mineru":
+            pdf_extractor = get_extractor("pymupdf")
+            try:
+                if page_range is None:
+                    text = pdf_extractor.extract_text(pdf_path)
+                    cache.put(pdf_path, "pymupdf", text)
+                else:
+                    text = pdf_extractor.extract_text(pdf_path, pages=page_range)
+            except PdfExtractionError:
+                return {"error": str(e), "context": "pdf"}
+        else:
+            return {"error": str(e), "context": "pdf"}
     finally:
         cache.close()
 


### PR DESCRIPTION
The CLI commands/pdf.py falls back from mineru to pymupdf on PdfExtractionError, but `_handle_pdf` in mcp_server.py was returning `{"error": ...}` instead. This caused a user-visible behavioral divergence between `zot pdf` and the MCP pdf tool. 

Now mirror CLI's mineru → pymupdf fallback logic in order to maintain logical consistency.