### PR TITLE
docs(skill): split SKILL.md into a multi-file reference structure

### DIFF
--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -1,318 +1,80 @@
 ---
-name: zotero-cli
-description: "Use when user mentions papers, references, citations, Zotero, literature, bibliography, workspaces, or needs to search/read/export documents in zotero. Uses zot CLI for all operations including workspace-based RAG."
-version: 0.5.3
+name: zotero-cli-cc
+description: Use when user mentions papers, references, citations, Zotero, literature, bibliography, workspaces, or needs to search, read, export, or organize documents. Handles all zot CLI operations including workspace-based RAG search.
 ---
 
-# Zotero CLI Skill for Claude Code
+# Zotero CLI Skill
 
-**`zot`** — all-in-one Zotero CLI: CRUD, search, PDF, export, workspace-based RAG. Local SQLite for reads, Zotero API for writes.
+`zot` is an all-in-one Zotero CLI: search, CRUD, PDF extraction, citation export, and workspace-based RAG. Local SQLite for reads, Zotero Web API for writes.
 
-**Always use `--json` when processing results programmatically.** (Auto-enabled when stdout is not a TTY; can be placed before or after the subcommand.)
-
-For exhaustive flags / types / safety tier of any command, run `zot schema <cmd>` (e.g. `zot schema add`) — that's the canonical machine-readable surface.
-
-## Routing Rules
-
-| User Intent | Command | Why |
-|-------------|---------|-----|
-| Search by title/author/tag | `zot --json search "transformer"` | Fast metadata match |
-| Read/view a paper | `zot --json read KEY` | Direct lookup |
-| Export citation | `zot export KEY` | Local data |
-| Formatted citation to clipboard | `zot cite KEY --style apa` | APA/Nature/Vancouver |
-| Batch import DOIs/URLs | `zot add --from-file file.txt` | One per line |
-| Add/delete/tag/note | `zot ...` | All write ops |
-| Update item metadata | `zot update KEY --title/--field` | Web API write |
-| Upload attachment | `zot attach KEY --file paper.pdf` | Web API write |
-| Check preprint pub status | `zot update-status --limit 20` | Semantic Scholar API |
-| Find duplicates | `zot --json duplicates` | Local SQLite |
-| Recently added items | `zot --json recent --days 7` | Local SQLite |
-| Trash management | `zot --json trash list` | Local SQLite |
-| PDF full text extraction | `zot --json pdf KEY` | Local file access |
-| PDF outline extraction | `zot --json pdf --outline KEY` | Local file access + section parsing |
-| PDF section extraction | `zot --json pdf --section SECID KEY` | Local file access + section parsing |
-| Library stats | `zot --json stats` | Local aggregation |
-| Open PDF/URL | `zot open KEY` or `zot open --url KEY` | System open |
-| Group library access | `zot --library group:123 search "query"` | All commands |
-| Organize papers by topic | `zot workspace new llm-safety` | Local workspace, no API needed |
-| Bulk import to workspace | `zot workspace import name --collection/--tag/--search` | From collection, tag, or search |
-| Search within workspace | `zot workspace search "query" --workspace name` | Fast metadata match |
-| Export workspace for AI | `zot workspace export name` | Markdown/JSON/BibTeX |
-| Deep content search (RAG) | `zot workspace query "question" --workspace name` | BM25 + optional semantic |
-
-**Rule of thumb**: Use `zot search` for quick metadata lookups. Use `zot workspace query` for deep content search over a curated set of papers (indexes metadata + PDF fulltext).
-
----
-
-## zot — Zotero CLI (Core Tool)
-
-### Search & Browse
+## Quick Start
 
 ```bash
-zot --json search "transformer attention"
-zot --json search "BERT" --collection "NLP"
-zot --json list --collection "Machine Learning" --limit 10
-zot --json read ITEMKEY
-zot --json relate ITEMKEY
+zot search "transformer attention"       # Search papers
+zot --json read ABC123                   # View paper details (JSON)
+zot export ABC123                        # BibTeX export
+zot workspace query "RLHF" --workspace my-ws  # RAG search
 ```
 
-### Notes & Tags
+## Critical Rules
 
