### PR TITLE
fix(embedding): surface embed_texts provider failures to stderr

### DIFF
--- a/src/zotero_cli_cc/core/rag.py
+++ b/src/zotero_cli_cc/core/rag.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+import sys
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -339,5 +340,12 @@ def embed_texts(
     router = EmbeddingRouter(config)
     try:
         return router.embed(texts, progress_callback)
-    except Exception:
+    except Exception as e:
+        # Configured-but-failed: surface the reason so callers don't silently
+        # degrade to BM25-only without telling the user. See issue #28.
+        sys.stderr.write(
+            f"\r{' ' * 60}\r"
+            f"  [WARN] Embedding provider '{config.provider}' failed: "
+            f"{type(e).__name__}: {e}. Falling back to BM25-only.\n"
+        )
         return None

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -201,6 +201,26 @@ class TestEmbedding:
             assert body["model"] == "model"
             assert body["input"] == ["hello world"]
 
+    def test_embed_texts_surfaces_provider_error(self, capsys):
+        cfg = EmbeddingConfig(url="http://test/v1/embeddings", api_key="key", model="model", provider="aliyun")
+        with patch(
+            "zotero_cli_cc.core.embedding_router.EmbeddingRouter.embed",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = embed_texts(["hello"], cfg)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+        assert "aliyun" in captured.err
+        assert "boom" in captured.err
+
+    def test_embed_texts_silent_when_not_configured(self, capsys):
+        cfg = EmbeddingConfig(url="", api_key="", model="")
+        result = embed_texts(["hello"], cfg)
+        assert result is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
 
 class TestRRF:
     def test_reciprocal_rank_fusion(self):


### PR DESCRIPTION
## Summary
- `embed_texts` in `core/rag.py` caught every `Exception` from the router and returned `None`, which callers (`workspace index`, `mcp_server`) treat the same as "embedding not configured" — so a misconfigured key, a malformed payload (#26), a network blip, or a rate limit silently degraded the index to BM25-only with no signal to the user.
- Now we still return `None` on failure (so callers stay simple and the BM25 fallback still works), but emit a one-liner to stderr identifying the provider and the underlying exception. The not-configured path remains silent.
- Two new tests pin the behavior: `test_embed_texts_surfaces_provider_error` (warning is emitted on raise) and `test_embed_texts_silent_when_not_configured` (no noise when caller never asked for embeddings).

Closes #28. Builds on #27.

## Test plan
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/zotero_cli_cc/`
- [x] `uv run pytest tests/test_rag.py -v` (26 passed)
- [ ] Manual: configure `[embedding] provider=jina` with an invalid key, run `zot workspace index <name> --force`, verify a `[WARN] Embedding provider 'jina' failed: ...` line appears on stderr and the index completes BM25-only.