### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-28
+
+### Added
+
+- `zot find-pdf KEY` triggers Zotero desktop's "Find Full Text" over a local
+  bridge plugin, so the CLI can fetch and attach PDFs that the Zotero Web API
+  cannot reach (paywalled content behind the desktop's configured resolvers,
+  authenticated sessions, and institutional proxies). Ships with
+  `zot bridge install` / `status` / `uninstall` to package the bundled
+  `zot-cli-bridge` plugin into an `.xpi` and guide installation. Both commands
+  are also exposed over MCP. `meta.schema_version` is bumped 1.3.0 → 1.4.0 (#43).
+- `zot workspace index --skip-tag` excludes attachments carrying a given tag
+  from the RAG index (default `skip-index`), so large or irrelevant PDFs can be
+  kept out of the index. Also available on the MCP `workspace_index` tool
+  (#44, #46).
+
+### Fixed
+
+- On Windows with a CJK (GBK/CP936) system locale, `zot` crashed with
+  `UnicodeEncodeError` whenever output contained characters outside the GBK
+  range (e.g. emoji). stdout/stderr are now reconfigured to UTF-8 at startup on
+  Windows when the encoding is not already UTF-8 (#48).
+
+### Changed
+
+- The bundled Claude Code skill was split from a single `SKILL.md` into a
+  concise entry point plus on-demand `references/` files (commands, workspaces,
+  workflows, windows-encoding), and now documents the `find-pdf` / `bridge`
+  commands and `workspace index --skip-tag` (#49).
+
 ## [0.4.4] - 2026-05-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.4.4"
+version = "0.5.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "CC-BY-NC-4.0"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2104,7 +2104,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.4.4"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release **0.5.0**. Bumps `pyproject.toml` + `uv.lock` and adds the CHANGELOG entry. Everything since v0.4.4:

### Added
- `zot find-pdf` + `zot bridge install/status/uninstall` — trigger Zotero desktop's "Find Full Text" via a bundled local-bridge plugin to fetch paywalled PDFs the Web API can't reach (#43). Schema bumped 1.3.0 → 1.4.0.
- `zot workspace index --skip-tag` — exclude tagged attachments from the RAG index (default `skip-index`) (#44, #46).

### Fixed
- Windows CJK (`UnicodeEncodeError`) crash — stdout/stderr reconfigured to UTF-8 on non-UTF-8 Windows locales (#48).

### Changed
- Bundled skill split into a multi-file `SKILL.md` + `references/` structure, now covering find-pdf/bridge/skip-tag (#49).

Minor bump (new commands) per the project's SemVer policy.

## Release steps (after merge)
- [ ] Merge this PR
- [ ] Tag `v0.5.0` on the merge commit and push it → `publish.yml` runs lint + builds + publishes to PyPI

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean (the publish gate)
- [x] `uv build` succeeds; wheel is `0.5.0` and bundles `bridge_assets/{manifest.json,bootstrap.js,icon.png}`
- [x] `uv.lock` synced to 0.5.0 (no repeat of the #47 staleness)