### PR TITLE
feat(schema): add --diff PATH to report changes vs a cached schema

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -144,6 +144,34 @@ Output:
 
 Agents should use `zot schema <cmd>` instead of parsing `--help` output.
 
+### Detecting changes between releases
+
+When an agent has cached a previous schema and sees a new `meta.schema_version` on a later call, it can fetch a structural diff instead of re-parsing the whole tree:
+
+```bash
+zot schema --diff /path/to/cached-schema.json
+```
+
+The diff envelope reports added/removed commands (dotted paths) and added/removed option flags per surviving command. Type, help, and default changes are intentionally out of scope — re-fetch the full schema if those matter for your use case.
+
+```json
+{
+  "ok": true,
+  "data": {
+    "from": { "schema_version": "1.0.0", "cli_version": "0.4.0" },
+    "to":   { "schema_version": "1.1.0", "cli_version": "0.4.4" },
+    "commands_added":   ["recent"],
+    "commands_removed": ["legacy-cmd"],
+    "commands_changed": {
+      "search": { "params_added": ["--sort"] }
+    }
+  },
+  "meta": { ... }
+}
+```
+
+The input file may be either a full envelope or a bare `data` tree.
+
 ## Safety tiers
 
 Commands are grouped by risk in `zot --help`:

--- a/src/zotero_cli_cc/commands/schema.py
+++ b/src/zotero_cli_cc/commands/schema.py
@@ -107,17 +107,91 @@ def _resolve_command(root: click.Command, target: str) -> click.Command | None:
     return current
 
 
+def _flatten_commands(node: dict, path: tuple[str, ...] = ()) -> dict[tuple[str, ...], dict]:
+    out: dict[tuple[str, ...], dict] = {path: node}
+    for sub_name, sub_node in node.get("subcommands", {}).items():
+        out.update(_flatten_commands(sub_node, path + (sub_name,)))
+    return out
+
+
+def _option_flags(node: dict) -> set[str]:
+    flags: set[str] = set()
+    for p in node.get("params", []):
+        if p.get("kind") == "option":
+            flags.update(p.get("flags", []))
+    return flags
+
+
+def compute_schema_diff(before: dict, after: dict) -> dict[str, Any]:
+    """Return a structural diff between two schema trees.
+
+    Tracks added/removed commands (by dotted path) and added/removed option
+    flags per surviving command. Type/help/default changes are intentionally
+    out of scope to keep the diff useful and short.
+    """
+    before_cmds = _flatten_commands(before)
+    after_cmds = _flatten_commands(after)
+    before_paths = set(before_cmds)
+    after_paths = set(after_cmds)
+
+    def label(p: tuple[str, ...]) -> str:
+        return ".".join(p) or "(root)"
+
+    commands_added = sorted(label(p) for p in after_paths - before_paths)
+    commands_removed = sorted(label(p) for p in before_paths - after_paths)
+
+    commands_changed: dict[str, dict[str, list[str]]] = {}
+    for path in sorted(before_paths & after_paths):
+        added = sorted(_option_flags(after_cmds[path]) - _option_flags(before_cmds[path]))
+        removed = sorted(_option_flags(before_cmds[path]) - _option_flags(after_cmds[path]))
+        if added or removed:
+            entry: dict[str, list[str]] = {}
+            if added:
+                entry["params_added"] = added
+            if removed:
+                entry["params_removed"] = removed
+            commands_changed[label(path)] = entry
+
+    return {
+        "commands_added": commands_added,
+        "commands_removed": commands_removed,
+        "commands_changed": commands_changed,
+    }
+
+
+def _load_cached_schema(path: str) -> tuple[dict, dict[str, str]]:
+    """Read a previously-emitted schema file. Accepts a full envelope or a bare data tree."""
+    with open(path, encoding="utf-8") as f:
+        loaded = json.load(f)
+    if isinstance(loaded, dict) and "data" in loaded and isinstance(loaded["data"], dict):
+        meta = loaded.get("meta") or {}
+        version_info = {
+            "schema_version": meta.get("schema_version", "unknown"),
+            "cli_version": meta.get("cli_version", "unknown"),
+        }
+        return loaded["data"], version_info
+    return loaded, {"schema_version": "unknown", "cli_version": "unknown"}
+
+
 @click.command("schema")
 @click.argument("command_path", nargs=-1)
+@click.option(
+    "--diff",
+    "diff_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    default=None,
+    help="Path to a previously-emitted schema. Output a structural diff against the current schema.",
+)
 @click.pass_context
-def schema_cmd(ctx: click.Context, command_path: tuple[str, ...]) -> None:
+def schema_cmd(ctx: click.Context, command_path: tuple[str, ...], diff_path: str | None) -> None:
     """Emit machine-readable schema for the CLI or one command.
 
     \b
     Examples:
-      zot schema                    # full tree
-      zot schema search             # schema for one command
-      zot schema collection add     # nested subcommand
+      zot schema                       # full tree
+      zot schema search                # schema for one command
+      zot schema collection add        # nested subcommand
+      zot schema --diff prev.json      # structural diff vs cached schema
     """
     root = ctx.find_root().command
 
@@ -136,6 +210,24 @@ def schema_cmd(ctx: click.Context, command_path: tuple[str, ...]) -> None:
         data = _command_to_dict(target, list(command_path))
     else:
         data = _command_to_dict(root, [])