-```bash
-zot --json note ITEMKEY
-zot note ITEMKEY --add "Key finding: ..."
-zot --json tag ITEMKEY
-zot tag ITEMKEY --add "important"
-zot tag ITEMKEY --remove "to-read"
-```
+1. **Always use `--json`** for programmatic processing (auto-enabled when stdout is not a TTY).
+2. **Windows CJK encoding**: On Windows with a CJK locale, recent `zot` versions auto-reconfigure stdout to UTF-8. For older versions or subprocess calls, set `PYTHONIOENCODING=utf-8`. See `references/windows-encoding.md`.
+3. **Write safety**: Use `--dry-run` to preview mutations. Pass `--idempotency-key` on retries.
+4. **Large PDFs**: Use `--outline` first, then `--section SECID` to extract selectively. Avoid pulling full text when >20k chars.
+5. **Workspace RAG index**: Do not `--force` rebuild without user confirmation — it is slow.
+6. **Find Full Text**: `zot find-pdf KEY` fetches paywalled PDFs but needs Zotero desktop running + the bridge plugin. One-time setup: `zot bridge install`. See `references/commands.md`.
+7. **Canonical schema**: Run `zot schema <cmd>` for exhaustive flags, types, and safety tiers.
 
-### Citation Export
+## Routing Table
 
-```bash
-zot export ITEMKEY                    # BibTeX
-zot export ITEMKEY --format csl-json  # CSL-JSON
-zot export ITEMKEY --format ris       # RIS
-zot export ITEMKEY --format json      # Raw JSON
+| User Intent | Command |
+|-------------|---------|
+| Search metadata | `zot --json search "query"` |
+| Read item detail | `zot --json read KEY` |
+| Export BibTeX/RIS/JSON | `zot export KEY --format bibtex` |
+| Formatted citation | `zot cite KEY --style apa` |
+| Batch import DOIs | `zot add --from-file dois.txt` |
+| Add single item | `zot add --doi "10.1038/..."` |
+| Update metadata | `zot update KEY --title "New"` |
+| Delete item | `zot --no-interaction delete KEY` |
+| PDF full text | `zot --json pdf KEY` |
+| PDF outline | `zot --json pdf --outline KEY` |
+| PDF section | `zot --json pdf --section SECID KEY` |
+| Fetch/attach missing PDF | `zot find-pdf KEY` (needs Zotero desktop + bridge) |
+| Set up find-pdf bridge | `zot bridge install` |
+| Collection list | `zot --json collection list` |
+| Collection items | `zot --json collection items COLLKEY` |
+| Find duplicates | `zot --json duplicates` |
+| Recent items | `zot --json recent --days 7` |
+| Library stats | `zot --json stats` |
+| Workspace create | `zot workspace new NAME` |
+| Workspace RAG query | `zot workspace query "q" --workspace NAME` |
+| Group library | `zot --library group:ID search "q"` |
 
-# Formatted citation (copies to clipboard)
-zot cite ITEMKEY                      # APA (default)
-zot cite ITEMKEY --style nature       # Nature
-zot cite ITEMKEY --style vancouver    # Vancouver
-```
+**Rule of thumb**: `zot search` for quick metadata lookups. `zot workspace query` for deep content search over curated papers.
 
