### PR TITLE
chore: sync uv.lock project version to 0.4.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2104,7 +2104,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
The `0.4.4` release (commit `29a991c`) bumped `pyproject.toml` to `0.4.4` but left `uv.lock` pinning the editable project at `0.4.3`. As a result, `uv` re-locks the project on every `uv run`/`uv sync`, producing a spurious one-line `uv.lock` diff in unrelated working trees.

This regenerates the lockfile via `uv lock` so it matches the declared version.

## Changes
- `uv.lock` — `zotero-cli-cc` editable entry `0.4.3` → `0.4.4` (single line; no dependency changes).

## Test plan
- [x] `uv lock` resolves cleanly (90 packages) and produces only the version-line change.