### PR TITLE
docs(claude.md): document the safety-tier convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,12 @@ Config lives at `~/.config/zot/config.toml` with multi-profile support (`[profil
 When adding or refactoring a CLI command (flags, output shape, exit codes, confirmation/idempotency behavior), invoke the **`agent-native-design`** skill first: https://github.com/Agents365-ai/agent-native-design
 
 It encodes the design rules that keep `zot` usable by both humans and agents — dual-output contract, typed exit codes, JSON envelope shape, idempotency, dry-run conventions — and aligns with `docs/agent-interface.md`. New contributors should read it before touching the CLI surface.
+
+### Safety tier — pick exactly one bucket
+
+Every top-level command must be registered in one of the three sets at the top of `src/zotero_cli_cc/cli.py` (`_READ_COMMANDS` / `_WRITE_COMMANDS` / `_DESTRUCTIVE_COMMANDS`). The set determines:
+
+- The header it appears under in `zot --help` (`Read` / `Write (MUTATES LIBRARY)` / `Destructive (MUTATES LIBRARY)`).
+- The `safety_tier` value emitted by `zot schema` for that command, which agents use to gate execution.
+
+Commands not in any set fall into an unlabeled `Other` bucket and are reported as untyped to agents — a footgun. The CI suite asserts the schema/help drift contract (`tests/test_agent_interface.py::TestHelpSchemaDrift`), but it does not flag missing tier membership, so this is a manual checklist when wiring up a new command in `cli.py`.


### PR DESCRIPTION
Small follow-up from the agent-native-design review (P2).

The three tier sets at the top of \`src/zotero_cli_cc/cli.py\` are load-bearing — they drive both the \`--help\` grouping and the \`safety_tier\` field that \`zot schema\` advertises to agents. A command not registered in any set silently falls into an \"Other\" bucket and is reported as untyped to agents, which is exactly the footgun the agent-native review warned about.

CI guards the schema/help drift contract (PR #36) but does not guard tier membership, so this stays a manual checklist item — now documented under \"Designing new commands\".

Docs-only; no code change.