### PR TITLE
fix(version): suggest upgrade command based on install source

### DIFF
--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -199,13 +199,13 @@ def _after_command(ctx: click.Context, *_args: object, **_kwargs: object) -> Non
     if obj.get("json") or obj.get("no_interaction") or not sys.stderr.isatty():
         return
     from zotero_cli_cc import __version__
-    from zotero_cli_cc.core.version_check import check_for_update
+    from zotero_cli_cc.core.version_check import check_for_update, upgrade_command
 
     latest = check_for_update(__version__)
     if latest:
         click.echo(
             click.style(
-                f"\n Update available: v{__version__} → v{latest}. Run: uv tool upgrade zotero-cli-cc",
+                f"\n Update available: v{__version__} → v{latest}. Run: {upgrade_command()}",
                 fg="yellow",
             ),
             err=True,

--- a/src/zotero_cli_cc/core/version_check.py
+++ b/src/zotero_cli_cc/core/version_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from pathlib import Path
 from urllib.request import urlopen
@@ -17,6 +18,20 @@ _TIMEOUT = 3  # seconds
 def _parse_version(v: str) -> tuple[int, ...]:
     """Parse version string into tuple for comparison."""
     return tuple(int(x) for x in v.strip().split(".") if x.isdigit())
+
+
+def upgrade_command(executable: str | None = None) -> str:
+    """Return the upgrade command appropriate to how this install was placed.
+
+    Detects uv tool and pipx by inspecting ``sys.executable``; falls back to
+    a plain ``pip install -U`` (which is correct for pip/conda/system installs).
+    """
+    exe = (executable if executable is not None else sys.executable).replace("\\", "/")
+    if "/uv/tools/" in exe:
+        return "uv tool upgrade zotero-cli-cc"
+    if "/pipx/venvs/" in exe:
+        return "pipx upgrade zotero-cli-cc"
+    return "pip install -U zotero-cli-cc"
 
 
 def check_for_update(current_version: str) -> str | None:

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -6,7 +6,7 @@ import json
 import time
 from unittest.mock import MagicMock, patch
 
-from zotero_cli_cc.core.version_check import _parse_version, check_for_update
+from zotero_cli_cc.core.version_check import _parse_version, check_for_update, upgrade_command
 
 
 class TestParseVersion:
@@ -108,3 +108,30 @@ class TestCheckForUpdate:
 
         result = check_for_update("0.2.3")
         assert result is None
+
+
+class TestUpgradeCommand:
+    def test_uv_tool_install(self):
+        exe = "/Users/me/.local/share/uv/tools/zotero-cli-cc/bin/python"
+        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-cc"
+
+    def test_pipx_install(self):
+        exe = "/Users/me/.local/pipx/venvs/zotero-cli-cc/bin/python"
+        assert upgrade_command(exe) == "pipx upgrade zotero-cli-cc"
+
+    def test_conda_install_falls_back_to_pip(self):
+        exe = "/Users/me/mambaforge/bin/python"
+        assert upgrade_command(exe) == "pip install -U zotero-cli-cc"
+
+    def test_system_pip_falls_back_to_pip(self):
+        exe = "/usr/bin/python3"
+        assert upgrade_command(exe) == "pip install -U zotero-cli-cc"
+
+    def test_windows_uv_tool_path(self):
+        exe = r"C:\Users\me\AppData\Roaming\uv\tools\zotero-cli-cc\Scripts\python.exe"
+        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-cc"
+
+    def test_uses_sys_executable_by_default(self):
+        with patch("zotero_cli_cc.core.version_check.sys") as mock_sys:
+            mock_sys.executable = "/opt/uv/tools/zotero-cli-cc/bin/python"
+            assert upgrade_command() == "uv tool upgrade zotero-cli-cc"


### PR DESCRIPTION
## Summary
- The post-command update banner hard-coded `Run: uv tool upgrade zotero-cli-cc`. For users who installed via pip / conda / pipx, that command does nothing (e.g. when `zot` lives in `~/mambaforge/bin/`, `uv tool upgrade` reports "Nothing to upgrade") and leaves them stuck on the old version with no obvious next step.
- Add `upgrade_command()` in `core/version_check.py` that inspects `sys.executable` and returns the matching upgrade command: `uv tool upgrade` for uv-tool installs, `pipx upgrade` for pipx, and `pip install -U` as the fallback (correct for pip/conda/system installs).
- Wire it into the banner so the suggested command always matches the user's actual install.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean
- [x] `uv run mypy src/zotero_cli_cc/` — clean
- [x] `uv run pytest tests/test_version_check.py -v` — 15 passed (6 new tests cover uv-tool, pipx, conda fallback, system pip fallback, Windows path, and default `sys.executable`)
- [x] Full `pytest tests/` — only pre-existing MCP `ModuleNotFoundError` failures (also fail on `main` in this env); my changes do not touch MCP code