+
+    if diff_path is not None:
+        try:
+            before, before_versions = _load_cached_schema(diff_path)
+        except (OSError, json.JSONDecodeError) as e:
+            env = envelope_error(
+                code="validation_error",
+                message=f"Could not read cached schema at {diff_path!r}: {e}",
+                retryable=False,
+                hint="Provide a JSON file produced by `zot schema`",
+            )
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+            raise SystemExit(3) from e
+        data = {
+            "from": before_versions,
+            "to": {"schema_version": SCHEMA_VERSION, "cli_version": __version__},
+            **compute_schema_diff(before, data),
+        }
 
     env = envelope_ok(
         data,

--- a/tests/test_agent_interface.py
+++ b/tests/test_agent_interface.py
@@ -158,6 +158,64 @@ class TestSchemaCommand:
         assert env["meta"]["cli_version"]
 
 
+class TestSchemaDiff:
+    def _write(self, tmp_path, data, meta=None):
+        path = tmp_path / "cached.json"
+        envelope = {"ok": True, "data": data, "meta": meta or {}}
+        path.write_text(json.dumps(envelope), encoding="utf-8")
+        return str(path)
+
+    def test_diff_against_self_reports_no_changes(self, tmp_path):
+        current = json.loads(_run(["schema"]).output)
+        cached_path = self._write(tmp_path, current["data"], current["meta"])
+        result = _run(["schema", "--diff", cached_path])
+        assert result.exit_code == EXIT_OK
+        data = json.loads(result.output)["data"]
+        assert data["commands_added"] == []
+        assert data["commands_removed"] == []
+        assert data["commands_changed"] == {}
+        assert data["from"]["schema_version"] == current["meta"]["schema_version"]
+        assert data["to"]["schema_version"] == current["meta"]["schema_version"]
+
+    def test_diff_detects_added_and_removed_commands(self, tmp_path):
+        current = json.loads(_run(["schema"]).output)
+        # Build a fake "old" tree with one command removed and a fake one added.
+        old_tree = json.loads(json.dumps(current["data"]))  # deep copy
+        old_tree["subcommands"]["ghost-cmd"] = {"name": "ghost-cmd", "params": [], "subcommands": {}}
+        del old_tree["subcommands"]["search"]
+        cached_path = self._write(tmp_path, old_tree, {"schema_version": "0.9.0", "cli_version": "0.0.0"})
+        result = _run(["schema", "--diff", cached_path])
+        data = json.loads(result.output)["data"]
+        assert "search" in data["commands_added"]
+        assert "ghost-cmd" in data["commands_removed"]
+        assert data["from"]["schema_version"] == "0.9.0"
+
+    def test_diff_detects_param_changes(self, tmp_path):
+        current = json.loads(_run(["schema"]).output)
+        old_tree = json.loads(json.dumps(current["data"]))
+        # Drop the last param of `export` so the current schema appears to have added it.
+        old_tree["subcommands"]["export"]["params"].pop()
+        cached_path = self._write(tmp_path, old_tree)
+        result = _run(["schema", "--diff", cached_path])
+        data = json.loads(result.output)["data"]
+        assert "export" in data["commands_changed"]
+        assert data["commands_changed"]["export"]["params_added"]
+
+    def test_diff_with_missing_file_returns_validation_error(self, tmp_path):
+        # click.Path(exists=True) catches this before our code runs — Click exits
+        # with usage error (exit 2) and writes to stderr.
+        result = _run(["schema", "--diff", str(tmp_path / "no-such-file.json")])
+        assert result.exit_code != 0
+
+    def test_diff_with_invalid_json_returns_validation_error(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json at all", encoding="utf-8")
+        result = _run(["schema", "--diff", str(bad)])
+        assert result.exit_code == EXIT_VALIDATION
+        env = json.loads(result.output)
+        assert env["error"]["code"] == "validation_error"
+
+
 class TestDryRun:
     def test_delete_dry_run_json_envelope(self):
         result = _run(


### PR DESCRIPTION
Closes the last P2 follow-up from the agent-native-design review (the remaining one was the skill-rework, which is a separate effort).

## Motivation

An agent that caches a previous \`zot schema\` and later sees a new \`meta.schema_version\` in any response currently has two options: re-fetch the 50 KB tree and structurally diff it itself, or fall back to retrying through the full discovery loop. Both waste tokens. \`zot schema --diff <path>\` does the diff server-side and returns a compact change set.

## API

\`\`\`bash
zot schema --diff prev-schema.json
\`\`\`

Accepts either a full envelope or a bare \`data\` tree. Output:

\`\`\`json
{
  "ok": true,
  "data": {
    "from": { "schema_version": "1.0.0", "cli_version": "0.4.0" },
    "to":   { "schema_version": "1.1.0", "cli_version": "0.4.4" },
    "commands_added":   ["..."],
    "commands_removed": ["..."],
    "commands_changed": { "search": { "params_added": ["--sort"] } }
  },
  "meta": { ... }
}
\`\`\`

## Scope (intentionally minimal)

- Tracks: add/remove of commands (by dotted path) and add/remove of option flag strings per surviving command.
- **Does not track**: type/help/default/choice changes. Re-fetch the full schema if those matter — keeps the diff small and unambiguous.

## Test plan
- [x] \`uv run ruff check\` / \`format --check\` / \`mypy src/\` — clean
- [x] \`uv run pytest tests/test_agent_interface.py -v\` — 27 passed (5 new \`TestSchemaDiff\` cases: self-diff yields no changes; added/removed commands detected; added params detected; missing file rejected by Click; invalid JSON → \`validation_error\` exit 3)
- [x] Manually verified against the live build: self-diff is empty, synthetic diff with a removed subcommand and a dropped param surfaces the right changes
- [x] \`docs/agent-interface.md\` updated with the new contract