### PR TITLE
fix(win): auto-reconfigure stdout to UTF-8 on CJK Windows

### DIFF
--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -95,6 +95,24 @@ def _hoist_global_flags(args: list[str]) -> list[str]:
     return flags + rest
 
 
+def _fix_windows_encoding() -> None:
+    """Reconfigure stdout/stderr to UTF-8 on Windows with CJK system locales.
+
+    On Windows with a GBK/CP936 default encoding, click.echo() crashes with
+    UnicodeEncodeError when writing characters outside the GBK range (e.g.
+    emoji, special Unicode symbols). Forcing UTF-8 lets all Unicode be written.
+    """
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if (
+                hasattr(stream, "reconfigure")
+                and hasattr(stream, "encoding")
+                and stream.encoding
+                and stream.encoding.lower().replace("-", "") not in ("utf8", "utf8sig")
+            ):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 class TieredGroup(click.Group):
     """A Click Group that renders the command list grouped by safety tier."""
 
@@ -103,6 +121,7 @@ class TieredGroup(click.Group):
         args: list[str] | None = None,
         **kwargs: Any,
     ) -> Any:
+        _fix_windows_encoding()
         if args is None:
             args = sys.argv[1:]
         args = _hoist_global_flags(list(args))


### PR DESCRIPTION
## Summary

On Windows with a GBK/CP936 default encoding, `click.echo()` crashes with `UnicodeEncodeError` when output contains characters outside the GBK range (e.g. emoji like `⛔` U+26D4) — making `zot` unusable on any library whose metadata includes such characters.

`_fix_windows_encoding()` reconfigures `stdout`/`stderr` to UTF-8 at CLI entry. It is:
- **Windows-only** (`sys.platform == "win32"`) — no-op on macOS/Linux
- **conditional** — skipped when the stream is already UTF-8
- **safe** — uses `errors="replace"` and guards on `hasattr(stream, "reconfigure")`

This is the source fix extracted from #45 so it can land cleanly on its own; the skill-docs refactor in that PR is being handled separately (it needs a rebase + coverage for the newer `find-pdf` / `bridge` / `--skip-tag` surface).

Credit to @IA20201, who reported and fixed this (verified on Windows 11 Chinese / Simplified).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pytest tests/test_agent_interface.py tests/test_formatter.py` (schema/help drift) green
- [ ] Maintainer spot-check on a non-Windows host (change is a no-op there)