### PR TITLE
docs: slim READMEs (~500 → ~130 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,340 +14,66 @@
 
 [中文](README_CN.md) | [Documentation](https://agents365-ai.github.io/zotero-cli-cc/)
 
-## Introduction
+`zotero-cli-cc` is a Zotero CLI built for [Claude Code](https://claude.ai/code) and AI agents.
 
-`zotero-cli-cc` is a Zotero CLI designed for [Claude Code](https://claude.ai/code).
-
-**Core Features:**
-- **Reads**: Direct local SQLite database access — zero config, offline, millisecond response
-- **Writes**: Safe writes through Zotero Web API — Zotero fully aware of changes
-- **PDF**: Extract full text from local PDF storage with automatic caching
-- **Workspace**: Organize papers by topic with local workspaces + built-in RAG search
-- **Agent-native**: Stable JSON envelope, typed exit codes, `zot schema`, `--dry-run`, `--idempotency-key`, NDJSON streaming — see [`docs/agent-interface.md`](docs/agent-interface.md)
-
-**Search and read papers without launching Zotero desktop.**
-
-## Using with Claude Code
-
-In any Claude Code session, use natural language:
-
-```
-Search my Zotero for single cell papers
-→ Claude runs: zot search "single cell"
-
-Show me details of this paper
-→ Claude runs: zot read ABC123
-
-Export BibTeX for this paper
-→ Claude runs: zot export ABC123
-```
-
-When `zot` detects that stdout is not a TTY (agents, pipelines, subprocess calls) it automatically emits JSON. Humans still see tables. Agents never have to pass `--json`.
-
-Every command response is a stable envelope:
-
-```json
-{ "ok": true, "data": { ... }, "meta": { "request_id": "...", "cli_version": "0.4.0" } }
-```
-
-Errors carry machine-routable `code` and `retryable` fields; exit codes are distinct per failure class (1 runtime, 2 auth, 3 validation, 4 not-found, 5 network, 6 conflict). Mutating commands support `--dry-run` and `--idempotency-key` so retries are safe. See [`docs/agent-interface.md`](docs/agent-interface.md) for the full contract, or run `zot schema` to introspect the CLI tree programmatically.
-
-Install the zotero-cli skill so Claude Code automatically recognizes literature-related requests:
-
-```bash
-# Install skill (copy skill/zotero-cli-cc/ to ~/.claude/skills/)
-cp -r skill/zotero-cli-cc ~/.claude/skills/
-```
+- **Reads** — direct local SQLite, zero-config, offline, millisecond response
+- **Writes** — safe via Zotero Web API, Zotero stays in sync
+- **PDF + RAG** — extract full text with caching; built-in BM25 (+ optional embedding) search over per-topic workspaces
+- **Agent-native** — stable JSON envelope, typed exit codes, `zot schema`, `--dry-run`, `--idempotency-key`, NDJSON streaming
+- **MCP server** — exposes 45 tools to Claude Desktop / LM Studio / Cursor via `zot mcp serve`
 
 ## Install
 
 ```bash
-# Recommended
-uv tool install zotero-cli-cc
-
-# Or
-pipx install zotero-cli-cc
-
-# Or
-pip install zotero-cli-cc
+uv tool install zotero-cli-cc      # recommended
+pipx install zotero-cli-cc         # or
+pip install zotero-cli-cc          # or
 ```
 
-Upgrade to the latest version:
+## 60-second quickstart
 
 ```bash
-uv tool upgrade zotero-cli-cc    # uv
-pipx upgrade zotero-cli-cc       # pipx
-pip install -U zotero-cli-cc     # pip
-```
+# Reads work out of the box — no API key, Zotero data dir auto-detected
+zot search "transformer attention"
+zot read ABC123
+zot export ABC123                  # BibTeX
 
-## Setup
-
-```bash
-# Configure Web API credentials (write operations only)
+# Writes need a Web API key (https://www.zotero.org/settings/keys)
 zot config init
+zot add --doi "10.1038/s41586-023-06139-9"
 ```
 
-### Data Directory
-
-> **Data directory** refers to the folder containing the `zotero.sqlite` database file (not the Zotero installation directory or the PDF sync directory). You can find it in Zotero Settings → Advanced → "Data Directory Location".
-
-Read operations work out of the box. `zot` automatically detects the Zotero data directory:
-
-| Platform | Detection Order |
-|----------|----------------|
-| **Windows** | Registry `HKCU\Software\Zotero\Zotero\dataDir` → `%APPDATA%\Zotero` → `%LOCALAPPDATA%\Zotero` |
-| **macOS / Linux** | `~/Zotero` |
-
-If your Zotero data is not in the default location, specify it:
+In Claude Code, just ask in natural language — the bundled skill maps requests to `zot` commands automatically:
 
 ```bash
-# Option 1: Config file (recommended)
-zot config init --data-dir "D:\MyZotero"
-
-# Option 2: Environment variable
-export ZOT_DATA_DIR="/path/to/zotero/data"
-
-# Option 3: Edit config file manually
-# Edit ~/.config/zot/config.toml
+cp -r skill/zotero-cli-cc ~/.claude/skills/
 ```
 
-Example config file:
-
-```toml
-[zotero]
-data_dir = "D:\\MyZotero"
-library_id = "12345"
-api_key = "xxx"
-
-[output]
-default_format = "table"
-limit = 50
-
-[export]
-default_style = "bibtex"
-```
-
-### API Credentials
-
-Write operations require an API Key from https://www.zotero.org/settings/keys.
-
-### MCP Server Mode
-
-zotero-cli-cc supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) and can be used in MCP-compatible clients like LM Studio, Claude Desktop, and Cursor.
-
-**Install MCP Support:**
-
-```bash
-pip install zotero-cli-cc[mcp]
-```
-
-**Start MCP Server:**
-
-```bash
-zot mcp serve
-```
-
-**Client Configuration (LM Studio / Claude Desktop / Cursor):**
+When stdout is not a TTY, `zot` automatically emits a stable JSON envelope so agents never need `--json`:
 
 ```json
-{
-  "mcpServers": {
-    "zotero": {
-      "command": "zot",
-      "args": ["mcp", "serve"]
-    }
-  }
-}
+{ "ok": true, "data": { ... }, "meta": { "request_id": "...", "cli_version": "0.4.3" } }
 ```
 
-MCP mode provides 45 tools covering search, reading, PDF extraction, note management, tag management, citation export, workspace management with RAG, library statistics, and preprint status checking.
+## Documentation
 
-## Commands
+Full docs live at **https://agents365-ai.github.io/zotero-cli-cc/**.
 
-### Search & Browse
+| Topic | Link |
+|---|---|
+| Installation & setup | [Getting started](https://agents365-ai.github.io/zotero-cli-cc/getting-started/installation/) |
+| Search, list, read | [Search guide](https://agents365-ai.github.io/zotero-cli-cc/guide/search/) |
+| Notes, tags, citations | [Notes & tags](https://agents365-ai.github.io/zotero-cli-cc/guide/notes-tags/), [Citations](https://agents365-ai.github.io/zotero-cli-cc/guide/citations/) |
+| Add / update / delete items | [Item management](https://agents365-ai.github.io/zotero-cli-cc/guide/item-management/) |
+| Collections | [Collections](https://agents365-ai.github.io/zotero-cli-cc/guide/collections/) |
+| Workspaces + RAG | [Workspaces](https://agents365-ai.github.io/zotero-cli-cc/guide/workspace/) |
+| PDF extraction | [PDF](https://agents365-ai.github.io/zotero-cli-cc/guide/pdf/) |
+| Preprint → published | [update-status](https://agents365-ai.github.io/zotero-cli-cc/guide/update-status/) |
+| MCP setup & tools | [MCP](https://agents365-ai.github.io/zotero-cli-cc/mcp/setup/) |
+| Full CLI reference | [CLI reference](https://agents365-ai.github.io/zotero-cli-cc/reference/cli/) |
+| Agent contract (envelope, exit codes, schema) | [`docs/agent-interface.md`](docs/agent-interface.md) |
 
-> **How search works:** `zot search` matches keywords across four layers: ① titles & abstracts ② author names ③ tags ④ PDF fulltext index. For deeper content search with BM25 ranking and optional semantic matching, use `zot workspace query` — it indexes metadata + full PDF text and supports hybrid BM25 + embedding retrieval.
-
-```bash
-# Search across title, author, tags, fulltext
-zot search "transformer attention"
-
-# Filter by collection
-zot search "BERT" --collection "NLP"
-
-# List items
-zot list --collection "Machine Learning" --limit 10
-
-# View item details (metadata + abstract + notes)
-zot read ABC123
-
-# Find related items
-zot relate ABC123
-```
-
-### Notes & Tags
-
-```bash
-# View/add notes
-zot note ABC123
-zot note ABC123 --add "This paper proposes a new attention mechanism"
-
-# View/add/remove tags
-zot tag ABC123
-zot tag ABC123 --add "important"
-zot tag ABC123 --remove "to-read"
-```
-
-### Citation Export
-
-```bash
-zot export ABC123                    # BibTeX
-zot export ABC123 --format csl-json  # CSL-JSON
-zot export ABC123 --format ris       # RIS
-zot export ABC123 --format json      # JSON
-
-# Format citation and copy to clipboard
-zot cite ABC123                      # APA (default)
-zot cite ABC123 --style nature       # Nature
-zot cite ABC123 --style vancouver    # Vancouver
-```
-
-### Item Management
-
-```bash
-zot add --doi "10.1038/s41586-023-06139-9"       # Add by DOI
-zot add --url "https://arxiv.org/abs/2301.00001"  # Add by URL
-zot add --from-file dois.txt                      # Batch import from file
-zot delete ABC123 --yes                           # Delete (move to trash)
-```
-
-### Collections
-
-```bash
-zot collection list                # List all collections (tree view)
-zot collection items COLML01       # View items in a collection
-zot collection create "New Project"  # Create a new collection
-```
-
-### Workspaces
-
-> **Why workspaces?** Zotero collections are great for permanent library organization, but research often requires temporary, cross-cutting groupings — "all papers for my ICML submission", "papers to discuss at lab meeting", or "references for Chapter 3". Workspaces fill this gap: they're lightweight, local-only views that don't modify your Zotero library. Each workspace is a simple TOML file at `~/.config/zot/workspaces/<name>.toml` containing item key references — no API key needed, no syncing side effects. Combined with built-in RAG indexing, workspaces become a powerful bridge between your Zotero library and AI coding assistants like Claude Code.
-
-```bash
-# Create and populate a workspace
-zot workspace new llm-safety --description "LLM alignment papers"
-zot workspace add llm-safety ABC123 DEF456 GHI789
-zot workspace import llm-safety --collection "Alignment"   # Bulk import from collection
-zot workspace import llm-safety --tag "safety"              # or by tag
-zot workspace import llm-safety --search "RLHF"            # or by search
-
-# Browse workspace
-zot workspace list                          # List all workspaces
-zot workspace show llm-safety               # View items with metadata
-zot workspace search "reward" --workspace llm-safety  # Search within workspace
-
-# Export for AI consumption
-zot workspace export llm-safety                       # Markdown (for Claude Code)
-zot workspace export llm-safety --format json         # JSON
-zot workspace export llm-safety --format bibtex       # BibTeX
-
-# Built-in RAG: index and query
-zot workspace index llm-safety                       # Build BM25 index (metadata + PDF text)
-zot workspace index llm-safety --extractor mineru    # Use MinerU for higher-quality PDF text
-zot workspace query "reward hacking methods" --workspace llm-safety
-
-# Manage
-zot workspace remove llm-safety ABC123      # Remove item
-zot workspace delete llm-safety --yes       # Delete workspace
-```
-
-**Optional semantic search** — configure an embedding endpoint for hybrid BM25 + vector retrieval. Multiple providers are supported via `[embedding] provider` (`jina` (default) / `aliyun` / `openai`):
-
-```bash
-# Jina AI (default, 10M free tokens)
-export ZOT_EMBEDDING_URL="https://api.jina.ai/v1/embeddings"
-export ZOT_EMBEDDING_KEY="your-jina-key"
-
-# Or Aliyun DashScope (OpenAI-compatible)
-export ZOT_EMBEDDING_PROVIDER=aliyun
-export ZOT_EMBEDDING_KEY="your-dashscope-key"
-
-zot workspace index llm-safety --force                              # Rebuild with embeddings
-zot workspace query "reward hacking" --workspace llm-safety --mode hybrid
-```
-
-### Profiles & Cache
-
-```bash
-zot config profile list            # List all config profiles
-zot config profile set lab         # Set default profile
-zot config cache stats             # Show PDF cache statistics
-zot config cache clear             # Clear PDF cache
-```
-
-### Preprint Status Check
-
-```bash
-# Check if arXiv/bioRxiv/medRxiv preprints have been published (dry-run)
-zot update-status
-
-# Actually update Zotero metadata for published papers
-zot update-status --apply
-
-# Check a single item
-zot update-status ABC123
-
-# Check items in a collection
-zot update-status --collection "scRNA-seq" --limit 20
-```
-
-Uses the [Semantic Scholar API](https://www.semanticscholar.org/product/api). Optional API key for faster rate limits:
-
-```bash
-export S2_API_KEY=your_key_here   # in ~/.zshrc or ~/.bashrc
-```
-
-### AI Features
-
-```bash
-zot summarize ABC123               # Structured summary (optimized for Claude Code)
-zot pdf ABC123                     # Extract PDF full text
-zot pdf ABC123 --pages 1-5         # Extract specific pages
-zot pdf ABC123 --outline           # List headings as a numbered outline
-zot pdf ABC123 --section 3         # Extract just section 3 from --outline
-zot pdf ABC123 --extractor mineru  # Use MinerU (auto-falls-back to pymupdf)
-```
-
-**PDF extractors.** Two backends are available: the default `pymupdf` (fast, no network), and `mineru` (higher-fidelity layout/equation/table parsing via the MinerU API; falls back to pymupdf on failure). Configure once via `[pdf] extractor` / `[pdf] mineru_token` in `~/.config/zot/config.toml`, or via `ZOT_PDF_EXTRACTOR` / `MINERU_TOKEN` env vars.
-
-### Global Flags
-
-```bash
-zot --json search "attention"              # JSON output
-zot --limit 5 list                         # Limit results
-zot --detail minimal search "attention"    # Minimal output (key/title/authors/year only)
-zot --detail full read ABC123              # Full output (including extra fields)
-zot --no-interaction delete ABC123         # Skip confirmation prompts (AI/script mode)
-zot --profile lab search "CRISPR"          # Use a specific config profile
-zot --version                              # Show version
-```
-
-### Shell Completions
-
-```bash
-# Zsh (recommended)
-zot completions zsh >> ~/.zshrc
-
-# Bash
-zot completions bash >> ~/.bashrc
-
-# Fish
-zot completions fish > ~/.config/fish/completions/zot.fish
-```
-
-Restart your terminal or `source` the config file to enable tab completions.
-
-## Comparison with Similar Tools
+## Comparison with similar tools
 
 | Feature | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -360,28 +86,10 @@ Restart your terminal or `source` the config file to enable tab completions.
 | **AI Coding Assistant** | **✅ Claude Code** | Partial | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
 | **Terminal CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | **MCP Protocol** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **JSON Output** | ✅ | ✅ | ❌ | ❌ | N/A | N/A | N/A |
-| **Note Management** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| **Collections** | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **Citation Export** | ✅ BibTeX/CSL-JSON/RIS | ✅ | ❌ | ✅ Excel | ❌ | ❌ | ❌ |
 | **Semantic Search** | **✅ Built-in (workspace RAG)** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **Detail Levels** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **Multi-Profile** | **✅** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **PDF Cache** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Library Maintenance** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **Language** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
 | **Active** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
 
-### Why zotero-cli-cc?
-
-> **The only actively maintained Python CLI that reads Zotero's local SQLite database directly.**
-
-- **Fast**: Millisecond response, no network latency
-- **Offline**: No internet, no Zotero desktop needed
-- **Zero-Config**: Install and go, no API key for reads
-- **AI-Native**: Built for Claude Code, `--json` output for AI consumption
-- **Safe**: Read/write separation — writes go through Web API to protect DB integrity
-- **Terminal-Native**: The only CLI combining local SQLite reads with safe Web API writes; MCP tools require AI client, not usable in terminal
+**Why zotero-cli-cc?** The only actively maintained Python CLI that reads Zotero's local SQLite database directly, with a clean read/write split: SQLite for fast offline reads, Web API for safe writes that Zotero stays aware of.
 
 ## Architecture
 
@@ -389,91 +97,9 @@ Restart your terminal or `source` the config file to enable tab completions.
   <img src="asserts/architecture.png" alt="Architecture diagram" width="720">
 </p>
 
-## Environment Variables
-
-| Variable | Purpose |
-|----------|---------|
-| `ZOT_DATA_DIR` | Override Zotero data directory path |
-| `ZOT_LIBRARY_ID` | Override Library ID (write operations) |
-| `ZOT_API_KEY` | Override API Key (write operations) |
-| `ZOT_PROFILE` | Override default config profile |
-| `S2_API_KEY` | Semantic Scholar API key (for `update-status`) |
-| `ZOT_PDF_EXTRACTOR` | PDF extractor: `pymupdf` (default) or `mineru` |
-| `MINERU_TOKEN` | API token for the MinerU PDF extractor |
-| `ZOT_EMBEDDING_PROVIDER` | Embedding provider: `jina` (default), `aliyun`, or `openai` |
-| `ZOT_EMBEDDING_URL` | Embedding API endpoint (default: Jina AI) |
-| `ZOT_EMBEDDING_KEY` | Embedding API key (enables semantic workspace search) |
-| `ZOT_EMBEDDING_MODEL` | Embedding model name (default: `jina-embeddings-v3`) |
-
-## TODO
-
-- [x] Improve HTML-to-Markdown: support lists, links, tables, and other common Zotero note formats (v0.1.2: uses markdownify)
-- [x] `summarize-all` pagination: add offset/cursor pagination for large libraries (v0.1.2: `--offset` flag)
-- [x] `--dry-run` for destructive ops: add preview mode to `delete`, `collection delete`, and `tag` (v0.1.2)
-
-### Features
-
-- [x] `zot cite`: copy formatted citation to clipboard (APA, Nature, Vancouver)
-- [x] Bulk operations from file input (`zot add --from-file dois.txt`)
-- [x] `zot export`: add RIS format support (BibTeX, CSL-JSON, RIS, JSON)
-
-### Tier 1 — High Value, Moderate Effort
-
-- [x] `zot update KEY --title/--date/--field`: update item metadata (pyzotero `update_item()`)
-- [x] `zot search --type journalArticle`: filter search results by item type
-- [x] `zot search --sort dateAdded --direction desc`: sort control for search/list
-- [x] `zot recent --days 7`: recently added/modified items
-- [x] `zot pdf KEY --annotations`: extract PDF annotations (highlights, comments, page numbers) — pymupdf
-
-### Tier 2 — High Value, Higher Effort
-
-- [x] `zot duplicates --by doi|title|both`: duplicate detection (fuzzy title + DOI matching)
-- [x] `zot trash list/restore`: trash management (view + restore)
-- [x] `zot attach KEY --file paper.pdf`: attachment upload
-- [x] `--library group:<id>`: group library support (all commands + MCP tools)
-- [x] `zot add --pdf paper.pdf`: add from local PDF (auto-extract DOI + upload attachment)
-
-### Tier 3 — Medium Value
-
-- [ ] Saved searches CRUD
-- [ ] More export formats: BibLaTeX, MODS, TEI, CSV
-- [ ] Formatted bibliography via citeproc-py with CSL styles
-- [ ] `zot collection remove`: remove item from collection (counterpart to `collection move`)
-- [ ] BetterBibTeX citation key lookup support
-
-### Tier 4 — Nice to Have
-
-- [x] Semantic search via workspace RAG (BM25 + optional embeddings, v0.2.0)
-- [ ] DOI-to-key index
-- [ ] Version tracking / incremental sync
-- [ ] Web interface (`zot serve`)
-- [ ] View tags by collection
-
-### Polish
-
-- [ ] GitHub Issues / Discussions setup for user feedback
-- [x] Improve `--help` text with usage examples
-- [x] Shell completion install instructions in README (zsh/bash/fish)
-
-### Distribution
-
-- [x] `pipx` install instructions
-- [x] GitHub Releases with changelogs (v0.1.1, v0.1.2)
-- [x] README badges: PyPI version, CI status, Python versions, License
-
-### MCP Server
-
-- [x] Expand MCP tools: workspace, cite, stats, update-status (45 tools total)
-- [ ] MCP server documentation / integration guide
-
----
-
 ## Author
 
-**Agents365-ai**
-
-- GitHub: [https://github.com/Agents365-ai](https://github.com/Agents365-ai)
-- Bilibili: [https://space.bilibili.com/441831884](https://space.bilibili.com/441831884)
+**Agents365-ai** — [GitHub](https://github.com/Agents365-ai) · [Bilibili](https://space.bilibili.com/441831884)
 
 ## Support
 
@@ -499,4 +125,4 @@ Restart your terminal or `source` the config file to enable tab completions.
 
 ## License
 
-[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) — Free for non-commercial use.
+[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) — free for non-commercial use.

--- a/README.md
+++ b/README.md
@@ -72,24 +72,10 @@ Full docs live at **https://agents365-ai.github.io/zotero-cli-cc/**.
 | MCP setup & tools | [MCP](https://agents365-ai.github.io/zotero-cli-cc/mcp/setup/) |
 | Full CLI reference | [CLI reference](https://agents365-ai.github.io/zotero-cli-cc/reference/cli/) |
 | Agent contract (envelope, exit codes, schema) | [`docs/agent-interface.md`](docs/agent-interface.md) |
+| Comparison with similar tools | [Comparison](https://agents365-ai.github.io/zotero-cli-cc/comparison/) |
+| Roadmap | [`ROADMAP.md`](ROADMAP.md) |
 
-## Comparison with similar tools
-
-| Feature | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Direct SQLite Read** | **✅** | ❌ | ❌ (cache only) | ❌ | ❌ | ❌ (plugin) | ✅ |
-| **Offline Read** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **No Zotero Running** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **Zero-Config Read** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **Safe Write (Web API)** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ (direct SQLite) |
-| **PDF Full-Text** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **AI Coding Assistant** | **✅ Claude Code** | Partial | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
-| **Terminal CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **MCP Protocol** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **Semantic Search** | **✅ Built-in (workspace RAG)** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **Active** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
-
-**Why zotero-cli-cc?** The only actively maintained Python CLI that reads Zotero's local SQLite database directly, with a clean read/write split: SQLite for fast offline reads, Web API for safe writes that Zotero stays aware of.
+**Why zotero-cli-cc?** The only actively maintained Python CLI that reads Zotero's local SQLite database directly, with a clean read/write split: SQLite for fast offline reads, Web API for safe writes that Zotero stays aware of. See the [comparison page](https://agents365-ai.github.io/zotero-cli-cc/comparison/) for a feature-by-feature breakdown against similar tools.
 
 ## Architecture
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -72,24 +72,10 @@ cp -r skill/zotero-cli-cc ~/.claude/skills/
 | MCP 配置与工具 | [MCP](https://agents365-ai.github.io/zotero-cli-cc/zh/mcp/setup/) |
 | 完整 CLI 参考 | [CLI Reference](https://agents365-ai.github.io/zotero-cli-cc/zh/reference/cli/) |
 | Agent 契约（envelope、退出码、schema） | [`docs/agent-interface.md`](docs/agent-interface.md) |
+| 同类工具对比 | [Comparison](https://agents365-ai.github.io/zotero-cli-cc/zh/comparison/) |
+| 开发路线图 | [`ROADMAP.md`](ROADMAP.md) |
 
-## 同类工具对比
-
-| 特性 | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **直读 SQLite** | **✅** | ❌ | ❌（仅缓存） | ❌ | ❌ | ❌（插件） | ✅ |
-| **离线读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **无需 Zotero 运行** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **零配置读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **安全写（Web API）** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌（直写 SQLite） |
-| **PDF 全文** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **AI 编程助手** | **✅ Claude Code** | 部分 | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
-| **终端 CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **MCP 协议** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **语义搜索** | **✅ 内置（workspace RAG）** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **活跃度** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
-
-**为什么选 zotero-cli-cc？** 当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI；读写分离架构 —— SQLite 提供快速离线读，Web API 提供让 Zotero 感知的安全写。
+**为什么选 zotero-cli-cc？** 当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI；读写分离架构 —— SQLite 提供快速离线读，Web API 提供让 Zotero 感知的安全写。完整功能对比见[对比页面](https://agents365-ai.github.io/zotero-cli-cc/zh/comparison/)。
 
 ## 架构
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,471 +14,94 @@
 
 [English](README.md) | [文档](https://agents365-ai.github.io/zotero-cli-cc/zh/)
 
-## 简介
+`zotero-cli-cc` 是一个专为 [Claude Code](https://claude.ai/code) 和 AI Agent 设计的 Zotero 命令行工具。
 
-`zotero-cli-cc` 是一个专为 [Claude Code](https://claude.ai/code) 设计的 Zotero 命令行工具。
-
-**核心特性：**
-- **读操作**：直接读取本地 SQLite 数据库，零配置、离线可用、毫秒级响应
-- **写操作**：通过 Zotero Web API 安全写入，Zotero 完全感知变更
-- **PDF 提取**：直接从本地存储提取 PDF 全文，自动缓存
-- **工作空间**：按主题组织文献，内置轻量级 RAG 检索
-
-**无需启动 Zotero 桌面端即可检索和阅读文献。**
-
-## 在 Claude Code 中使用
-
-在任何 Claude Code 会话中，直接用自然语言请求：
-
-```
-帮我搜索 Zotero 中关于 single cell 的论文
-→ Claude 自动运行: zot --json search "single cell"
-
-查看这篇论文的详情
-→ Claude 自动运行: zot --json read ABC123
-
-导出这篇论文的 BibTeX
-→ Claude 自动运行: zot export ABC123
-```
-
-安装 zotero-cli skill 后，Claude Code 会自动识别文献相关请求并调用 `zot`：
-
-```bash
-# 安装 skill（将 skill/zotero-cli-cc/ 复制到 ~/.claude/skills/）
-cp -r skill/zotero-cli-cc ~/.claude/skills/
-```
+- **读操作** — 直接读取本地 SQLite，零配置、离线可用、毫秒级响应
+- **写操作** — 通过 Zotero Web API 安全写入，Zotero 完全感知变更
+- **PDF + RAG** — 提取 PDF 全文并自动缓存；内置 BM25（可选向量）按主题工作空间检索
+- **Agent-native** — 稳定 JSON envelope、类型化退出码、`zot schema`、`--dry-run`、`--idempotency-key`、NDJSON 流
+- **MCP 服务器** — 通过 `zot mcp serve` 向 Claude Desktop / LM Studio / Cursor 暴露 45 个工具
 
 ## 安装
 
 ```bash
-# 推荐
-uv tool install zotero-cli-cc
-
-# 或者
-pipx install zotero-cli-cc
-
-# 或者
-pip install zotero-cli-cc
+uv tool install zotero-cli-cc      # 推荐
+pipx install zotero-cli-cc         # 或者
+pip install zotero-cli-cc          # 或者
 ```
 
-升级到最新版本：
+## 60 秒上手
 
 ```bash
-uv tool upgrade zotero-cli-cc    # uv
-pipx upgrade zotero-cli-cc       # pipx
-pip install -U zotero-cli-cc     # pip
-```
+# 读操作开箱即用 —— 无需 API Key，自动检测 Zotero 数据目录
+zot search "transformer attention"
+zot read ABC123
+zot export ABC123                  # BibTeX
 
-## 配置
-
-```bash
-# 配置 Web API 凭证（仅写操作需要）
+# 写操作需要 Web API Key（https://www.zotero.org/settings/keys）
 zot config init
+zot add --doi "10.1038/s41586-023-06139-9"
 ```
 
-### 数据目录
-
-> **数据目录**是指包含 `zotero.sqlite` 数据库文件的目录（不是 Zotero 程序安装目录，也不是 PDF 同步目录）。通常在 Zotero 设置 → 高级 → "数据存储位置" 中查看。
-
-读操作开箱即用，`zot` 会自动检测 Zotero 数据目录：
-
-| 平台 | 检测顺序 |
-|------|----------|
-| **Windows** | 注册表 `HKCU\Software\Zotero\Zotero\dataDir` → `%APPDATA%\Zotero` → `%LOCALAPPDATA%\Zotero` |
-| **macOS / Linux** | `~/Zotero` |
-
-如果 Zotero 数据不在默认目录，可以通过以下方式指定：
+在 Claude Code 中直接用自然语言提问——配套 skill 会自动把请求映射到 `zot` 命令：
 
 ```bash
-# 方式一：配置文件（推荐）
-zot config init --data-dir "D:\MyZotero"
-
-# 方式二：环境变量
-export ZOT_DATA_DIR="/path/to/zotero/data"
-
-# 方式三：手动编辑配置文件
-# 编辑 ~/.config/zot/config.toml
+cp -r skill/zotero-cli-cc ~/.claude/skills/
 ```
 
-配置文件示例：
-
-```toml
-[zotero]
-data_dir = "D:\\MyZotero"
-library_id = "12345"
-api_key = "xxx"
-
-[output]
-default_format = "table"
-limit = 50
-
-[export]
-default_style = "bibtex"
-```
-
-### API 凭证
-
-写操作需要 API Key，在 https://www.zotero.org/settings/keys 获取。
-
-### MCP 服务器模式
-
-zotero-cli-cc 支持 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)，可在 LM Studio、Claude Desktop、Cursor 等支持 MCP 的客户端中使用。
-
-**安装 MCP 支持：**
-
-```bash
-pip install zotero-cli-cc[mcp]
-```
-
-**启动 MCP 服务器：**
-
-```bash
-zot mcp serve
-```
-
-**客户端配置（LM Studio / Claude Desktop / Cursor）：**
+当 stdout 不是终端时，`zot` 自动输出稳定的 JSON envelope，Agent 调用无需加 `--json`：
 
 ```json
-{
-  "mcpServers": {
-    "zotero": {
-      "command": "zot",
-      "args": ["mcp", "serve"]
-    }
-  }
-}
+{ "ok": true, "data": { ... }, "meta": { "request_id": "...", "cli_version": "0.4.3" } }
 ```
 
-MCP 模式提供 45 个工具，涵盖搜索、阅读、PDF 提取、笔记管理、标签管理、导出引用���工作区 RAG、库统计、预���本状态检查等完整功能。
+## 文档
 
-## 命令一览
+完整文档：**https://agents365-ai.github.io/zotero-cli-cc/zh/**
 
-### 检索与浏览
-
-> **搜索原理：** `zot search` 会在四个层面进行关键词匹配：① 标题与摘要 ② 作者姓名 ③ 标签 ④ PDF 全文索引。如需更深层的内容检索（BM25 排序 + 可选语义匹配），可使用 `zot workspace query` — 它索引元数据 + PDF 全文，支持混合 BM25 + embedding 检索。
-
-```bash
-# 全库搜索（标题、作者、标签、全文）
-zot search "transformer attention"
-
-# 按 collection 过滤搜索
-zot search "BERT" --collection "NLP"
-
-# 列出文献
-zot list --collection "Machine Learning" --limit 10
-
-# 查看文献详情（元数据 + 摘要 + 笔记）
-zot read ABC123
-
-# 查找相关文献
-zot relate ABC123
-```
-
-### 笔记与标签
-
-```bash
-# 查看/添加笔记
-zot note ABC123
-zot note ABC123 --add "这篇论文提出了新的注意力机制"
-
-# 查看/添加/删除标签
-zot tag ABC123
-zot tag ABC123 --add "重要"
-zot tag ABC123 --remove "待读"
-```
-
-### 引用导出
-
-```bash
-zot export ABC123                    # BibTeX
-zot export ABC123 --format csl-json  # CSL-JSON
-zot export ABC123 --format ris       # RIS
-zot export ABC123 --format json      # JSON
-
-# 格式化引用并复制到剪贴板
-zot cite ABC123                      # APA（默认）
-zot cite ABC123 --style nature       # Nature
-zot cite ABC123 --style vancouver    # Vancouver
-```
-
-### 文献管理
-
-```bash
-zot add --doi "10.1038/s41586-023-06139-9"    # 通过 DOI 添加
-zot add --url "https://arxiv.org/abs/2301.00001"  # 通过 URL 添加
-zot add --from-file dois.txt                     # 从文件批量导入
-zot delete ABC123 --yes                        # 删除（移入回收站）
-```
-
-### Collection 管理
-
-```bash
-zot collection list                # 列出所有 collection（树形展示）
-zot collection items COLML01       # 查看 collection 内的文献
-zot collection create "新项目"      # 创建新 collection
-```
-
-### 工作空间（Workspace）
-
-> **为什么需要工作空间？** Zotero Collection 适合永久性的文献库组织，但科研工作中经常需要临时的、跨越多个 Collection 的文献分组——"ICML 投稿相关论文"、"组会要讨论的论文"、"第三章参考文献"。工作空间填补了这个空白：它是轻量级的本地视图，不会修改 Zotero 数据。每个工作空间是一个简单的 TOML 文件 (`~/.config/zot/workspaces/<name>.toml`)，只存储条目 key 引用——不需要 API key，不会产生同步副作用。结合内置的 RAG 索引，工作空间成为连接 Zotero 文献库和 AI 编程助手（如 Claude Code）的桥梁。
-
-```bash
-# 创建并填充工作空间
-zot workspace new llm-safety --description "LLM 对齐与安全论文"
-zot workspace add llm-safety ABC123 DEF456 GHI789
-zot workspace import llm-safety --collection "Alignment"   # 从 collection 批量导入
-zot workspace import llm-safety --tag "safety"              # 按标签导入
-zot workspace import llm-safety --search "RLHF"            # 按搜索导入
-
-# 浏览工作空间
-zot workspace list                          # 列出所有工作空间
-zot workspace show llm-safety               # 查看条目及元数据
-zot workspace search "reward" --workspace llm-safety  # 在工作空间内搜索
-
-# 导出（供 AI 使用）
-zot workspace export llm-safety                       # Markdown（适合 Claude Code）
-zot workspace export llm-safety --format json         # JSON
-zot workspace export llm-safety --format bibtex       # BibTeX
-
-# 内置 RAG：索引与查询
-zot workspace index llm-safety                       # 构建 BM25 索引（元数据 + PDF 全文）
-zot workspace index llm-safety --extractor mineru    # 使用 MinerU 提取更高质量的 PDF 文本
-zot workspace query "reward hacking methods" --workspace llm-safety
-
-# 管理
-zot workspace remove llm-safety ABC123      # 移除条目
-zot workspace delete llm-safety --yes       # 删除工作空间
-```
-
-**可选语义搜索** — 配置 embedding 端点以启用混合 BM25 + 向量检索。支持多家 provider，可通过 `[embedding] provider` 切换（`jina`（默认）/ `aliyun` / `openai`）：
-
-```bash
-# Jina AI（默认，10M 免费 tokens）
-export ZOT_EMBEDDING_URL="https://api.jina.ai/v1/embeddings"
-export ZOT_EMBEDDING_KEY="your-jina-key"
-
-# 或者使用阿里云 DashScope（OpenAI 兼容接口）
-export ZOT_EMBEDDING_PROVIDER=aliyun
-export ZOT_EMBEDDING_KEY="your-dashscope-key"
-
-zot workspace index llm-safety --force                              # 重建索引（含 embedding）
-zot workspace query "reward hacking" --workspace llm-safety --mode hybrid
-```
-
-### 配置与档案
-
-```bash
-zot config profile list            # 列出所有配置档案
-zot config profile set lab         # 设置默认档案
-zot config cache stats             # 查看 PDF 缓存统计
-zot config cache clear             # 清除 PDF 缓存
-```
-
-### 预印本状态检查
-
-```bash
-# 检查 arXiv/bioRxiv/medRxiv 预印本是否已正式发表（默认仅预览）
-zot update-status
-
-# 实际更新 Zotero 元数据
-zot update-status --apply
-
-# 检查单篇
-zot update-status ABC123
-
-# 检查某个 collection 内的预印本
-zot update-status --collection "scRNA-seq" --limit 20
-```
-
-使用 [Semantic Scholar API](https://www.semanticscholar.org/product/api)。可选 API key 以提升速率限制：
-
-```bash
-export S2_API_KEY=your_key_here   # 写入 ~/.zshrc 或 ~/.bashrc
-```
-
-### AI 辅助功能
-
-```bash
-zot summarize ABC123               # 结构化摘要（专为 Claude Code 优化）
-zot pdf ABC123                     # 提取 PDF 全文
-zot pdf ABC123 --pages 1-5         # 提取指定页
-zot pdf ABC123 --outline           # 列出文档大纲（编号的标题列表）
-zot pdf ABC123 --section 3         # 仅提取第 3 个章节的内容
-zot pdf ABC123 --extractor mineru  # 使用 MinerU 提取（失败时自动回退到 pymupdf）
-```
-
-**PDF 提取器。** 提供两种后端：默认的 `pymupdf`（速度快、本地处理），以及 `mineru`（通过 MinerU API 实现更高质量的版面/公式/表格解析；失败时自动回退到 pymupdf）。可在 `~/.config/zot/config.toml` 中通过 `[pdf] extractor` / `[pdf] mineru_token` 配置，或通过 `ZOT_PDF_EXTRACTOR` / `MINERU_TOKEN` 环境变量。
-
-### 全局选项
-
-```bash
-zot --json search "attention"              # JSON 输出
-zot --limit 5 list                         # 限制结果数量
-zot --detail minimal search "attention"    # 精简输出（仅 key/标题/作者/年份）
-zot --detail full read ABC123              # 完整输出（含 extra 字段）
-zot --no-interaction delete ABC123         # 跳过交互确认（AI/脚本模式）
-zot --profile lab search "CRISPR"          # 使用指定配置档案
-zot --version                              # 查看版本
-```
-
-### Shell 补全
-
-```bash
-# Zsh（推荐）
-zot completions zsh >> ~/.zshrc
-
-# Bash
-zot completions bash >> ~/.bashrc
-
-# Fish
-zot completions fish > ~/.config/fish/completions/zot.fish
-```
-
-添加后重启终端或 `source` 配置文件即可使用 Tab 补全。
+| 主题 | 链接 |
+|---|---|
+| 安装与配置 | [快速开始](https://agents365-ai.github.io/zotero-cli-cc/zh/getting-started/installation/) |
+| 搜索、列表、阅读 | [搜索指南](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/search/) |
+| 笔记、标签、引用 | [笔记与标签](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/notes-tags/)、[引用导出](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/citations/) |
+| 增 / 改 / 删条目 | [条目管理](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/item-management/) |
+| 分类（Collection） | [Collections](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/collections/) |
+| 工作空间 + RAG | [Workspace](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/workspace/) |
+| PDF 提取 | [PDF](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/pdf/) |
+| 预印本 → 已发表 | [update-status](https://agents365-ai.github.io/zotero-cli-cc/zh/guide/update-status/) |
+| MCP 配置与工具 | [MCP](https://agents365-ai.github.io/zotero-cli-cc/zh/mcp/setup/) |
+| 完整 CLI 参考 | [CLI Reference](https://agents365-ai.github.io/zotero-cli-cc/zh/reference/cli/) |
+| Agent 契约（envelope、退出码、schema） | [`docs/agent-interface.md`](docs/agent-interface.md) |
 
 ## 同类工具对比
 
 | 特性 | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **本地 SQLite 直读** | **✅** | ❌ | ❌ (仅缓存) | ❌ | ❌ | ❌ (插件) | ✅ |
-| **离线可用** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **无需启动 Zotero** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **零配置读操作** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **安全写入 (Web API)** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ (直写 SQLite) |
-| **PDF 全文提取** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **AI 编码助手集成** | **✅ Claude Code** | 部分 | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
-| **CLI 终端使用** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **直读 SQLite** | **✅** | ❌ | ❌（仅缓存） | ❌ | ❌ | ❌（插件） | ✅ |
+| **离线读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **无需 Zotero 运行** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **零配置读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **安全写（Web API）** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌（直写 SQLite） |
+| **PDF 全文** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **AI 编程助手** | **✅ Claude Code** | 部分 | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
+| **终端 CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | **MCP 协议** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **JSON 输出** | ✅ | ✅ | ❌ | ❌ | N/A | N/A | N/A |
-| **笔记管理** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| **Collection 管理** | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **引用导出** | ✅ BibTeX/CSL-JSON/RIS | ✅ | ❌ | ✅ Excel | ❌ | ❌ | ❌ |
-| **语义搜索** | **✅ 内置（工作空间 RAG）** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **输出分级** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| **多配置档案** | **✅** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **PDF 缓存** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **库维护** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **语言** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
-| **活跃维护** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
+| **语义搜索** | **✅ 内置（workspace RAG）** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| **活跃度** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
 
-### 为什么选择 zotero-cli-cc？
-
-> **唯一一个直接读取本地 SQLite 数据库的活跃 Python CLI 工具。**
-
-- **极速**：毫秒级响应，无网络延迟
-- **离线**：无需网络、无需启动 Zotero 桌面端
-- **零配置**：安装即用，读操作无需 API Key
-- **AI 原生**：专为 Claude Code 设计，`--json` 输出直接供 AI 解析
-- **安全**：读写分离架构，写操作通过 Web API 确保 Zotero 数据库完整性
-- **终端原生**：唯一同时支持本地 SQLite 直读和安全写入的 CLI 工具，MCP 工具无法在终端中直接使用
+**为什么选 zotero-cli-cc？** 当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI；读写分离架构 —— SQLite 提供快速离线读，Web API 提供让 Zotero 感知的安全写。
 
 ## 架构
 
-```mermaid
-graph TD
-    A["zot CLI (Click)<br>search | list | read | workspace | ..."] --> B["核心服务层"]
-    C["MCP Server (FastMCP)<br>stdio 传输"] --> B
-
-    subgraph B["核心服务层"]
-        R["ZoteroReader<br>(SQLite 只读)"]
-        W["ZoteroWriter<br>(Web API)"]
-        RAG["RAG 引擎<br>(BM25 + Embeddings)"]
-    end
-
-    R --> D["SQLite<br>~/Zotero/zotero.sqlite"]
-    W --> E["Zotero Web API<br>(远程)"]
-    D --> F["~/Zotero/storage/*.pdf"]
-    RAG --> G["工作空间索引<br>~/.config/zot/workspaces/*.idx.sqlite"]
-    RAG -.->|可选| H["Embedding API<br>(Jina / OpenAI)"]
-```
-
-## 环境变量
-
-| 变量 | 用途 |
-|------|------|
-| `ZOT_DATA_DIR` | 覆盖 Zotero 数据目录路径 |
-| `ZOT_LIBRARY_ID` | 覆盖 Library ID（写操作） |
-| `ZOT_API_KEY` | 覆盖 API Key（写操作） |
-| `ZOT_PROFILE` | 覆盖默认配置档案 |
-| `S2_API_KEY` | Semantic Scholar API key（用于 `update-status`） |
-| `ZOT_PDF_EXTRACTOR` | PDF 提取器：`pymupdf`（默认）或 `mineru` |
-| `MINERU_TOKEN` | MinerU PDF 提取器的 API token |
-| `ZOT_EMBEDDING_PROVIDER` | Embedding 提供商：`jina`（默认）、`aliyun` 或 `openai` |
-| `ZOT_EMBEDDING_URL` | Embedding API 端点（默认：Jina AI） |
-| `ZOT_EMBEDDING_KEY` | Embedding API 密钥（启用语义工作空间搜索） |
-| `ZOT_EMBEDDING_MODEL` | Embedding 模型名称（默认：`jina-embeddings-v3`） |
-
-## TODO
-
-- [x] 改进 HTML 转 Markdown：支持列表、链接、表格等 Zotero 笔记常用格式（v0.1.2：使用 markdownify）
-- [x] `summarize-all` 分页：为大型文献库添加 offset/cursor 分页支持（v0.1.2：`--offset` 参数）
-- [x] 危险操作 `--dry-run`：为 `delete`、`collection delete`、`tag` 添加预览模式（v0.1.2）
-
-### Features
-
-- [x] `zot cite`：格式化引用并复制到剪贴板（APA、Nature、Vancouver）
-- [x] 批量操作：从文件批量导入（`zot add --from-file dois.txt`）
-- [x] `zot export`：增加 RIS 格式支持（BibTeX、CSL-JSON、RIS、JSON）
-
-### Tier 1 — High Value, Moderate Effort
-
-- [x] `zot update KEY --title/--date/--field`：更新条目元数据（pyzotero `update_item()` 已支持）
-- [x] `zot search --type journalArticle`：按条目类型过滤搜索结果
-- [x] `zot search --sort dateAdded --direction desc`：搜索/列表排序控制
-- [x] `zot recent --days 7`：最近添加/修改的条目
-- [x] `zot pdf KEY --annotations`：提取 PDF 标注（高亮、批注、页码）— pymupdf 已支持
-
-### Tier 2 — High Value, Higher Effort ✅
-
-- [x] `zot duplicates --by doi|title|both`：重复检测（模糊标题 + DOI 比对）
-- [x] `zot trash list/restore`：回收站管理（查看 + 恢复）
-- [x] `zot attach KEY --file paper.pdf`：附件上传
-- [x] `--library group:<id>`：群组文库支持（所有命令 + MCP 工具）
-- [x] `zot add --pdf paper.pdf`：从本地 PDF 添加（自动提取 DOI + 附件上传）
-
-### Tier 3 — Medium Value
-
-- [ ] Saved searches CRUD：保存的搜索管理
-- [ ] 更多导出格式：BibLaTeX、MODS、TEI、CSV
-- [ ] 格式化参考文献：通过 citeproc-py 生成 CSL 格式参考文献表
-- [ ] `zot collection remove`：从集合移除条目（`collection move` 的对应操作）
-- [ ] BetterBibTeX citation key 查找支持
-
-### Tier 4 — Nice to Have
-
-- [x] 语义搜索：通过工作空间 RAG 实现（BM25 + 可选 embedding，v0.2.0）
-- [ ] DOI-to-key 索引
-- [ ] 版本跟踪 / 增量同步
-- [ ] Web 界面（`zot serve`）
-- [ ] 按集合查看标签
-
-### Polish
-
-- [ ] GitHub Issues / Discussions：开放用户反馈渠道
-- [x] 改进 `--help` 文本：添加使用示例
-- [x] Shell 补全安装说明：在 README 中添加 zsh/bash/fish 安装指引
-
-### Distribution
-
-- [x] `pipx` 安装说明
-- [x] GitHub Releases：附带 changelog（v0.1.1, v0.1.2）
-- [x] README 徽章：PyPI 版本、CI 状态、Python 版本、License
-
-### MCP Server
-
-- [x] 扩��� MCP 工具：workspace、cite、stats、update-status��共 45 个工具）
-- [ ] MCP 服务器文档 / 集成指南
-
----
+<p align="center">
+  <img src="asserts/architecture.png" alt="Architecture diagram" width="720">
+</p>
 
 ## 作者
 
-**Agents365-ai**
+**Agents365-ai** — [GitHub](https://github.com/Agents365-ai) · [Bilibili](https://space.bilibili.com/441831884)
 
-- GitHub: [https://github.com/Agents365-ai](https://github.com/Agents365-ai)
-- Bilibili: [https://space.bilibili.com/441831884](https://space.bilibili.com/441831884)
-
-## 支持作者 / Support
+## 赞助
 
 <table>
   <tr>
@@ -500,6 +123,6 @@ graph TD
   </tr>
 </table>
 
-## 许可证 / License
+## 许可证
 
-[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) — 免费用于非商业用途 / Free for non-commercial use.
+[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) — 非商业使用免费。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,49 @@
+# Roadmap
+
+Historical TODO list extracted from the README. Completed items are kept for
+context; open items are tracked here until they're promoted to GitHub Issues.
+
+## Done
+
+- [x] Improve HTML-to-Markdown: support lists, links, tables, and other common Zotero note formats (v0.1.2: uses markdownify)
+- [x] `summarize-all` pagination: add offset/cursor pagination for large libraries (v0.1.2: `--offset` flag)
+- [x] `--dry-run` for destructive ops: add preview mode to `delete`, `collection delete`, and `tag` (v0.1.2)
+- [x] `zot cite`: copy formatted citation to clipboard (APA, Nature, Vancouver)
+- [x] Bulk operations from file input (`zot add --from-file dois.txt`)
+- [x] `zot export`: add RIS format support (BibTeX, CSL-JSON, RIS, JSON)
+- [x] `zot update KEY --title/--date/--field`: update item metadata (pyzotero `update_item()`)
+- [x] `zot search --type journalArticle`: filter search results by item type
+- [x] `zot search --sort dateAdded --direction desc`: sort control for search/list
+- [x] `zot recent --days 7`: recently added/modified items
+- [x] `zot pdf KEY --annotations`: extract PDF annotations (highlights, comments, page numbers) — pymupdf
+- [x] `zot duplicates --by doi|title|both`: duplicate detection (fuzzy title + DOI matching)
+- [x] `zot trash list/restore`: trash management (view + restore)
+- [x] `zot attach KEY --file paper.pdf`: attachment upload
+- [x] `--library group:<id>`: group library support (all commands + MCP tools)
+- [x] `zot add --pdf paper.pdf`: add from local PDF (auto-extract DOI + upload attachment)
+- [x] Semantic search via workspace RAG (BM25 + optional embeddings, v0.2.0)
+- [x] Improve `--help` text with usage examples
+- [x] Shell completion install instructions in README (zsh/bash/fish)
+- [x] `pipx` install instructions
+- [x] GitHub Releases with changelogs
+- [x] README badges: PyPI version, CI status, Python versions, License
+- [x] Expand MCP tools: workspace, cite, stats, update-status (45 tools total)
+
+## Open
+
+### Features
+
+- [ ] Saved searches CRUD
+- [ ] More export formats: BibLaTeX, MODS, TEI, CSV
+- [ ] Formatted bibliography via citeproc-py with CSL styles
+- [ ] `zot collection remove`: remove item from collection (counterpart to `collection move`)
+- [ ] BetterBibTeX citation key lookup support
+- [ ] DOI-to-key index
+- [ ] Version tracking / incremental sync
+- [ ] Web interface (`zot serve`)
+- [ ] View tags by collection
+
+### Polish & Distribution
+
+- [ ] GitHub Issues / Discussions setup for user feedback
+- [ ] MCP server documentation / integration guide

--- a/docs/en/comparison.md
+++ b/docs/en/comparison.md
@@ -1,0 +1,35 @@
+# Comparison with Similar Tools
+
+| Feature | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Direct SQLite Read** | **✅** | ❌ | ❌ (cache only) | ❌ | ❌ | ❌ (plugin) | ✅ |
+| **Offline Read** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **No Zotero Running** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Zero-Config Read** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Safe Write (Web API)** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ (direct SQLite) |
+| **PDF Full-Text** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **AI Coding Assistant** | **✅ Claude Code** | Partial | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
+| **Terminal CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **MCP Protocol** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **JSON Output** | ✅ | ✅ | ❌ | ❌ | N/A | N/A | N/A |
+| **Note Management** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
+| **Collections** | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **Citation Export** | ✅ BibTeX/CSL-JSON/RIS | ✅ | ❌ | ✅ Excel | ❌ | ❌ | ❌ |
+| **Semantic Search** | **✅ Built-in (workspace RAG)** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| **Detail Levels** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| **Multi-Profile** | **✅** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **PDF Cache** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Library Maintenance** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Language** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
+| **Active** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
+
+## Why zotero-cli-cc?
+
+> **The only actively maintained Python CLI that reads Zotero's local SQLite database directly.**
+
+- **Fast** — millisecond response, no network latency
+- **Offline** — no internet, no Zotero desktop needed
+- **Zero-config** — install and go, no API key for reads
+- **AI-native** — built for Claude Code, automatic JSON envelope for AI consumption
+- **Safe** — read/write separation: writes go through the Web API to protect DB integrity
+- **Terminal-native** — the only CLI combining local SQLite reads with safe Web API writes; MCP-only tools require an AI client and aren't usable from a terminal

--- a/docs/zh/comparison.md
+++ b/docs/zh/comparison.md
@@ -1,0 +1,35 @@
+# 同类工具对比
+
+| 特性 | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **直读 SQLite** | **✅** | ❌ | ❌（仅缓存） | ❌ | ❌ | ❌（插件） | ✅ |
+| **离线读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **无需 Zotero 运行** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **零配置读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **安全写（Web API）** | **✅** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌（直写 SQLite） |
+| **PDF 全文** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **AI 编程助手** | **✅ Claude Code** | 部分 | ❌ | ❌ | Claude/ChatGPT | Claude/Cursor | Claude/Cursor |
+| **终端 CLI** | **✅** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **MCP 协议** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **JSON 输出** | ✅ | ✅ | ❌ | ❌ | N/A | N/A | N/A |
+| **笔记管理** | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
+| **分类管理** | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **引用导出** | ✅ BibTeX/CSL-JSON/RIS | ✅ | ❌ | ✅ Excel | ❌ | ❌ | ❌ |
+| **语义搜索** | **✅ 内置（workspace RAG）** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| **详细级别** | **✅** | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| **多 Profile** | **✅** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **PDF 缓存** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **库维护** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **语言** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
+| **活跃度** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
+
+## 为什么选 zotero-cli-cc？
+
+> **当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI。**
+
+- **快** —— 毫秒级响应，无网络延迟
+- **离线** —— 无需联网、无需 Zotero 桌面端
+- **零配置** —— 装完即用，读操作不需要 API Key
+- **AI 原生** —— 为 Claude Code 而生，自动输出 JSON envelope 供 AI 消费
+- **安全** —— 读写分离：写操作走 Web API 以保护数据库完整性
+- **终端原生** —— 唯一一个把本地 SQLite 读 + 安全 Web API 写组合在一起的终端 CLI；纯 MCP 工具必须配 AI 客户端才能用

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,4 +81,5 @@ nav:
   - Reference:
     - CLI Reference: reference/cli.md
     - Agent Interface: reference/agent-interface.md
+  - Comparison: comparison.md
   - Changelog: changelog.md


### PR DESCRIPTION
Draft for side-by-side comparison — please review and tell me to adjust before merging.

## What changed
- `README.md` / `README_CN.md` both go from ~500 lines to **128 lines** each.
- Kept on the README (what GitHub visitors need at evaluation time):
  - One-paragraph intro + bullet list of differentiators
  - Install (3 commands)
  - 60-second quickstart (reads + writes + Claude Code skill + JSON envelope sample)
  - Topic-indexed link table → mkdocs site
  - Tool-comparison table (trimmed: kept the differentiating rows, dropped feature rows that are now table-stakes)
  - Architecture diagram, author, support, license
- Moved out (already lives in `docs/`):
  - Data-directory detection table & full config example → `docs/en/getting-started/setup.md`
  - Full per-command tour (search/notes/citations/items/collections/workspaces/AI/global flags/completions) → `docs/en/guide/*`
  - MCP install + client config → `docs/en/mcp/setup.md`
  - Environment-variable table → covered by setup / cli reference docs
- Dropped from the README:
  - The roadmap / "Tier N — High Value..." TODO section. Roadmaps belong in GitHub Issues / a project board / `ROADMAP.md`, not the README. Happy to extract it to `ROADMAP.md` if you want to preserve it as a file.

## Questions for you
1. Are the deep-link URLs I used (`/getting-started/installation/`, `/guide/search/`, etc.) actually what mkdocs generates for this site? If anchors differ, point me at one and I'll fix the table.
2. Keep the comparison table on the README, or move it to docs too? I left it on the README because evaluation-stage readers compare tools before clicking through.
3. Should I save the dropped TODO list as `ROADMAP.md`?

## Test plan
- [x] `wc -l README*.md` → both 128 lines
- [ ] Render preview on GitHub PR
- [ ] Verify documentation links once mkdocs URL structure is confirmed