### PR TITLE
feat(rename): rename attachment files by a metadata template via the local bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `zot rename KEY...` renames an item's PDF attachment files from its metadata
+  via the bridge plugin. The default template is `{journal}_{year}_{title}`
+  (tokens `{journal} {year} {title} {shorttitle} {author}`); `{journal}` is
+  resolved from a `Jab/#` tag or an item-type-aware abbreviation (arXiv →
+  `Pre`). Non-PDF attachments (Excel/Word/snapshots) are filtered out by
+  content type; supplementary PDFs are detected by filename and get an `_SI`
+  suffix so names never collide. Supports `--dry-run`, `--main-only`,
+  `--force`, `--template`, and `--attachment/--name` for explicit single-file
+  renames. Requires the `zot-cli-bridge` plugin **v0.2.0+** (re-run
+  `zot bridge install`). `meta.schema_version` is bumped 1.4.0 → 1.5.0.
+
 ## [0.5.0] - 2026-05-28
 
 ### Added

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -180,7 +180,7 @@ The input file may be either a full envelope or a bare `data` tree.
 Commands are grouped by risk in `zot --help`:
 
 - **Read** — `search`, `list`, `read`, `export`, `recent`, `stats`, `cite`, `pdf`, `collection list`, `tag list`, ...
-- **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `bridge` (mutates local config, not the library)
+- **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `bridge` (mutates local config, not the library)
 - **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`
 
 Each write or destructive command's `--help` carries a `MUTATES LIBRARY` marker. The same classification is available via `zot schema <cmd>.safety_tier`.
@@ -282,6 +282,39 @@ Plugin From File…**, pick the `.xpi`, restart. `install`/`uninstall` use
 > The plugin manifest must carry `icons` and `applications.zotero.update_url`
 > — Zotero 8/9 reject a manifest lacking them as "incompatible with this
 > version of Zotero".
+
+## Renaming attachment files (`zot rename`)
+
+Renaming an attachment's *stored file* is a desktop operation: the Web API
+can't rename the file in `storage/` without desyncing, and writing the SQLite
+DB directly is forbidden. So `zot rename` goes through the same bridge plugin
+as `find-pdf`, calling `POST /zot-cli/rename` →
+`item.renameAttachmentFile(newName, force)` (and syncing the attachment title).
+Requires the bridge plugin **v0.2.0+** — older installs return `bridge_missing`
+(re-run `zot bridge install`).
+
+```bash
+zot rename ABCD1234 --dry-run        # preview old -> new for main + supp PDFs
+zot rename ABCD1234 EFGH5678         # rename several items
+zot rename ABCD1234 --main-only      # skip supplementary PDFs
+zot rename ABCD1234 --template "{author}_{year}_{title}"
+zot rename --attachment ATT0001 --name "X.pdf"  # rename one file explicitly
+```
+
+`zot` builds the new names from SQLite metadata (no network): the default
+template is `{journal}_{year}_{title}` (tokens: `{journal} {year} {title}
+{shorttitle} {author}`). Attachments are filtered to PDFs by content type, so
+Excel/Word/snapshots are skipped. Among PDFs, supplementary files are detected
+by filename keywords (`supp`, `supplement`, `supporting`, `appendix`, a
+standalone `si`); the main PDF gets the template name and each supplementary
+one gets an `_SI` / `_SI2` suffix so names never collide.
+
+The envelope's `data.results[]` carries a per-attachment `status`
+(`renamed` / `unchanged` / `dry-run` / `error`); `data.renamed_count` and
+`data.sync_required` summarize the run. Per-attachment failures appear inline
+(e.g. `conflict` when the destination exists — pass `--force`); a missing
+bridge or stopped desktop aborts the whole command with `bridge_missing` (3) /
+`not_reachable` (5).
 
 ## `--idempotency-key`
 

--- a/extension/zot-cli-bridge/README.md
+++ b/extension/zot-cli-bridge/README.md
@@ -15,12 +15,13 @@ Zotero's Find Full Text uses two things that Web-API clients cannot reach:
 
 Both live inside the running Zotero process. The only safe way to drive them
 from outside is to ask Zotero itself to do the work, which is what this
-plugin enables. It registers two endpoints on `http://127.0.0.1:23119`:
+plugin enables. It registers these endpoints on `http://127.0.0.1:23119`:
 
 | Method | Path | Description |
 | --- | --- | --- |
 | `GET` | `/zot-cli/ping` | Health probe — returns plugin + Zotero version |
 | `POST` | `/zot-cli/find-pdf` | Body: `{"key": "ABCD1234"}`. Triggers `Zotero.Attachments.addAvailableFile(item)` and returns the attached PDF's key on success, or `{found: false}` if no resolver had a hit. |
+| `POST` | `/zot-cli/rename` | Body: `{"attachmentKey": "...", "newName": "X.pdf", "force": false}`. Calls `item.renameAttachmentFile(newName, force)` on the attachment, syncs its title, and returns `{renamed, old_name, new_name}`. Powers `zot rename`. |
 
 ## Install
 
@@ -48,7 +49,7 @@ zot bridge status        # verify -> Bridge OK
 3. Verify it's wired up:
    ```bash
    curl http://127.0.0.1:23119/zot-cli/ping
-   # {"ok": true, "bridge_version": "0.1.0", "zotero_version": "9.x.y", ...}
+   # {"ok": true, "bridge_version": "0.2.0", "zotero_version": "9.x.y", ...}
    ```
 
 You can now run `zot find-pdf <item-key>` from the parent repo.