-### Item Management (Write Ops)
-
-```bash
-zot add --doi "10.1038/s41586-023-06139-9"
-zot add --url "https://arxiv.org/abs/2301.00001"
-zot add --from-file dois.txt              # Batch import (one DOI/URL per line)
-zot add --pdf paper.pdf                   # Add from local PDF (auto-extract DOI)
-zot --no-interaction delete ITEMKEY
-zot update ITEMKEY --title "New Title"
-zot update ITEMKEY --field volume=42 --field pages=1-10
-zot attach ITEMKEY --file supplement.pdf
-```
-
-**Agent-safety flags on every mutating command:**
-
-```bash
-# Preview without writing — confirms intent before commit, no Zotero API call
-zot add --doi "10.1038/..." --dry-run
-zot delete ITEMKEY --dry-run
-zot update ITEMKEY --field volume=42 --dry-run
-
-# Idempotency — replay the same write safely after a network blip
-zot add --doi "10.1038/..." --idempotency-key abc-123
-zot update ITEMKEY --title "X" --idempotency-key abc-124
-zot attach ITEMKEY --file x.pdf --idempotency-key abc-125
-zot delete ITEMKEY --yes --idempotency-key abc-126
-```
-
-> Use `--dry-run` before any unfamiliar write, and pass a unique `--idempotency-key` whenever you might retry on failure — agent-native contract documented in `docs/agent-interface.md`.
-
-### Collections
-
-```bash
-zot --json collection list
-zot --json collection items COLLECTIONKEY
-zot collection create "New Project"
-zot collection move ITEMKEY COLLECTIONKEY
-zot collection rename COLLECTIONKEY "New Name"
-zot collection delete COLLECTIONKEY
-```
-
-### Duplicates, Recent & Trash
-
-```bash
-zot --json duplicates                # Find duplicates (DOI + title matching)
-zot --json duplicates --by title     # Title-only matching
-zot --json recent --days 7           # Recently added items
-zot --json recent --sort dateModified
-zot --json trash list                # View trashed items
-zot trash restore ITEMKEY            # Restore from trash
-```
-
-### PDF & Summarization
-
-```bash
-zot --json pdf ITEMKEY
-zot --json pdf --outline ITEMKEY        # PDF outline (headings)
-zot --json pdf --section SECID ITEMKEY  # Extract specific section by ID
-zot pdf ITEMKEY --annotations           # Extract PDF annotations
-zot --json summarize ITEMKEY
-zot summarize-all
-```
-
-### Utilities
-
-```bash
-zot --json stats                     # Library statistics
-zot open ITEMKEY                     # Open PDF in system viewer
-zot open --url ITEMKEY               # Open URL/DOI in browser
-```
-
-### Group Library
-
-```bash
-zot --library group:12345 search "query"    # Search in group library
-zot --library group:12345 list              # List group library items
-```
-
-### Workspaces (Topic-Based Paper Organization + RAG)
-
-Workspaces are local collections of paper references for organizing research by topic. Each workspace stores item keys in a TOML file (`~/.config/zot/workspaces/<name>.toml`) — no Zotero API needed.
-
-```bash
-# Create and manage workspaces
-zot workspace new llm-safety --description "LLM alignment and safety papers"
-zot workspace add llm-safety KEY1 KEY2 KEY3
-zot workspace remove llm-safety KEY1
-zot workspace list                         # List all workspaces
-zot --json workspace list                  # JSON output
-zot workspace show llm-safety              # Show items with full metadata
-zot workspace delete llm-safety --yes
-
-# Bulk import from collection, tag, or search
-zot workspace import llm-safety --collection "Alignment"
-zot workspace import llm-safety --tag "safety"
-zot workspace import llm-safety --search "RLHF"
-
-# Search within workspace (metadata substring match)
-zot workspace search "reward" --workspace llm-safety
-zot --json workspace search "attention" --workspace llm-safety
-
-# Export for AI consumption
-zot workspace export llm-safety                       # Markdown (default)
-zot workspace export llm-safety --format json         # JSON
-zot workspace export llm-safety --format bibtex       # BibTeX
-
-# Build RAG index (BM25 over metadata + PDF text)
-zot workspace index llm-safety             # Incremental index
-zot workspace index llm-safety --force     # Full rebuild
-zot workspace index llm-safety --skip-tag skip-index   # Skip attachments with this tag (default: skip-index)
-
-# Query workspace with natural language
-zot workspace query "reward hacking" --workspace llm-safety
-zot workspace query "RLHF methods" --workspace llm-safety --top-k 10
-zot --json workspace query "attention" --workspace llm-safety
-
-# Retrieval modes (auto selects hybrid if embeddings available)
-zot workspace query "query" --workspace name --mode bm25      # Keyword only
-zot workspace query "query" --workspace name --mode semantic   # Embeddings only
-zot workspace query "query" --workspace name --mode hybrid     # BM25 + semantic fusion
-```
-
-The format of chunks is:
-
-```json
-[title > heading] chunk text...
-```
-
-Full example:
-
-```
-{
-    "rank": 1,
-    "score": 0.0154,
-    "item_key": "B6TZ6TQX",
-    "source": "pdf",
-    "content": "[现代电路理论与设计 > 5.2 跨导电容滤波器的分析与设计] 跨导放大器是一种输入信号是电压、输出信号是电流的放大器。由跨导放大器组成的集成运算放大器称为跨导运算放大器（Operational Transconductance Amplifier, OTA）。由跨导运算放大器和电容构成的滤波器称为 跨导电容滤波器。跨导电容滤波器以有源RC滤波器为基础，以跨导运算放大器作为有源器件，利用跨导运算放大器的电导特性，将跨导运算放大器作为电阻元件使用，以实现有源滤波器的全集成实现。由于跨导运算放大器的跨导值 $g_{\\mathrm{m}}$ 可以通过改变跨导运算放大器的偏置电流很容易 地加以改变，所以跨导电容滤波器可以比较容易地实现对滤波器频率特性的调整。与MOSFET-C滤波器相比，跨导电容滤波器最适宜于高速应用。另外，它可以应用于开环结构，所以不需要考虑其稳定性，而这两个特点正是普通运算放大器所不具有的。\n\n跨导电容滤波器的缺点是：由于跨导运算放大器往往工作在开环状态，为了保持电路\n\n的线性，所加的输入信号必须非常小，因此，分布电容对电路工作频率的影响比较大。另外，由于跨导电容滤波器对跨导运"
-  }
-```
-
-> Never build workspace RAG index with `--force` unless you know what you're doing. It takes time to build the full index from scratch.
-> Before building the index, ask the user if they want to build right now or later, and explain that it may take a while. Or Let the user build the index in their own time, and just show a warning if they try to query before the index is built.
-
-### Global Flags
+## Global Flags
 
 | Flag | Purpose |
 |------|---------|
