### PR TITLE
release: v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-05-11
+
+### Fixed
+
+- Update-available banner hard-coded `uv tool upgrade zotero-cli-cc`, which
+  is wrong for users who installed via pip / conda / pipx. The suggested
+  command is now detected from `sys.executable` (uv tool / pipx) with a
+  `pip install -U` fallback that works for pip, conda, and system installs (#31).
+
 ## [0.4.2] - 2026-05-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.4.2"
+version = "0.4.3"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "CC-BY-NC-4.0"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2104,7 +2104,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bump to v0.4.3 to ship the install-source-aware upgrade banner from #31.

## Changes
- `pyproject.toml`: 0.4.2 → 0.4.3
- `CHANGELOG.md`: new 0.4.3 entry summarizing #31
- `uv.lock`: refreshed

## Release flow
After merge, push `v0.4.3` tag to trigger `publish.yml` → PyPI.