--- a/extension/zot-cli-bridge/bootstrap.js
+++ b/extension/zot-cli-bridge/bootstrap.js
@@ -8,6 +8,9 @@
  *   POST /zot-cli/find-pdf      — body {"key": "ABCD1234"} (or "?key=" query)
  *                                  triggers Zotero.Attachments.addAvailableFile
  *                                  for that item, returns the attachment key on success
+ *   POST /zot-cli/rename        — body {"attachmentKey","newName","libraryID"?,"force"?}
+ *                                  renames the attachment's stored file via
+ *                                  renameAttachmentFile and syncs its title
  *
  * The whole point of going through Zotero (rather than fetching the PDF
  * directly from Python) is that Zotero's "Find Full Text" reuses the user's
@@ -19,7 +22,7 @@
 
 /* global Zotero, ChromeUtils */
 
-const PLUGIN_VERSION = "0.1.0";
+const PLUGIN_VERSION = "0.2.0";
 
 function buildEndpoint(handler, { methods = ["GET"], dataTypes = ["application/json"] } = {}) {
   const Endpoint = function () {};
@@ -140,7 +143,98 @@ async function handleFindPdf(options) {
   ];
 }
 
+async function handleRename(options) {
+  // Body: {"attachmentKey": "...", "newName": "X.pdf", "libraryID"?, "force"?}
+  let attachmentKey = null;
+  let newName = null;
+  let libraryID = null;
+  let force = false;
+  if (options.data && typeof options.data === "object") {
+    attachmentKey = options.data.attachmentKey || null;
+    newName = options.data.newName || null;
+    libraryID = options.data.libraryID || null;
+    force = options.data.force === true;
+  }
+  if (!attachmentKey || !newName) {
+    return [400, "application/json", JSON.stringify({ ok: false, error: "missing 'attachmentKey' or 'newName'" })];
+  }
+  libraryID = libraryID || Zotero.Libraries.userLibraryID;
+
+  let att;
+  try {
+    att = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, attachmentKey);
+  } catch (e) {
+    return [500, "application/json", JSON.stringify({ ok: false, error: "lookup failed: " + e })];
+  }
+  if (!att) {
+    return [
+      404,
+      "application/json",
+      JSON.stringify({ ok: false, error: "attachment not found", key: attachmentKey, libraryID }),
+    ];
+  }
+  if (!att.isAttachment || !att.isAttachment()) {
+    return [400, "application/json", JSON.stringify({ ok: false, error: "item is not an attachment", key: attachmentKey })];
+  }
+
+  let oldName = null;
+  try {
+    oldName = att.attachmentFilename;
+  } catch (_) {
+    /* tolerate */
+  }
+
+  let status;
+  try {
+    status = await att.renameAttachmentFile(newName, force, false);
+  } catch (e) {
+    Zotero.logError(e);
+    return [500, "application/json", JSON.stringify({ ok: false, error: "rename failed: " + e, key: attachmentKey })];
+  }
+
+  if (status === -1) {
+    return [
+      409,
+      "application/json",
+      JSON.stringify({
+        ok: false,
+        error: "destination file already exists (pass force to overwrite)",
+        code: "exists",
+        key: attachmentKey,
+        new_name: newName,
+      }),
+    ];
+  }
+  if (status !== true) {
+    return [
+      404,
+      "application/json",
+      JSON.stringify({ ok: false, error: "attachment file not found on disk", key: attachmentKey }),
+    ];
+  }
+
+  // Keep the displayed title in sync with the new filename.
+  try {
+    if (newName !== att.getField("title")) {
+      att.setField("title", newName);
+      await att.saveTx();
+    }
+  } catch (e) {
+    Zotero.logError(e);
+  }
+
+  return [
+    200,
+    "application/json",
+    JSON.stringify({ ok: true, renamed: true, attachment_key: attachmentKey, old_name: oldName, new_name: newName }),
+  ];
+}
+
 const PING_ENDPOINT = buildEndpoint(handlePing, { methods: ["GET"] });