-| `--json` | JSON output (ALWAYS use for programmatic processing) |
+| `--json` | JSON output (always use for programmatic processing) |
 | `--limit N` | Limit results (default: 50) |
 | `--detail minimal` | Only key/title/authors/year — saves tokens |
-| `--detail full` | Include extra fields |
-| `--no-interaction` | Suppress prompts (for automation) |
-| `--profile NAME` | Use a specific config profile |
-| `--verbose` | Verbose/debug output |
+| `--detail full` | All fields |
+| `--no-interaction` | Suppress prompts (automation) |
+| `--verbose` | Debug output |
 
----
+## Key Facts
 
-## Workflow Patterns
+- Read ops work offline with zero config
+- Write ops need API credentials (`zot config init`)
+- Item keys are 8-char alphanumeric strings (e.g. `K853PGUG`)
+- Non-TTY stdout auto-emits JSON envelope — agents never need explicit `--json`
 
-### Pattern 1: Find and Read a document(papers,manuals,books)
+## References
 
-```bash
-# Step 1: Search
-zot --json search "single cell RNA sequencing"
-
-# Step 2: Read metadata details
-zot --json read K853PGUG
-
-# Step 3: Full PDF text if needed or read section selectively
-zot --json pdf K853PGUG               # Get full text extraction
-zot --json pdf --outline K853PGUG     # Get section headings and secid
-zot --json pdf --section 10 K853PGUG  # Extract section with secid 10 (e.g. Results)
-```
-
-> Before fetching the full PDF text, use `wc -m` on the command line to check the character count of the PDF output. If it's very long (>20000), use the `--outline` option to get section headings and IDs, then selectively extract only the relevant sections with `--section` to save tokens.
-
-### Pattern 2: Deep Content Search via Workspace RAG
-
-```bash
-# Step 1: Create workspace and add papers
-zot workspace new drug-resistance --description "Cancer drug resistance mechanisms"
-zot --json search "drug resistance cancer" --limit 20
-zot workspace add drug-resistance KEY1 KEY2 KEY3
-
-# Step 2: Build index (metadata + PDF fulltext)
-zot workspace index drug-resistance
-
-# Step 3: Query with natural language
-zot --json workspace query "mechanisms of acquired resistance" --workspace drug-resistance --top-k 5
-
-# Step 4: If want to read more context of some chunks (for incomplete chunks), get the item key and section from the results, then fetch the full PDF text and extract that section
-zot --json pdf --outline ITEMKEY        # Recognize section headings and secid
-zot --json pdf --section SECID ITEMKEY  # Extract specific section by ID for more context
-```
-
-
-### Pattern 3: AI-Powered Library Reorganization
-
-```bash
-# Step 1: Export all abstracts
-zot --json summarize-all > abstracts.json
-
-# Step 2: AI analyzes and generates classification plan
-# Step 3: Create collections and move items
-zot collection create "Category A"
-zot collection move ITEMKEY COLLECTIONKEY
-```
-
-### Pattern 4: Workspace RAG 
-
-```bash
-# Step 1: Create a topic workspace
-zot workspace new protein-folding --description "Protein structure prediction papers"
-
-# Step 2: Add relevant papers
-zot --json search "protein folding" --limit 20
-zot workspace add protein-folding KEY1 KEY2 KEY3 KEY4
-
-# Step 3: Build RAG index
-zot workspace index protein-folding
-
-# Step 4: Query and feed results to Claude Code
-zot --json workspace query "AlphaFold architecture" --workspace protein-folding --top-k 5
-# Paste JSON output into Claude Code conversation as context
-```
-
-## Important Notes
-
-- **`zot` read operations** work offline with zero config
-- **`zot` write operations** need API credentials via `zot config init`
-- **`zot update-status`** uses Semantic Scholar API; set `S2_API_KEY` env var for faster rate limits
-- **PDF cache** — `zot` caches PDF extractions automatically
-- **Item keys** are 8-character alphanumeric strings like `K853PGUG`
-- **Group libraries** — use `--library group:<id>` with any command
-- **Workspaces** — pure local TOML files, no API needed for basic operations; `workspace index` reads PDFs from Zotero storage
-- **Workspace RAG** — BM25 always available (zero new deps); optional semantic search via embedding endpoint (`ZOT_EMBEDDING_URL` + `ZOT_EMBEDDING_KEY`
+- `references/commands.md` — Full command reference with examples
+- `references/workspaces.md` — Workspace management and RAG deep dive
+- `references/workflows.md` — Common multi-step workflow patterns
+- `references/windows-encoding.md` — Windows CJK encoding fix

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -1,0 +1,144 @@
+# Command Reference
+
+## Search & Browse
+
+```bash
+zot --json search "transformer attention"
+zot --json search "BERT" --collection "NLP"
+zot --json list --collection "Machine Learning" --limit 10
+zot --json read ITEMKEY
+zot --json relate ITEMKEY
+```
+
+## Notes & Tags
+
+```bash
+zot --json note ITEMKEY
+zot note ITEMKEY --add "Key finding: ..."
+zot --json tag ITEMKEY
+zot tag ITEMKEY --add "important"
+zot tag ITEMKEY --remove "to-read"
+```
+
+## Citation Export
+
+```bash
+zot export ITEMKEY                    # BibTeX (default)
+zot export ITEMKEY --format csl-json  # CSL-JSON
+zot export ITEMKEY --format ris       # RIS
+zot export ITEMKEY --format json      # Raw JSON
+
+# Formatted citation (copies to clipboard)
+zot cite ITEMKEY                      # APA (default)
+zot cite ITEMKEY --style nature       # Nature
+zot cite ITEMKEY --style vancouver    # Vancouver
+```
+
+## Item Management (Write Ops)
+
+```bash
+zot add --doi "10.1038/s41586-023-06139-9"
+zot add --url "https://arxiv.org/abs/2301.00001"
+zot add --from-file dois.txt              # Batch import (one DOI/URL per line)
+zot add --pdf paper.pdf                   # Add from local PDF (auto-extract DOI)
+zot --no-interaction delete ITEMKEY
+zot update ITEMKEY --title "New Title"
+zot update ITEMKEY --field volume=42 --field pages=1-10
+zot attach ITEMKEY --file supplement.pdf
+```
+
+### Safety Flags
+
+```bash
+# Preview without writing — no API call
+zot add --doi "10.1038/..." --dry-run
+zot delete ITEMKEY --dry-run
+zot update ITEMKEY --field volume=42 --dry-run
+
+# Idempotency — safe retry after network failure
+zot add --doi "10.1038/..." --idempotency-key abc-123
+zot update ITEMKEY --title "X" --idempotency-key abc-124
+zot attach ITEMKEY --file x.pdf --idempotency-key abc-125
+zot delete ITEMKEY --yes --idempotency-key abc-126
+```
+
+## Find Full Text PDF (Zotero desktop bridge)
+
+`zot find-pdf` triggers Zotero desktop's "Find Full Text", reusing the
+desktop's configured PDF resolvers AND its authenticated sessions /
+institutional proxies. This is the only way to reach paywalled PDFs from the
+CLI — the Zotero Web API cannot do it. Requires Zotero running with the
+`zot-cli-bridge` plugin installed.
+
+```bash
+zot find-pdf ITEMKEY                  # find & attach a PDF via desktop resolvers
+zot find-pdf ITEMKEY --dry-run        # only check the bridge is reachable
+zot find-pdf ITEMKEY --timeout 180    # give slow resolvers more time
+zot find-pdf ITEMKEY --library-id 42  # target a specific library
+```
+
+One-time bridge setup (enables `find-pdf`):
+
+```bash
+zot bridge install                    # build the plugin .xpi + print install steps
+zot bridge install --output ~/zot-cli-bridge.xpi   # choose where to write the .xpi
+zot bridge status                     # check Zotero + plugin reachability
+zot bridge uninstall                  # show how to remove the plugin
+```
+
+`zot bridge install` builds the `.xpi`; you finish installation in Zotero via
+Tools -> Plugins -> gear -> Install Plugin From File (Zotero owns plugin
+installation, so the CLI cannot sideload silently).
+
+## Collections
+
+```bash
+zot --json collection list
+zot --json collection items COLLECTIONKEY
+zot collection create "New Project"
+zot collection move ITEMKEY COLLECTIONKEY
+zot collection rename COLLECTIONKEY "New Name"
+zot collection delete COLLECTIONKEY
+```
+
+## Duplicates, Recent & Trash
+
+```bash
+zot --json duplicates                # DOI + title matching
+zot --json duplicates --by title     # Title-only matching
+zot --json recent --days 7           # Recently added
+zot --json recent --sort dateModified
+zot --json trash list                # View trashed items
+zot trash restore ITEMKEY            # Restore from trash
+```
+
+## PDF & Summarization
+
+```bash
+zot --json pdf ITEMKEY                      # Full text extraction
+zot --json pdf --outline ITEMKEY            # Section headings + secid
+zot --json pdf --section SECID ITEMKEY      # Extract specific section
+zot pdf ITEMKEY --annotations               # PDF annotations
+zot --json summarize ITEMKEY
+zot summarize-all
+```
+
+**Token-saving strategy**: For large PDFs, use `--outline` to get section IDs first, then `--section` to extract only what you need.
+
+## Utilities
+
+```bash
+zot --json stats                     # Library statistics
+zot open ITEMKEY                     # Open PDF in system viewer
+zot open --url ITEMKEY               # Open URL/DOI in browser
+zot update-status --limit 20        # Check preprint publication status (needs S2_API_KEY)
+```
+
+## Group Library
+
+```bash
+zot --library group:12345 search "query"
+zot --library group:12345 list
+```
+
+All commands support `--library group:<id>` to operate on group libraries.

--- a/skill/zotero-cli-cc/references/windows-encoding.md
+++ b/skill/zotero-cli-cc/references/windows-encoding.md
@@ -1,0 +1,90 @@
+# Windows CJK Encoding Fix
+
+## Problem
+
+`zot` is a Python/Click application. On Windows with a CJK system locale (Chinese, Japanese, Korean), stdout defaults to GBK/CP936 encoding. This causes two failures:
+
+### Failure 1: zot crashes on output
+
+`click.echo()` encodes output as GBK. Unicode characters outside the GBK range (e.g. emoji `⛔` U+26D4) cause:
+
+```
+UnicodeEncodeError: 'gbk' codec can't encode character '⛔' in position 1061
+```
+
+The JSON output never reaches stdout — the subprocess gets an empty result or a traceback.
+
+### Failure 2: subprocess decode error
+
+Even when zot outputs GBK bytes successfully, Python's `subprocess` defaults to UTF-8 decoding:
+
+```
+UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd6
+```
+
+## Solution (recent versions)
+
+Recent `zot` releases auto-reconfigure stdout/stderr to UTF-8 on Windows when the system encoding is not UTF-8. No user action required.
+
+## Solution (older versions or subprocess calls)
+
+Set `PYTHONIOENCODING=utf-8` in the environment before invoking `zot`. This forces Python's stdin/stdout/stderr to use UTF-8, fixing both failures simultaneously.
+
+### Python subprocess
+
+```python
+import subprocess, os
+
+env = os.environ.copy()
+env['PYTHONIOENCODING'] = 'utf-8'
+
+result = subprocess.run(
+    ['zot', '--json', 'search', 'query'],
+    capture_output=True,
+    env=env,
+)
+
+text = result.stdout.decode('utf-8')
+```
+
+### PowerShell
+
+```powershell
+$env:PYTHONIOENCODING = "utf-8"
+zot --json search "transformer"
+```
+
+### CMD
+
+```cmd
+set PYTHONIOENCODING=utf-8
+zot --json search "transformer"
+```
+
+### Persistent (recommended)
+
+Set as a user environment variable so all new terminals inherit it:
+
+```powershell
+[Environment]::SetEnvironmentVariable("PYTHONIOENCODING", "utf-8", "User")
+```
+
+## Why Not Other Approaches
+
+| Approach | Problem |
+|----------|---------|
+| `chcp 65001` | Only changes the console code page, not Python's `sys.stdout.encoding` |
+| PowerShell `Out-File -Encoding utf8` | PowerShell decodes zot's GBK output first, corrupting CJK characters |
+| `result.stdout.decode('gbk')` | Only fixes Failure 2; Failure 1 (zot crash) still produces no output |
+
+## Fallback Decoding
+
+If `PYTHONIOENCODING` is not set and you are on an older version, use multi-stage decoding:
+
+```python
+raw = result.stdout
+try:
+    text = raw.decode('utf-8')
+except UnicodeDecodeError:
+    text = raw.decode('gbk', errors='replace')
+```

--- a/skill/zotero-cli-cc/references/workflows.md
+++ b/skill/zotero-cli-cc/references/workflows.md
@@ -1,0 +1,96 @@
+# Workflow Patterns
+
+## Pattern 1: Find and Read a Paper
+
+```bash
+# Step 1: Search
+zot --json search "single cell RNA sequencing"
+
+# Step 2: Read metadata
+zot --json read K853PGUG
+
+# Step 3: PDF — check structure first, extract selectively
+zot --json pdf --outline K853PGUG             # Get section headings + secid
+zot --json pdf --section 10 K853PGUG          # Extract only the section you need
+zot --json pdf K853PGUG                       # Full text (only if short or necessary)
+```
+
+**Token budget**: For PDFs >20k chars, always use `--outline` then `--section` instead of pulling full text.
+
+**No PDF attached?** If `zot pdf` reports no attachment, run `zot find-pdf K853PGUG` to have Zotero desktop fetch and attach one (requires the bridge — see `references/commands.md`).
+
+## Pattern 2: Deep Content Search via Workspace RAG
+
+```bash
+# Step 1: Create workspace and populate
+zot workspace new drug-resistance --description "Cancer drug resistance mechanisms"
+zot --json search "drug resistance cancer" --limit 20
+zot workspace add drug-resistance KEY1 KEY2 KEY3
+
+# Step 2: Build index
+zot workspace index drug-resistance
+
+# Step 3: Query
+zot --json workspace query "mechanisms of acquired resistance" --workspace drug-resistance --top-k 5
+
+# Step 4: Drill into specific chunks for more context
+zot --json pdf --outline ITEMKEY
+zot --json pdf --section SECID ITEMKEY
+```
+
+## Pattern 3: Batch Export from Collections
+
+```python
+import subprocess, json, os
+
+env = os.environ.copy()
+env['PYTHONIOENCODING'] = 'utf-8'  # Required on Windows CJK systems (older versions)
+
+collections = {
+    'topic_a': 'COLLKEY1',
+    'topic_b': 'COLLKEY2',
+}
+
+for name, key in collections.items():
+    result = subprocess.run(
+        ['zot', '--json', 'collection', 'items', key],
+        capture_output=True, env=env,
+    )
+    if result.returncode != 0:
+        print(f'{name}: error - {result.stderr.decode("utf-8", errors="replace")}')
+        continue
+
+    data = json.loads(result.stdout.decode('utf-8'))
+    with open(f'batch_{name}.json', 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    print(f'{name}: {data["meta"]["count"]} items')
+```
+
+## Pattern 4: Library Reorganization
+
+```bash
+# Step 1: Export all abstracts
+zot --json summarize-all > abstracts.json
+
+# Step 2: Analyze and classify (AI or manual)
+# Step 3: Create collections and move items
+zot collection create "Category A"
+zot collection move ITEMKEY COLLECTIONKEY
+```
+
+## Pattern 5: Literature Review Pipeline
+
+```bash
+# 1. Import papers from DOI list
+zot add --from-file dois.txt
+
+# 2. Organize into workspace
+zot workspace new lit-review --description "Systematic review papers"
+zot workspace import lit-review --tag "review-candidate"
+
+# 3. Build index for deep search
+zot workspace index lit-review
+
+# 4. Query for themes
+zot --json workspace query "methodology comparison" --workspace lit-review --top-k 10
+```

--- a/skill/zotero-cli-cc/references/workspaces.md
+++ b/skill/zotero-cli-cc/references/workspaces.md
@@ -1,0 +1,105 @@
+# Workspaces & RAG
+
+Workspaces are local topic-based paper collections for organizing research. Each workspace stores item keys in a TOML file (`~/.config/zot/workspaces/<name>.toml`) — no Zotero API needed.
+
+## Workspace Management
+
+```bash
+# Create
+zot workspace new llm-safety --description "LLM alignment and safety papers"
+
+# Add/remove items
+zot workspace add llm-safety KEY1 KEY2 KEY3
+zot workspace remove llm-safety KEY1
+
+# List and inspect
+zot workspace list
+zot --json workspace list
+zot workspace show llm-safety
+
+# Delete
+zot workspace delete llm-safety --yes
+```
+
+## Bulk Import
+
+```bash
+zot workspace import llm-safety --collection "Alignment"
+zot workspace import llm-safety --tag "safety"
+zot workspace import llm-safety --search "RLHF"
+```
+
+## Search Within Workspace
+
+Metadata substring match (no index required):
+
+```bash
+zot workspace search "reward" --workspace llm-safety
+zot --json workspace search "attention" --workspace llm-safety
+```
+
+## Export
+
+```bash
+zot workspace export llm-safety                       # Markdown (default)
+zot workspace export llm-safety --format json         # JSON
+zot workspace export llm-safety --format bibtex       # BibTeX
+```
+
+## RAG Index
+
+```bash
+zot workspace index llm-safety                          # Incremental index
+zot workspace index llm-safety --force                  # Full rebuild (slow — confirm with user first)
+zot workspace index llm-safety --skip-tag skip-index    # Skip PDFs carrying this tag (default: skip-index)
+```
+
+Attachments tagged `skip-index` are skipped by default. Use `--skip-tag` to
+change which tag(s) are excluded — useful for keeping huge or irrelevant PDFs
+out of the index. Tag a PDF `skip-index` in Zotero to exclude it.
+
+**Important**: Never `--force` rebuild without user confirmation. Incremental indexing is usually sufficient.
+
+## RAG Query
+
+```bash
+zot workspace query "reward hacking" --workspace llm-safety
+zot workspace query "RLHF methods" --workspace llm-safety --top-k 10
+zot --json workspace query "attention" --workspace llm-safety
+```
+
+### Retrieval Modes
+
+```bash
+--mode bm25       # Keyword only (always available, zero deps)
+--mode semantic   # Embeddings only (requires ZOT_EMBEDDING_URL + ZOT_EMBEDDING_KEY)
+--mode hybrid     # BM25 + semantic fusion (auto-selected if embeddings available)
+```
+
+## Chunk Format
+
+RAG results return chunks structured as:
+
+```json
+{
+  "rank": 1,
+  "score": 0.0154,
+  "item_key": "B6TZ6TQX",
+  "source": "pdf",
+  "content": "[Title > Section Heading] chunk text..."
+}
+```
+
+## Reading More Context from Chunks
+
+When a chunk is incomplete, drill into the source:
+
+```bash
+zot --json pdf --outline ITEMKEY            # Get section headings + secid
+zot --json pdf --section SECID ITEMKEY      # Extract full section
+```
+
+## Configuration
+
+- BM25: always available, zero additional dependencies
+- Semantic search: set `ZOT_EMBEDDING_URL` and `ZOT_EMBEDDING_KEY` environment variables


### PR DESCRIPTION
## Summary

Refactors the bundled Claude Code skill from a single ~300-line `SKILL.md` into a concise entry point plus on-demand `references/` files, following [Anthropic's skill-authoring guidance](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices):

```
skill/zotero-cli-cc/
├── SKILL.md                       # routing table + critical rules + global flags
└── references/
    ├── commands.md                # full command reference
    ├── workspaces.md              # workspace & RAG deep dive
    ├── workflows.md               # multi-step workflow patterns
    └── windows-encoding.md        # Windows CJK encoding fix
```

- Smaller entry point — agents load the routing table first and pull detail on demand.
- Skill `name` renamed to `zotero-cli-cc` to match its directory (per the skill spec).
- Drops the large embedded Chinese chunk example in favor of a generic one.

This **supersedes #45** and rebases its idea onto current `main`, which resolves that PR's `SKILL.md` conflict and the now-redundant `cli.py` change (the Windows fix already merged as #48). It also closes the coverage gaps #45 had: the refactored docs now include the commands that #45 predated —

- `zot find-pdf` and the `zot bridge install/status/uninstall` setup (added in #43)
- `zot workspace index --skip-tag` (added in #46)

Builds on the structure proposed by @IA20201 in #45 (credited as co-author).

## Test plan
- [x] No skill-validation test exists; structure verified manually
- [x] No residual non-English text in the skill files
- [x] All documented commands/flags checked against `zot --help` / `zot <cmd> --help`