### PR TITLE
fix(embedding): send Jina payload as flat list, not {"texts": ...}

### DIFF
--- a/src/zotero_cli_cc/core/providers/jina.py
+++ b/src/zotero_cli_cc/core/providers/jina.py
@@ -46,7 +46,7 @@ class JinaProvider(EmbeddingProvider):
         return all_embeddings
 
     def _embed_batch(self, batch: list[str]) -> list[list[float]]:
-        body = json_mod.dumps({"model": self.model, "input": {"texts": batch}}).encode()
+        body = json_mod.dumps({"model": self.model, "input": batch}).encode()
         req = urllib.request.Request(self.url, data=body)
         req.add_header("Content-Type", "application/json")
         req.add_header("Authorization", f"Bearer {self.api_key}")
@@ -76,7 +76,7 @@ class JinaProvider(EmbeddingProvider):
         results: list[list[float]] = []
         for text in batch:
             try:
-                body = json_mod.dumps({"model": self.model, "input": {"texts": [text]}}).encode()
+                body = json_mod.dumps({"model": self.model, "input": [text]}).encode()
                 req = urllib.request.Request(self.url, data=body)
                 req.add_header("Content-Type", "application/json")
                 req.add_header("Authorization", f"Bearer {self.api_key}")


### PR DESCRIPTION
## Summary
- Jina v1 `/embeddings` expects `{"input": [str, ...]}`, but `JinaProvider._embed_batch` wrapped the batch as `{"input": {"texts": batch}}`, producing HTTP 422.
- The error was swallowed by `embed_texts` in `core/rag.py` (returns `None` on any exception), so `workspace index` silently fell back to BM25 with `chunks.embedding` left NULL — symptom in the wild was `[BM25]` instead of `[BM25 + embeddings]`.
- Fixed in both `_embed_batch` and the per-item `_fallback_to_individual` path so the 413 fallback also produces a valid request.

Closes #26.

## Test plan
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/zotero_cli_cc/`
- [x] `uv run pytest tests/ -v` (549 passed, 1 skipped)
- [ ] Manual: configure `[embedding] provider=jina` with a valid key, run `zot workspace index <name> --force`, verify `SELECT COUNT(embedding) FROM chunks` is non-zero and progress prints `[BM25 + embeddings]`.