+const RENAME_ENDPOINT = buildEndpoint(handleRename, {
+  methods: ["POST"],
+  dataTypes: ["application/json"],
+});
 const FIND_PDF_ENDPOINT = buildEndpoint(handleFindPdf, {
   methods: ["POST", "GET"],
   dataTypes: ["application/json", "application/x-www-form-urlencoded"],
@@ -153,6 +247,7 @@ async function startup({ id, version }) {
   Zotero.debug("[zot-cli-bridge] startup " + id + " v" + version);
   Zotero.Server.Endpoints["/zot-cli/ping"] = PING_ENDPOINT;
   Zotero.Server.Endpoints["/zot-cli/find-pdf"] = FIND_PDF_ENDPOINT;
+  Zotero.Server.Endpoints["/zot-cli/rename"] = RENAME_ENDPOINT;
 }
 
 function shutdown() {
@@ -160,5 +255,6 @@ function shutdown() {
   if (Zotero && Zotero.Server && Zotero.Server.Endpoints) {
     delete Zotero.Server.Endpoints["/zot-cli/ping"];
     delete Zotero.Server.Endpoints["/zot-cli/find-pdf"];
+    delete Zotero.Server.Endpoints["/zot-cli/rename"];
   }
 }

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "Zot CLI Bridge",
-  "version": "0.1.0",
-  "description": "Exposes Zotero Find Full Text over the local HTTP server for the zot CLI.",
+  "version": "0.2.0",
+  "description": "Exposes Zotero Find Full Text and attachment rename over the local HTTP server for the zot CLI.",
   "author": "zotero-cli-cc",
   "homepage_url": "https://github.com/Agents365-ai/zotero-cli-cc",
   "icons": {

--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -42,6 +42,7 @@ zot workspace query "RLHF" --workspace my-ws  # RAG search
 | PDF outline | `zot --json pdf --outline KEY` |
 | PDF section | `zot --json pdf --section SECID KEY` |
 | Fetch/attach missing PDF | `zot find-pdf KEY` (needs Zotero desktop + bridge) |
+| Rename attachment files | `zot rename KEY --dry-run` (needs bridge; preview first) |
 | Set up find-pdf bridge | `zot bridge install` |
 | Collection list | `zot --json collection list` |
 | Collection items | `zot --json collection items COLLKEY` |

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -90,6 +90,27 @@ zot bridge uninstall                  # show how to remove the plugin
 Tools -> Plugins -> gear -> Install Plugin From File (Zotero owns plugin
 installation, so the CLI cannot sideload silently).
 
+## Rename Attachment Files
+
+`zot rename` renames an item's PDF attachment files from its metadata. Default
+template `{journal}_{year}_{title}.pdf` (tokens: `{journal} {year} {title}
+{shorttitle} {author}`). Non-PDF files (Excel/Word/snapshots) are skipped;
+supplementary PDFs are detected by filename and get an `_SI` suffix. Goes
+through the bridge plugin (needs v0.2.0+), so Zotero must be running.
+
+```bash
+zot rename ITEMKEY --dry-run               # ALWAYS preview first: shows old -> new
+zot rename ITEMKEY                          # rename main + supplementary PDFs
+zot rename ITEMKEY1 ITEMKEY2                # several items at once
+zot rename ITEMKEY --main-only             # only the main PDF
+zot rename ITEMKEY --template "{author}_{year}_{title}"
+zot rename ITEMKEY --force                 # overwrite if the target name exists
+zot rename --attachment ATTKEY --name "X.pdf"   # rename one specific file
+```
+
+**Always `--dry-run` first** so the user can confirm the new names before any
+files change.
+
 ## Collections
 
 ```bash

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -26,6 +26,7 @@ from zotero_cli_cc.commands.pdf import pdf_cmd
 from zotero_cli_cc.commands.read import read_cmd
 from zotero_cli_cc.commands.recent import recent_cmd
 from zotero_cli_cc.commands.relate import relate_cmd
+from zotero_cli_cc.commands.rename import rename_cmd
 from zotero_cli_cc.commands.schema import schema_cmd
 from zotero_cli_cc.commands.search import search_cmd
 from zotero_cli_cc.commands.stats import stats_cmd
@@ -64,7 +65,7 @@ _READ_COMMANDS = {
     "schema",
     "trash",
 }
-_WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge"}
+_WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge", "rename"}
 _DESTRUCTIVE_COMMANDS = {"delete", "update-status"}
 
 
@@ -296,6 +297,7 @@ main.add_command(trash_group, "trash")
 main.add_command(duplicates_cmd, "duplicates")
 main.add_command(attach_cmd, "attach")
 main.add_command(find_pdf_cmd, "find-pdf")
+main.add_command(rename_cmd, "rename")
 main.add_command(bridge_group, "bridge")
 main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")

--- a/src/zotero_cli_cc/commands/rename.py
+++ b/src/zotero_cli_cc/commands/rename.py
@@ -1,0 +1,182 @@
+"""`zot rename <KEY>...` — rename attachment files by a metadata template via the local bridge."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.local_bridge import LocalBridgeError, ping, rename_attachment
+from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.core.rename import RenameError, build_plan
+from zotero_cli_cc.core.writer import SYNC_REMINDER
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
+
+_BRIDGE_HINT = "Start Zotero desktop; run 'zot bridge install' to (re)install the bridge plugin (rename needs v0.2.0+)"
+_ABORT_CODES = {"not_reachable", "bridge_missing"}
+
+
+@click.command("rename")
+@click.argument("item_keys", nargs=-1)
+@click.option(
+    "--template",
+    default="{journal}_{year}_{title}",
+    show_default=True,
+    help="Filename template; tokens: {journal} {year} {title} {shorttitle} {author}",
+)
+@click.option("--main-only", is_flag=True, help="Rename only the main PDF (default also renames supplementary PDFs)")
+@click.option(
+    "--attachment", "attachment_key", default=None, help="Rename one specific attachment key (use with --name)"
+)
+@click.option(
+    "--name", "explicit_name", default=None, help="Explicit new filename for --attachment (include the extension)"
+)
+@click.option("--library-id", type=int, default=None, help="Override the Zotero library ID (default: user library)")
+@click.option("--force", is_flag=True, help="Overwrite if a file with the new name already exists")
+@click.option("--dry-run", is_flag=True, help="Preview the renames without changing any files")
+@click.pass_context
+def rename_cmd(
+    ctx: click.Context,
+    item_keys: tuple[str, ...],
+    template: str,
+    main_only: bool,
+    attachment_key: str | None,
+    explicit_name: str | None,
+    library_id: int | None,
+    force: bool,
+    dry_run: bool,
+) -> None:
+    """Rename PDF attachment files from item metadata. MUTATES LIBRARY.
+
+    By default builds `{journal}_{year}_{title}.pdf` for each item's main PDF
+    and `..._SI.pdf` for supplementary PDFs. Non-PDF attachments (Excel, Word,
+    web snapshots) are skipped. Requires Zotero desktop running with the
+    `zot-cli-bridge` plugin v0.2.0+ (run `zot bridge install`).
+
+    \b
+    Examples:
+      zot rename ABCD1234 --dry-run                 # preview main + supp renames
+      zot rename ABCD1234 EFGH5678                  # rename several items
+      zot rename ABCD1234 --main-only               # skip supplementary PDFs
+      zot rename ABCD1234 --template "{author}_{year}_{title}"
+      zot rename --attachment ATT0001 --name "X.pdf"  # rename one file explicitly
+    """
+    json_out = ctx.obj.get("json", False)
+
+    # Mode 1: explicit single-attachment rename (bypasses metadata/heuristics).
+    if attachment_key or explicit_name:
+        if not (attachment_key and explicit_name):
+            emit_error(
+                "validation_error",
+                "--attachment and --name must be used together",
+                output_json=json_out,
+                context="rename",
+            )
+        row: dict[str, object] = {"attachment_key": attachment_key, "new_name": explicit_name, "role": "explicit"}
+        if dry_run:
+            row["status"] = "dry-run"
+        else:
+            try:
+                res = rename_attachment(attachment_key, explicit_name, library_id=library_id, force=force)  # type: ignore[arg-type]
+            except LocalBridgeError as e:
+                emit_error(
+                    e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="rename"
+                )
+            row["old_name"] = res.get("old_name")
+            row["status"] = "renamed"
+        _emit(ctx, json_out, [{"key": None, "renames": [row]}], renamed=0 if dry_run else 1, dry_run=dry_run)
+        return
+
+    if not item_keys:
+        emit_error(
+            "validation_error",
+            "Provide at least one ITEM_KEY, or use --attachment with --name",
+            output_json=json_out,
+            context="rename",
+        )
+
+    # Fail fast if the desktop / bridge is unreachable (skip for dry-run).
+    if not dry_run:
+        try:
+            ping()
+        except LocalBridgeError as e:
+            emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="rename")
+
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    db_path = get_data_dir(cfg) / "zotero.sqlite"
+    reader = ZoteroReader(
+        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
+    )
+
+    results: list[dict] = []
+    renamed = 0
+    for key in item_keys:
+        item = reader.get_item(key)
+        if item is None:
+            results.append({"key": key, "error": "item not found", "code": "not_found"})
+            continue
+        try:
+            plan = build_plan(item, reader.get_attachments(key), template=template, include_supp=not main_only)
+        except RenameError as e:
+            results.append({"key": key, "error": str(e), "code": e.code})
+            continue
+        if not plan:
+            results.append({"key": key, "warning": "no PDF attachments found"})
+            continue
+        renames: list[dict] = []
+        for entry in plan:
+            row = {
+                "attachment_key": entry.attachment_key,
+                "old_name": entry.old_name,
+                "new_name": entry.new_name,
+                "role": entry.role,
+            }
+            if entry.skip:
+                row["status"] = "unchanged"
+            elif dry_run:
+                row["status"] = "dry-run"
+            else:
+                try:
+                    rename_attachment(entry.attachment_key, entry.new_name, library_id=library_id, force=force)
+                    row["status"] = "renamed"
+                    renamed += 1
+                except LocalBridgeError as e:
+                    if e.code in _ABORT_CODES:
+                        emit_error(
+                            e.code,
+                            str(e),
+                            output_json=json_out,
+                            retryable=e.retryable,
+                            hint=_BRIDGE_HINT,
+                            context="rename",
+                        )
+                    row["status"] = "error"
+                    row["error"] = str(e)
+                    row["code"] = e.code
+            renames.append(row)
+        results.append({"key": key, "renames": renames})
+
+    _emit(ctx, json_out, results, renamed=renamed, dry_run=dry_run)
+
+
+def _emit(ctx: click.Context, json_out: bool, results: list[dict], *, renamed: int, dry_run: bool) -> None:
+    data = {"results": results, "renamed_count": renamed, "sync_required": renamed > 0}
+    env = envelope_ok(data, extra={"dry_run": True} if dry_run else None)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        return
+    for item in results:
+        if item.get("key"):
+            click.echo(f"{item['key']}:")
+        if item.get("error"):
+            click.echo(f"  error: {item['error']}", err=True)
+        elif item.get("warning"):
+            click.echo(f"  {item['warning']}", err=True)
+        for r in item.get("renames", []):
+            click.echo(f"  [{r['role']}] {r.get('old_name') or '?'} -> {r['new_name']}  ({r['status']})")
+    if dry_run:
+        click.echo("[dry-run] no files changed", err=True)
+    elif renamed:
+        click.echo(SYNC_REMINDER, err=True)

--- a/src/zotero_cli_cc/commands/schema.py
+++ b/src/zotero_cli_cc/commands/schema.py
@@ -71,6 +71,7 @@ _SAFETY_TIER: dict[str, str] = {
     "attach": "write",
     "find-pdf": "write",
     "bridge": "write",
+    "rename": "write",
     # destructive
     "delete": "destructive",
     "update-status": "destructive",

--- a/src/zotero_cli_cc/core/local_bridge.py
+++ b/src/zotero_cli_cc/core/local_bridge.py
@@ -159,6 +159,81 @@ def find_pdf(
     return _parse_json(resp)
 
 
+RENAME_TIMEOUT = 30.0
+
+
+def rename_attachment(
+    attachment_key: str,
+    new_name: str,
+    *,
+    library_id: int | None = None,
+    force: bool = False,
+    timeout: float = RENAME_TIMEOUT,
+) -> dict[str, Any]:
+    """Rename an attachment's stored file via the bridge's `renameAttachmentFile`.
+
+    Returns a dict with `renamed`, `attachment_key`, `old_name`, `new_name`.
+
+    Raises:
+        LocalBridgeError. `bridge_missing` means the endpoint isn't registered
+        (the installed plugin predates rename — re-run `zot bridge install`);
+        `not_found` means the attachment/file is gone; `conflict` means the
+        destination already exists (retry with `force`).
+    """
+    payload: dict[str, Any] = {"attachmentKey": attachment_key, "newName": new_name, "force": force}
+    if library_id is not None:
+        payload["libraryID"] = library_id
+    try:
+        resp = httpx.post(
+            f"{LOCAL_BASE}/zot-cli/rename",
+            json=payload,
+            timeout=timeout,
+            headers={"User-Agent": _user_agent()},
+            trust_env=_TRUST_ENV,
+        )
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+        raise LocalBridgeError(
+            f"Cannot reach Zotero at {LOCAL_BASE} — is the desktop app running?",
+            code="not_reachable",
+            retryable=True,
+        ) from e
+    except httpx.HTTPError as e:
+        raise LocalBridgeError(f"Bridge request failed: {e}", code="network_error", retryable=True) from e
+
+    if resp.status_code == 404:
+        body = _parse_json_or_none(resp)
+        if body and body.get("error"):
+            raise LocalBridgeError(str(body["error"]), code="not_found", retryable=False)
+        raise LocalBridgeError(
+            "The /zot-cli/rename endpoint is missing — update the bridge plugin with 'zot bridge install'.",
+            code="bridge_missing",
+            retryable=False,
+        )
+    if resp.status_code == 409:
+        body = _parse_json_or_none(resp) or {}
+        raise LocalBridgeError(
+            str(body.get("error", "destination file already exists")),
+            code="conflict",
+            retryable=False,
+        )
+    if resp.status_code == 400:
+        body = _parse_json_or_none(resp) or {}
+        raise LocalBridgeError(
+            f"Bridge rejected request: {body.get('error', resp.text)}",
+            code="validation_error",
+            retryable=False,
+        )
+    if resp.status_code >= 500:
+        raise LocalBridgeError(f"Bridge returned HTTP {resp.status_code}", code="bridge_error", retryable=True)
+    if resp.status_code != 200:
+        raise LocalBridgeError(
+            f"Bridge returned HTTP {resp.status_code}: {resp.text}",
+            code="bridge_error",
+            retryable=False,
+        )
+    return _parse_json(resp)
+
+
 def _parse_json(resp: httpx.Response) -> dict[str, Any]:
     try:
         data = resp.json()

--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -571,7 +571,8 @@ class ZoteroReader:
             "SELECT i.itemID, i.key, ia.contentType, ia.path "
             "FROM itemAttachments ia "
             "JOIN items i ON ia.itemID = i.itemID "
-            "WHERE ia.parentItemID = ?",
+            "WHERE ia.parentItemID = ? "
+            "ORDER BY i.itemID",
             (parent["itemID"],),
         ).fetchall()
         attachments = []

--- a/src/zotero_cli_cc/core/rename.py
+++ b/src/zotero_cli_cc/core/rename.py
@@ -1,0 +1,180 @@
+"""Build attachment-rename plans from item metadata.
+
+Pure functions only — no SQLite, no network — so the naming rules and the
+main-vs-supplementary classification are unit-testable in isolation. The
+physical rename is executed elsewhere (the `zot-cli-bridge` plugin via
+`core/local_bridge.rename_attachment`); this module only decides *what* each
+attachment should be called.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from zotero_cli_cc.models import Attachment, Item
+
+# Tokens a template may reference. Anything else is rejected so a typo surfaces
+# as a validation error instead of a literal "{titel}" in a filename.
+_KNOWN_TOKENS = frozenset({"journal", "year", "title", "shorttitle", "author"})
+
+# Characters that are illegal in filenames on Windows / unsafe on POSIX.
+_ILLEGAL_FS = re.compile(r'[/\\:*?"<>|\x00-\x1f]')
+_HTML_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+
+# Filename markers that identify a supplementary / supporting-information PDF.
+_SUPP_WORDS = re.compile(r"supp|supporting|appendix|appendices", re.IGNORECASE)
+_SUPP_SI = re.compile(r"(?:^|[\W_])si(?:[\W_]|\d|$)", re.IGNORECASE)
+
+
+class RenameError(Exception):
+    """Raised when a rename plan cannot be built (e.g. bad template, no title)."""
+
+    def __init__(self, message: str, *, code: str = "validation_error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass
+class RenameEntry:
+    attachment_key: str
+    old_name: str
+    new_name: str
+    role: str  # "main" | "supp"
+    skip: bool = False  # True when new_name already equals old_name
+
+
+def is_pdf(att: Attachment) -> bool:
+    return att.content_type == "application/pdf" or att.filename.lower().endswith(".pdf")
+
+
+def is_supplementary(filename: str) -> bool:
+    """Heuristic: does this filename look like supplementary material?"""
+    return bool(_SUPP_WORDS.search(filename) or _SUPP_SI.search(filename))
+
+
+def _sanitize(value: str) -> str:
+    value = _HTML_TAG.sub("", value)
+    value = _ILLEGAL_FS.sub("", value)
+    return _WS.sub(" ", value).strip()
+
+
+def extract_year(item: Item) -> str:
+    """First 4-digit year found in the item's date field, else empty."""
+    m = re.search(r"\d{4}", item.date or "")
+    return m.group(0) if m else ""
+
+
+def _first_caps_abbrev(name: str) -> str:
+    """Abbreviate a venue name to the initials of its significant words.
+
+    Drops lowercase connectives, publisher prefixes (IEEE/ACM), articles, and
+    pure numbers — e.g. "IEEE Transactions on Pattern Analysis and Machine
+    Intelligence" -> "TPAMI".
+    """
+    skip = {"IEEE", "ACM", "The"}
+    initials = [w[0] for w in name.split() if w and w[0].isupper() and w not in skip and not re.search(r"\d", w)]
+    return "".join(initials)
+
+
+def journal_short(item: Item) -> str:
+    """Resolve the `{journal}` token: Jab/# tag > type-aware abbrev > 'Pre'."""
+    for tag in item.tags:
+        if tag.startswith("Jab/#") and tag[5:]:
+            return tag[5:]
+
+    extra = item.extra
+    if item.item_type == "journalArticle":
+        venue = extra.get("publicationTitle", "")
+        if "arxiv" in venue.lower():
+            return "Pre"
+        return _first_caps_abbrev(venue) or "Pre"
+    if item.item_type == "conferencePaper":
+        venue = extra.get("conferenceName") or extra.get("proceedingsTitle") or ""
+        paren = re.search(r"\(([^)]+)\)", venue)
+        if paren:
+            return paren.group(1)
+        return _first_caps_abbrev(venue) or "Pre"
+    if item.item_type == "bookSection":
+        book = extra.get("bookTitle", "")
+        for marker in ("ECCV", "ACCV"):
+            if marker in book:
+                return marker
+        return _first_caps_abbrev(book) or "Book"
+    if item.item_type == "preprint":
+        return "Pre"
+    return "Pre"
+
+
+def _tokens(item: Item) -> dict[str, str]:
+    short = item.extra.get("shortTitle") or item.title
+    author = item.creators[0].last_name if item.creators else ""
+    return {
+        "journal": journal_short(item),
+        "year": extract_year(item),
+        "title": _sanitize(item.title),
+        "shorttitle": _sanitize(short),
+        "author": _sanitize(author),
+    }
+
+
+def resolve_template(template: str, item: Item) -> str:
+    """Render a template like '{journal}_{year}_{title}' to a base filename (no extension)."""
+    used = set(re.findall(r"\{(\w+)\}", template))
+    unknown = used - _KNOWN_TOKENS
+    if unknown:
+        raise RenameError(
+            f"Unknown template token(s): {', '.join('{' + t + '}' for t in sorted(unknown))}. "
+            f"Allowed: {', '.join('{' + t + '}' for t in sorted(_KNOWN_TOKENS))}"
+        )
+    tokens = _tokens(item)
+    base = re.sub(r"\{(\w+)\}", lambda m: tokens[m.group(1)], template)
+    base = _sanitize(base)
+    if not base or base.strip("_-. ") == "":
+        raise RenameError("Template produced an empty filename (item is missing title/metadata)")
+    return base
+
+
+def classify_pdfs(attachments: list[Attachment]) -> tuple[Attachment | None, list[Attachment]]:
+    """Split PDF attachments into (main, [supplementary...]).
+
+    Main = the first non-supplementary PDF (attachments arrive in dateAdded
+    order). If every PDF looks supplementary, the earliest one is promoted to
+    main. Extra non-supplementary PDFs beyond the first are treated as
+    supplementary so their names never collide.
+    """
+    pdfs = [a for a in attachments if is_pdf(a)]
+    if not pdfs:
+        return None, []
+    mains = [a for a in pdfs if not is_supplementary(a.filename)]
+    supps = [a for a in pdfs if is_supplementary(a.filename)]
+    if not mains:
+        return pdfs[0], pdfs[1:]
+    main = mains[0]
+    extra = mains[1:]
+    # Keep supps in original (dateAdded) order: merge extras with keyword-supps.
+    ordered_supps = [a for a in pdfs if a is not main and (a in extra or a in supps)]
+    return main, ordered_supps
+
+
+def build_plan(
+    item: Item,
+    attachments: list[Attachment],
+    *,
+    template: str = "{journal}_{year}_{title}",
+    include_supp: bool = True,
+) -> list[RenameEntry]:
+    """Compute the rename plan for one item's PDF attachments."""
+    base = resolve_template(template, item)
+    main, supps = classify_pdfs(attachments)
+    plan: list[RenameEntry] = []
+    if main is not None:
+        new_name = f"{base}.pdf"
+        plan.append(RenameEntry(main.key, main.filename, new_name, "main", skip=new_name == main.filename))
+    if include_supp:
+        for i, supp in enumerate(supps):
+            suffix = "_SI" if i == 0 else f"_SI{i + 1}"
+            new_name = f"{base}{suffix}.pdf"
+            plan.append(RenameEntry(supp.key, supp.filename, new_name, "supp", skip=new_name == supp.filename))
+    return plan

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.4.0"
+SCHEMA_VERSION = "1.5.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,265 @@
+"""Tests for `zot rename` — naming/classification logic and the CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from zotero_cli_cc.cli import main
+from zotero_cli_cc.core.local_bridge import LocalBridgeError
+from zotero_cli_cc.core.rename import (
+    RenameError,
+    build_plan,
+    classify_pdfs,
+    extract_year,
+    is_pdf,
+    is_supplementary,
+    journal_short,
+    resolve_template,
+)
+from zotero_cli_cc.models import Attachment, Creator, Item
+
+
+def _item(*, item_type="journalArticle", title="A Title", date="2016-05-01", tags=None, creators=None, **extra) -> Item:
+    return Item(
+        key="ITEM0001",
+        item_type=item_type,
+        title=title,
+        creators=creators or [],
+        abstract=None,
+        date=date,
+        url=None,
+        doi=None,
+        tags=tags or [],
+        collections=[],
+        date_added="2020-01-01",
+        date_modified="2020-01-01",
+        extra=extra,
+    )
+
+
+def _att(key: str, filename: str, content_type: str = "application/pdf") -> Attachment:
+    return Attachment(key=key, parent_key="ITEM0001", filename=filename, content_type=content_type)
+
+
+# ---------------------------------------------------------------------------
+# naming
+# ---------------------------------------------------------------------------
+
+
+class TestJournalShort:
+    def test_jab_tag_wins(self):
+        item = _item(tags=["Jab/#TOG"], publicationTitle="ACM Transactions on Graphics")
+        assert journal_short(item) == "TOG"
+
+    def test_journal_article_abbrev(self):
+        item = _item(publicationTitle="IEEE Transactions on Pattern Analysis and Machine Intelligence")
+        assert journal_short(item) == "TPAMI"
+
+    def test_arxiv_is_preprint(self):
+        item = _item(publicationTitle="arXiv:1706.03762")
+        assert journal_short(item) == "Pre"
+
+    def test_conference_paren_abbrev(self):
+        item = _item(item_type="conferencePaper", conferenceName="Conference on Computer Vision (CVPR)")
+        assert journal_short(item) == "CVPR"
+
+    def test_book_section_eccv(self):
+        item = _item(item_type="bookSection", bookTitle="Computer Vision - ECCV 2020")
+        assert journal_short(item) == "ECCV"
+
+    def test_preprint_type(self):
+        assert journal_short(_item(item_type="preprint")) == "Pre"
+
+    def test_unknown_falls_back(self):
+        assert journal_short(_item(item_type="thesis")) == "Pre"
+
+
+class TestYearAndTemplate:
+    def test_extract_year(self):
+        assert extract_year(_item(date="2016-05-01")) == "2016"
+        assert extract_year(_item(date=None)) == ""
+
+    def test_default_template(self):
+        item = _item(publicationTitle="IEEE Transactions on Pattern Analysis and Machine Intelligence", title="Go-ICP")
+        assert resolve_template("{journal}_{year}_{title}", item) == "TPAMI_2016_Go-ICP"
+
+    def test_unknown_token_rejected(self):
+        with pytest.raises(RenameError):
+            resolve_template("{journal}_{foo}", _item())
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(RenameError):
+            resolve_template("{title}", _item(title=""))
+
+    def test_author_and_shorttitle_tokens(self):
+        item = _item(creators=[Creator("Kaiming", "He", "author")], shortTitle="ResNet")
+        assert resolve_template("{author}_{shorttitle}", item) == "He_ResNet"
+
+
+# ---------------------------------------------------------------------------
+# classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_is_pdf_and_filters_excel(self):
+        assert is_pdf(_att("A", "x.pdf"))
+        assert not is_pdf(_att("B", "data.xlsx", "application/vnd.ms-excel"))
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("paper_supp.pdf", True),
+            ("supplementary.pdf", True),
+            ("main_SI.pdf", True),
+            ("appendix.pdf", True),
+            ("vision.pdf", False),
+            ("paper.pdf", False),
+        ],
+    )
+    def test_is_supplementary(self, name, expected):
+        assert is_supplementary(name) is expected
+
+    def test_main_and_supp_split(self):
+        atts = [_att("A", "paper.pdf"), _att("B", "paper_supp.pdf"), _att("C", "data.xlsx", "application/vnd.ms-excel")]
+        main, supps = classify_pdfs(atts)
+        assert main is not None and main.key == "A"
+        assert [s.key for s in supps] == ["B"]
+
+    def test_all_supp_promotes_first(self):
+        atts = [_att("A", "a_supp.pdf"), _att("B", "b_supp.pdf")]
+        main, supps = classify_pdfs(atts)
+        assert main.key == "A"
+        assert [s.key for s in supps] == ["B"]
+
+    def test_multiple_non_supp_first_is_main(self):
+        atts = [_att("A", "a.pdf"), _att("B", "b.pdf")]
+        main, supps = classify_pdfs(atts)
+        assert main.key == "A"
+        assert [s.key for s in supps] == ["B"]
+
+    def test_no_pdfs(self):
+        main, supps = classify_pdfs([_att("A", "data.xlsx", "application/vnd.ms-excel")])
+        assert main is None and supps == []
+
+
+# ---------------------------------------------------------------------------
+# build_plan
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlan:
+    def _item_tpami(self):
+        return _item(publicationTitle="IEEE Transactions on Pattern Analysis and Machine Intelligence", title="Go-ICP")
+
+    def test_main_plus_supp_suffix(self):
+        atts = [_att("A", "paper.pdf"), _att("B", "supp.pdf"), _att("C", "supp2.pdf")]
+        plan = build_plan(self._item_tpami(), atts)
+        assert [(e.role, e.new_name) for e in plan] == [
+            ("main", "TPAMI_2016_Go-ICP.pdf"),
+            ("supp", "TPAMI_2016_Go-ICP_SI.pdf"),
+            ("supp", "TPAMI_2016_Go-ICP_SI2.pdf"),
+        ]
+
+    def test_main_only(self):
+        atts = [_att("A", "paper.pdf"), _att("B", "supp.pdf")]
+        plan = build_plan(self._item_tpami(), atts, include_supp=False)
+        assert len(plan) == 1 and plan[0].role == "main"
+
+    def test_skip_when_unchanged(self):
+        atts = [_att("A", "TPAMI_2016_Go-ICP.pdf")]
+        plan = build_plan(self._item_tpami(), atts)
+        assert plan[0].skip is True
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _invoke(args, test_db_path: Path, json_out=False):
+    runner = CliRunner()
+    base = ["--json"] if json_out else []
+    env = {"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"}
+    return runner.invoke(main, base + args, env=env)
+
+
+class TestRenameCLI:
+    def test_dry_run_reads_db(self, test_db_path):
+        result = _invoke(["rename", "ATTN001", "--dry-run"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["renamed_count"] == 0
+        renames = data["results"][0]["renames"]
+        assert renames[0]["status"] == "dry-run"
+        assert renames[0]["new_name"].endswith(".pdf")
+
+    def test_dry_run_main_and_supp(self, test_db_path):
+        result = _invoke(["rename", "BILI011", "--dry-run"], test_db_path, json_out=True)
+        data = json.loads(result.output)["data"]
+        roles = [r["role"] for r in data["results"][0]["renames"]]
+        assert "main" in roles and "supp" in roles
+
+    def test_main_only_flag(self, test_db_path):
+        result = _invoke(["rename", "BILI011", "--dry-run", "--main-only"], test_db_path, json_out=True)
+        data = json.loads(result.output)["data"]
+        roles = [r["role"] for r in data["results"][0]["renames"]]
+        assert roles == ["main"]
+
+    def test_attachment_without_name_errors(self, test_db_path):
+        result = _invoke(["rename", "--attachment", "ATT1"], test_db_path)
+        assert result.exit_code == 3
+
+    def test_no_keys_errors(self, test_db_path):
+        result = _invoke(["rename"], test_db_path)
+        assert result.exit_code == 3
+
+    def test_explicit_rename(self, test_db_path, monkeypatch):
+        called = {}
+
+        def fake_rename(att, name, **kw):
+            called["att"] = att
+            called["name"] = name
+            return {"renamed": True, "old_name": "old.pdf", "new_name": name}
+
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.rename_attachment", fake_rename)
+        result = _invoke(["rename", "--attachment", "ATT1", "--name", "X.pdf"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        assert called == {"att": "ATT1", "name": "X.pdf"}
+        data = json.loads(result.output)["data"]
+        assert data["renamed_count"] == 1
+
+    def test_not_reachable_aborts(self, test_db_path, monkeypatch):
+        def boom(*a, **k):
+            raise LocalBridgeError("down", code="not_reachable", retryable=True)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.ping", boom)
+        result = _invoke(["rename", "ATTN001"], test_db_path)
+        assert result.exit_code == 5
+
+    def test_bridge_missing_aborts(self, test_db_path, monkeypatch):
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.ping", lambda *a, **k: {"bridge_version": "0.1.0"})
+
+        def boom(*a, **k):
+            raise LocalBridgeError("no endpoint", code="bridge_missing", retryable=False)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.rename_attachment", boom)
+        result = _invoke(["rename", "ATTN001"], test_db_path)
+        assert result.exit_code == 3
+
+    def test_conflict_recorded_inline(self, test_db_path, monkeypatch):
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.ping", lambda *a, **k: {"bridge_version": "0.2.0"})
+
+        def conflict(*a, **k):
+            raise LocalBridgeError("exists", code="conflict", retryable=False)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.rename.rename_attachment", conflict)
+        result = _invoke(["rename", "ATTN001"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        statuses = [r["status"] for r in data["results"][0]["renames"]]
+        assert "error" in statuses


### PR DESCRIPTION
## Summary

Adds `zot rename` — rename an item's PDF attachment files from its metadata, inspired by [Theigrams/zotero-pdf-custom-rename](https://github.com/Theigrams/zotero-pdf-custom-rename) but agent-native and able to distinguish file types and main-vs-supplementary PDFs.

- **Default template** `{journal}_{year}_{title}` (tokens: `{journal} {year} {title} {shorttitle} {author}`). `{journal}` resolves from a `Jab/#` tag, else an item-type-aware abbreviation (journalArticle→initials, conferencePaper→parenthetical/initials, bookSection→ECCV/ACCV/Book), with arXiv/preprints → `Pre`.
- **Distinguishes file types**: filtered to PDFs by content type, so Excel/Word/web snapshots are skipped.
- **Distinguishes main vs supplementary PDFs**: supplementary files are detected by filename keywords (`supp`, `supplement`, `supporting`, `appendix`, a standalone `si`); the main PDF takes the template name and each supplementary one gets `_SI` / `_SI2` so names never collide. (The reference plugin just renamed the first PDF, which collides on multi-PDF items.)
- Flags: `--dry-run` (preview old→new), `--main-only`, `--force`, `--template`, and `--attachment/--name` for an explicit single-file rename.

## How it works

Renaming a *stored* attachment file is a desktop operation (the Web API can't rename it without desyncing; writing SQLite directly is forbidden). So selection + name-building happen in Python from SQLite metadata, and the actual rename goes through the **same bridge plugin as `find-pdf`** via a new `POST /zot-cli/rename` endpoint calling `renameAttachmentFile()`.

- Bridge plugin bumped **0.1.0 → 0.2.0** — users must re-run `zot bridge install`; `zot rename` reports `bridge_missing` against an older bridge.
- `meta.schema_version` bumped **1.4.0 → 1.5.0**.
- Naming + classification are pure functions in `core/rename.py` (fully unit-tested).
- **MCP**: not mirrored — consistent with `find-pdf`/`bridge`, which are also CLI-only (the bridge commands aren't exposed over MCP).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pytest tests/` — 654 passed, 1 skipped (35 new in `tests/test_rename.py`)
- [x] Manual dry-run against the fixture DB across journalArticle / preprint / multi-PDF items
- [ ] Live end-to-end rename against Zotero desktop with the v0.2.0 bridge (needs a desktop install)