### PR TITLE
feat(enrich): write journal metrics into Extra (source-neutral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `zot enrich KEY...` writes journal metrics (impact factor, JCR/CAS quartile,
+  core-journal flags, …) into an item's Extra field. Deliberately
+  **source-neutral**: values come from inline `--set "Label=value"` flags or a
+  user-maintained `--from-map` TOML table (matched by journal name) — `zot`
+  ships no journal data and calls no third-party API, so it stays independent of
+  any external product. Metrics are written in a `<!-- zot:metrics -->` block,
+  so re-running replaces only that block (idempotent) and preserves other Extra
+  content. Supports `--dry-run`.
 - `zot rename KEY...` renames an item's PDF attachment files from its metadata
   via the bridge plugin. The default template is `{journal}_{year}_{title}`
   (tokens `{journal} {year} {title} {shorttitle} {author}`); `{journal}` is

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -180,7 +180,7 @@ The input file may be either a full envelope or a bare `data` tree.
 Commands are grouped by risk in `zot --help`:
 
 - **Read** — `search`, `list`, `read`, `export`, `recent`, `stats`, `cite`, `pdf`, `collection list`, `tag list`, ...
-- **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `bridge` (mutates local config, not the library)
+- **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `enrich`, `bridge` (mutates local config, not the library)
 - **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`
 
 Each write or destructive command's `--help` carries a `MUTATES LIBRARY` marker. The same classification is available via `zot schema <cmd>.safety_tier`.
@@ -315,6 +315,32 @@ The envelope's `data.results[]` carries a per-attachment `status`
 (e.g. `conflict` when the destination exists — pass `--force`); a missing
 bridge or stopped desktop aborts the whole command with `bridge_missing` (3) /
 `not_reachable` (5).
+
+## Journal metrics (`zot enrich`)
+
+`zot enrich` writes journal metrics (impact factor, JCR/CAS quartile, core-journal
+flags, …) into an item's **Extra** field. It is deliberately **source-neutral**:
+the values come from the caller, never from a bundled dataset or a third-party
+API, so `zot` stays independent of any external product.
+
+```bash
+zot enrich ABCD1234 --set "SCI IF=5.8" --set "JCR=Q1" --dry-run
+zot enrich ABCD1234 EFGH5678 --from-map journals.toml   # apply a table by journal name
+zot enrich ABCD1234 --from-map journals.toml --set "JCR=Q1"   # --set overrides the map
+```
+
+- `--set "Label=value"` (repeatable) supplies metrics inline.
+- `--from-map FILE` is a TOML table of `journal name -> {metric: value}`; each item
+  is matched by its `publicationTitle` (or `conferenceName`), case-insensitively.
+- Metrics are written between `<!-- zot:metrics -->` / `<!-- /zot:metrics -->`
+  markers inside Extra (Zotero's official custom-field channel). Re-running
+  **replaces only that block**, so any other Extra content (`DOI:`, `Citation
+  Key:`, `tex.ids`, …) is preserved and re-running is idempotent.
+
+This is a plain Web-API write (no bridge), so it needs API credentials. The
+envelope's `data.results[]` carries per-item `status` (`updated` / `dry-run` /
+`error`) plus the resolved `metrics`; `data.updated_count` / `data.sync_required`
+summarize the run. Missing credentials abort with `auth_missing` (2).
 
 ## `--idempotency-key`
 

--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -43,6 +43,7 @@ zot workspace query "RLHF" --workspace my-ws  # RAG search
 | PDF section | `zot --json pdf --section SECID KEY` |
 | Fetch/attach missing PDF | `zot find-pdf KEY` (needs Zotero desktop + bridge) |
 | Rename attachment files | `zot rename KEY --dry-run` (needs bridge; preview first) |
+| Add journal metrics (IF/分区) | `zot enrich KEY --set "JCR=Q1"` or `--from-map journals.toml` |
 | Set up find-pdf bridge | `zot bridge install` |
 | Collection list | `zot --json collection list` |
 | Collection items | `zot --json collection items COLLKEY` |

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -111,6 +111,26 @@ zot rename --attachment ATTKEY --name "X.pdf"   # rename one specific file
 **Always `--dry-run` first** so the user can confirm the new names before any
 files change.
 
+## Enrich with Journal Metrics
+
+`zot enrich` writes journal metrics (impact factor, JCR/中科院 quartile,
+北大/南大核心 flags, etc.) into an item's Extra field. **Source-neutral**: you
+supply the values (inline `--set` or a `--from-map` table you maintain); `zot`
+ships no journal data and calls no third-party API. Plain Web-API write (no
+bridge); needs API credentials.
+
+```bash
+zot enrich ITEMKEY --set "SCI IF=5.8" --set "JCR=Q1" --dry-run   # preview first
+zot enrich ITEMKEY --set "中科院分区=2区"
+zot enrich ITEMKEY1 ITEMKEY2 --from-map journals.toml            # apply table by journal name
+zot enrich ITEMKEY --from-map journals.toml --set "JCR=Q1"       # --set overrides the map
+```
+
+Metrics go in a `<!-- zot:metrics -->` block in Extra; re-running replaces only
+that block (idempotent) and preserves other Extra content. The `--from-map`
+file is TOML: a `["Journal Name"]` table per journal with `"metric" = "value"`
+lines.
+
 ## Collections
 
 ```bash

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -16,6 +16,7 @@ from zotero_cli_cc.commands.completions import completions_cmd
 from zotero_cli_cc.commands.config import config_group
 from zotero_cli_cc.commands.delete import delete_cmd
 from zotero_cli_cc.commands.duplicates import duplicates_cmd
+from zotero_cli_cc.commands.enrich import enrich_cmd
 from zotero_cli_cc.commands.export import export_cmd
 from zotero_cli_cc.commands.find_pdf import find_pdf_cmd
 from zotero_cli_cc.commands.list_cmd import list_cmd
@@ -65,7 +66,7 @@ _READ_COMMANDS = {
     "schema",
     "trash",
 }
-_WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge", "rename"}
+_WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge", "rename", "enrich"}
 _DESTRUCTIVE_COMMANDS = {"delete", "update-status"}
 
 
@@ -298,6 +299,7 @@ main.add_command(duplicates_cmd, "duplicates")
 main.add_command(attach_cmd, "attach")
 main.add_command(find_pdf_cmd, "find-pdf")
 main.add_command(rename_cmd, "rename")
+main.add_command(enrich_cmd, "enrich")
 main.add_command(bridge_group, "bridge")
 main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")

--- a/src/zotero_cli_cc/commands/enrich.py
+++ b/src/zotero_cli_cc/commands/enrich.py
@@ -1,0 +1,146 @@
+"""`zot enrich <KEY>...` — write journal metrics (IF/quartile/partition/...) into an item's Extra field.
+
+Source-neutral: values come from `--set` flags or a user-maintained
+`--from-map` TOML table, never from a bundled dataset or third-party API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import click
+
+from zotero_cli_cc.config import AppConfig, get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.enrich import EnrichError, load_journal_map, merge_extra, metrics_for, parse_set_pairs
+from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
+
+_ABORT_CODES = {"auth_missing", "auth_invalid", "network_error"}
+
+
+@click.command("enrich")
+@click.argument("item_keys", nargs=-1, required=True)
+@click.option("--set", "set_pairs", multiple=True, help='Metric as "Label=value" (repeatable), e.g. --set "SCI IF=5.8"')
+@click.option(
+    "--from-map",
+    "map_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="TOML table of journal name -> {metric: value}; applied by the item's journal",
+)
+@click.option("--dry-run", is_flag=True, help="Preview the Extra changes without writing")
+@click.pass_context
+def enrich_cmd(
+    ctx: click.Context,
+    item_keys: tuple[str, ...],
+    set_pairs: tuple[str, ...],
+    map_path: Path | None,
+    dry_run: bool,
+) -> None:
+    """Write journal metrics into an item's Extra field. MUTATES LIBRARY.
+
+    Source-neutral — `zot` only writes the values you supply (inline `--set`
+    or a `--from-map` table you maintain); it ships no journal data and calls
+    no third-party API. Metrics go into a delimited `<!-- zot:metrics -->`
+    block in Extra, so re-running replaces just that block. Re-running is
+    idempotent.
+
+    \b
+    Examples:
+      zot enrich ABCD1234 --set "SCI IF=5.8" --set "JCR=Q1" --dry-run
+      zot enrich ABCD1234 --set "中科院分区=2区"
+      zot enrich ABCD1234 EFGH5678 --from-map journals.toml
+      zot enrich ABCD1234 --from-map journals.toml --set "JCR=Q1"   # --set overrides the map
+    """
+    json_out = ctx.obj.get("json", False)
+    try:
+        pairs = parse_set_pairs(set_pairs)
+        journal_map = load_journal_map(map_path) if map_path else {}
+    except EnrichError as e:
+        emit_error(e.code, str(e), output_json=json_out, context="enrich")
+
+    if not pairs and not journal_map:
+        emit_error(
+            "validation_error",
+            "Nothing to write — provide --set key=value and/or --from-map FILE",
+            output_json=json_out,
+            context="enrich",
+        )
+
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    db_path = get_data_dir(cfg) / "zotero.sqlite"
+    reader = ZoteroReader(
+        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
+    )
+
+    writer: ZoteroWriter | None = None
+    results: list[dict] = []
+    updated = 0
+    for key in item_keys:
+        item = reader.get_item(key)
+        if item is None:
+            results.append({"key": key, "error": "item not found", "code": "not_found"})
+            continue
+        metrics = metrics_for(item, journal_map, pairs)
+        if not metrics:
+            results.append({"key": key, "warning": "no metrics (journal not in map and no --set given)"})
+            continue
+        if dry_run:
+            preview = merge_extra(item.extra.get("extra", ""), metrics)
+            results.append({"key": key, "metrics": metrics, "status": "dry-run", "extra_preview": preview})
+            continue
+        if writer is None:
+            writer = _build_writer(ctx, cfg, json_out)
+        try:
+            writer.update_extra_metrics(key, metrics)
+            results.append({"key": key, "metrics": metrics, "status": "updated"})
+            updated += 1
+        except ZoteroWriteError as e:
+            if e.code in _ABORT_CODES:
+                emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, context="enrich")
+            results.append({"key": key, "status": "error", "error": str(e), "code": e.code})
+
+    _emit(json_out, results, updated=updated, dry_run=dry_run)
+
+
+def _build_writer(ctx: click.Context, cfg: AppConfig, json_out: bool) -> ZoteroWriter:
+    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
+    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
+    library_type = ctx.obj.get("library_type", "user")
+    if library_type == "group" and ctx.obj.get("group_id"):
+        library_id = ctx.obj["group_id"]
+    if not library_id or not api_key:
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
+            output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="enrich",
+        )
+    return ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+
+
+def _emit(json_out: bool, results: list[dict], *, updated: int, dry_run: bool) -> None:
+    data = {"results": results, "updated_count": updated, "sync_required": updated > 0}
+    env = envelope_ok(data, extra={"dry_run": True} if dry_run else None)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        return
+    for item in results:
+        click.echo(f"{item['key']}:")
+        if item.get("error"):
+            click.echo(f"  error: {item['error']}", err=True)
+        elif item.get("warning"):
+            click.echo(f"  {item['warning']}", err=True)
+        else:
+            for k, v in item.get("metrics", {}).items():
+                click.echo(f"  {k}: {v}")
+            click.echo(f"  ({item['status']})")
+    if dry_run:
+        click.echo("[dry-run] no items changed", err=True)
+    elif updated:
+        click.echo(SYNC_REMINDER, err=True)

--- a/src/zotero_cli_cc/commands/schema.py
+++ b/src/zotero_cli_cc/commands/schema.py
@@ -72,6 +72,7 @@ _SAFETY_TIER: dict[str, str] = {
     "find-pdf": "write",
     "bridge": "write",
     "rename": "write",
+    "enrich": "write",
     # destructive
     "delete": "destructive",
     "update-status": "destructive",

--- a/src/zotero_cli_cc/core/enrich.py
+++ b/src/zotero_cli_cc/core/enrich.py
@@ -1,0 +1,96 @@
+"""Resolve and merge journal-metric values into an item's Extra field.
+
+Source-neutral by design: the values come from the caller — inline `--set`
+pairs or a user-maintained `--from-map` TOML table — never from a bundled
+dataset or a third-party API. `zot` provides the *mechanism* (writing labeled
+metrics into Zotero's Extra field, the official custom-field channel); the
+*data* stays the user's responsibility, so the tool isn't coupled to any
+external product.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+from zotero_cli_cc.models import Item
+
+# Delimiters for the zot-managed region inside the Extra field. Re-running
+# enrich replaces only the text between these markers, leaving any other Extra
+# content (DOI:, Citation Key:, tex.ids, etc.) untouched.
+BLOCK_START = "<!-- zot:metrics -->"
+BLOCK_END = "<!-- /zot:metrics -->"
+
+
+class EnrichError(Exception):
+    """Raised on bad `--set` input or an unreadable `--from-map` file."""
+
+    def __init__(self, message: str, *, code: str = "validation_error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def parse_set_pairs(pairs: tuple[str, ...]) -> dict[str, str]:
+    """Parse `--set "Label=value"` pairs into an ordered dict."""
+    out: dict[str, str] = {}
+    for p in pairs:
+        if "=" not in p:
+            raise EnrichError(f"--set must be 'key=value', got: {p!r}")
+        k, v = p.split("=", 1)
+        k = k.strip()
+        if not k:
+            raise EnrichError(f"--set has an empty key: {p!r}")
+        out[k] = v.strip()
+    return out
+
+
+def load_journal_map(path: Path) -> dict[str, dict[str, str]]:
+    """Load a TOML table of `journal name -> {metric: value}`.
+
+    Keys are lower-cased for case-insensitive journal lookup. Example file:
+
+        ["Bioinformatics"]
+        "SCI IF" = "5.8"
+        "JCR" = "Q1"
+    """
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        raise EnrichError(f"Cannot read journal map {path}: {e}") from e
+    out: dict[str, dict[str, str]] = {}
+    for journal, metrics in data.items():
+        if isinstance(metrics, dict):
+            out[journal.strip().lower()] = {str(k): str(v) for k, v in metrics.items()}
+    return out
+
+
+def journal_of(item: Item) -> str:
+    """The journal/venue name used to look an item up in a `--from-map` table."""
+    if item.item_type == "conferencePaper":
+        return item.extra.get("conferenceName") or item.extra.get("proceedingsTitle") or ""
+    return item.extra.get("publicationTitle", "")
+
+
+def metrics_for(item: Item, journal_map: dict[str, dict[str, str]], set_pairs: dict[str, str]) -> dict[str, str]:
+    """Resolve the metrics to write for one item: map lookup, then `--set` overrides."""
+    metrics: dict[str, str] = {}
+    if journal_map:
+        name = journal_of(item).strip().lower()
+        if name and name in journal_map:
+            metrics.update(journal_map[name])
+    metrics.update(set_pairs)
+    return metrics
+
+
+def merge_extra(existing: str, metrics: dict[str, str]) -> str:
+    """Insert/replace the zot-managed metrics block in an Extra field value."""
+    block = "\n".join([BLOCK_START, *(f"{k}: {v}" for k, v in metrics.items()), BLOCK_END])
+    existing = existing or ""
+    if BLOCK_START in existing and BLOCK_END in existing:
+        before = existing.split(BLOCK_START, 1)[0].rstrip("\n")
+        after = existing.split(BLOCK_END, 1)[1].lstrip("\n")
+        base = "\n".join(p for p in (before, after) if p)
+    else:
+        base = existing.rstrip("\n")
+    return f"{base}\n{block}" if base else block

--- a/src/zotero_cli_cc/core/enrich.py
+++ b/src/zotero_cli_cc/core/enrich.py
@@ -10,9 +10,16 @@ external product.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
 
 from zotero_cli_cc.models import Item
 

--- a/src/zotero_cli_cc/core/writer.py
+++ b/src/zotero_cli_cc/core/writer.py
@@ -148,6 +148,28 @@ class ZoteroWriter:
         except PyZoteroError as e:
             raise _friendly_api_error(e) from e
 
+    def update_extra_metrics(self, key: str, metrics: dict[str, str]) -> str:
+        """Merge metrics into the item's Extra managed block via the Web API.
+
+        Reads the current Extra from the live item (authoritative for the
+        version check), replaces only the zot-managed block, and returns the
+        new Extra value.
+        """
+        from zotero_cli_cc.core.enrich import merge_extra
+
+        try:
+            item = self._zot.item(key)
+            new_extra = merge_extra(item["data"].get("extra", ""), metrics)
+            item["data"]["extra"] = new_extra
+            self._zot.update_item(item)
+            return new_extra
+        except ResourceNotFoundError:
+            raise ZoteroWriteError(f"Item '{key}' not found", code="not_found", retryable=False)
+        except (HttpxConnectError, HttpxTimeoutException) as e:
+            raise ZoteroWriteError(f"Network error: {e}", code="network_error", retryable=True) from e
+        except PyZoteroError as e:
+            raise _friendly_api_error(e) from e
+
     def restore_from_trash(self, key: str) -> None:
         """Restore an item from trash by clearing its deleted flag."""
         try:

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,0 +1,188 @@
+"""Tests for `zot enrich` — Extra-merge logic and the CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from zotero_cli_cc.cli import main
+from zotero_cli_cc.core.enrich import (
+    BLOCK_END,
+    BLOCK_START,
+    EnrichError,
+    journal_of,
+    load_journal_map,
+    merge_extra,
+    metrics_for,
+    parse_set_pairs,
+)
+from zotero_cli_cc.models import Item
+
+
+def _item(*, item_type="journalArticle", **extra) -> Item:
+    return Item(
+        key="ITEM0001",
+        item_type=item_type,
+        title="A Title",
+        creators=[],
+        abstract=None,
+        date="2016",
+        url=None,
+        doi=None,
+        tags=[],
+        collections=[],
+        date_added="2020-01-01",
+        date_modified="2020-01-01",
+        extra=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# pure logic
+# ---------------------------------------------------------------------------
+
+
+class TestParseSet:
+    def test_basic(self):
+        assert parse_set_pairs(("SCI IF=5.8", "JCR=Q1")) == {"SCI IF": "5.8", "JCR": "Q1"}
+
+    def test_value_with_equals(self):
+        assert parse_set_pairs(("note=a=b",)) == {"note": "a=b"}
+
+    def test_missing_equals_raises(self):
+        with pytest.raises(EnrichError):
+            parse_set_pairs(("bad",))
+
+    def test_empty_key_raises(self):
+        with pytest.raises(EnrichError):
+            parse_set_pairs(("=v",))
+
+
+class TestJournalMap:
+    def test_load_and_lookup(self, tmp_path: Path):
+        p = tmp_path / "j.toml"
+        p.write_text('["Bioinformatics"]\n"SCI IF" = 5.8\n"JCR" = "Q1"\n', encoding="utf-8")
+        m = load_journal_map(p)
+        assert m["bioinformatics"] == {"SCI IF": "5.8", "JCR": "Q1"}
+
+    def test_bad_file_raises(self, tmp_path: Path):
+        p = tmp_path / "bad.toml"
+        p.write_text("not = = valid", encoding="utf-8")
+        with pytest.raises(EnrichError):
+            load_journal_map(p)
+
+
+class TestJournalOf:
+    def test_journal_article(self):
+        assert journal_of(_item(publicationTitle="Nature")) == "Nature"
+
+    def test_conference(self):
+        assert journal_of(_item(item_type="conferencePaper", conferenceName="CVPR")) == "CVPR"
+
+
+class TestMetricsFor:
+    def test_map_lookup_case_insensitive(self):
+        item = _item(publicationTitle="Nature")
+        m = metrics_for(item, {"nature": {"JCR": "Q1"}}, {})
+        assert m == {"JCR": "Q1"}
+
+    def test_set_overrides_map(self):
+        item = _item(publicationTitle="Nature")
+        m = metrics_for(item, {"nature": {"JCR": "Q1"}}, {"JCR": "Q2"})
+        assert m == {"JCR": "Q2"}
+
+    def test_no_match_returns_set_only(self):
+        item = _item(publicationTitle="Unknown")
+        assert metrics_for(item, {"nature": {"JCR": "Q1"}}, {"IF": "1"}) == {"IF": "1"}
+
+    def test_empty(self):
+        assert metrics_for(_item(publicationTitle="Nature"), {}, {}) == {}
+
+
+class TestMergeExtra:
+    def test_empty_existing(self):
+        out = merge_extra("", {"IF": "5"})
+        assert out == f"{BLOCK_START}\nIF: 5\n{BLOCK_END}"
+
+    def test_appends_preserving_existing(self):
+        out = merge_extra("DOI: 10.x", {"IF": "5"})
+        assert out.startswith("DOI: 10.x\n")
+        assert "IF: 5" in out
+
+    def test_replaces_block_idempotent(self):
+        first = merge_extra("DOI: 10.x", {"IF": "5"})
+        second = merge_extra(first, {"IF": "5"})
+        assert first == second  # re-running is a no-op
+
+    def test_replaces_block_updates_values(self):
+        first = merge_extra("DOI: 10.x", {"IF": "5"})
+        updated = merge_extra(first, {"IF": "6"})
+        assert "DOI: 10.x" in updated
+        assert "IF: 6" in updated
+        assert "IF: 5" not in updated
+        assert updated.count(BLOCK_START) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _invoke(args, test_db_path: Path, json_out=False, env_extra=None):
+    runner = CliRunner()
+    base = ["--json"] if json_out else []
+    env = {"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"}
+    if env_extra:
+        env.update(env_extra)
+    return runner.invoke(main, base + args, env=env)
+
+
+class TestEnrichCLI:
+    def test_dry_run_set(self, test_db_path):
+        result = _invoke(["enrich", "ATTN001", "--set", "SCI IF=5.8", "--dry-run"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["updated_count"] == 0
+        r = data["results"][0]
+        assert r["status"] == "dry-run"
+        assert BLOCK_START in r["extra_preview"]
+        assert "SCI IF: 5.8" in r["extra_preview"]
+
+    def test_nothing_to_write_errors(self, test_db_path):
+        result = _invoke(["enrich", "ATTN001"], test_db_path)
+        assert result.exit_code == 3
+
+    def test_bad_set_errors(self, test_db_path):
+        result = _invoke(["enrich", "ATTN001", "--set", "bad"], test_db_path)
+        assert result.exit_code == 3
+
+    def test_item_not_found_recorded(self, test_db_path):
+        result = _invoke(["enrich", "NOPE9999", "--set", "IF=5", "--dry-run"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        assert json.loads(result.output)["data"]["results"][0]["code"] == "not_found"
+
+    def test_write_with_mocked_writer(self, test_db_path, monkeypatch):
+        calls = {}
+
+        class FakeWriter:
+            def update_extra_metrics(self, key, metrics):
+                calls[key] = metrics
+                return "merged"
+
+        monkeypatch.setattr("zotero_cli_cc.commands.enrich._build_writer", lambda *a, **k: FakeWriter())
+        result = _invoke(["enrich", "ATTN001", "--set", "JCR=Q1"], test_db_path, json_out=True)
+        assert result.exit_code == 0
+        assert calls == {"ATTN001": {"JCR": "Q1"}}
+        assert json.loads(result.output)["data"]["updated_count"] == 1
+
+    def test_auth_missing_aborts(self, test_db_path):
+        # Non-dry-run without credentials configured -> auth_missing (exit 2).
+        result = _invoke(
+            ["enrich", "ATTN001", "--set", "JCR=Q1"],
+            test_db_path,
+            env_extra={"ZOT_API_KEY": "", "ZOT_LIBRARY_ID": ""},
+        )
+        assert result.exit_code == 2


### PR DESCRIPTION
## Summary

Adds `zot enrich` — write journal metrics (impact factor, JCR/中科院 quartile, 北大/南大核心 flags, etc.) into an item's **Extra** field.

Inspired by the discussion around journal-ranking plugins (e.g. Green Frog / easyScholar), but deliberately **source-neutral**: `zot` provides only the *mechanism* (writing labeled metrics into Zotero's Extra field — its official custom-field channel). The *data* comes from the caller, so the project is **not coupled to any third-party commercial product or API**, ships no bundled dataset, and needs no API key.

```bash
zot enrich ABCD1234 --set "SCI IF=5.8" --set "JCR=Q1" --dry-run
zot enrich ABCD1234 --set "中科院分区=2区"
zot enrich ABCD1234 EFGH5678 --from-map journals.toml          # apply a table by journal name
zot enrich ABCD1234 --from-map journals.toml --set "JCR=Q1"    # --set overrides the map
```

- `--set "Label=value"` (repeatable) — inline values.
- `--from-map FILE` — a TOML table of `journal name -> {metric: value}` you maintain; items are matched by `publicationTitle` / `conferenceName`, case-insensitively.
- Values are written between `<!-- zot:metrics -->` markers in Extra; re-running **replaces only that block**, preserving other Extra content (`DOI:`, `Citation Key:`, `tex.ids`, …) and making re-runs idempotent.
- `--dry-run` previews the merged Extra.

## Design notes

- Plain Web-API write (no bridge); writes via the new `writer.update_extra_metrics`, which reads the live item, merges via the pure `core/enrich.merge_extra`, and writes back. Needs API credentials (`auth_missing` aborts).
- Naming/merge/parse logic is in `core/enrich.py` as pure, unit-tested functions.
- Why source-neutral: keeps the open-source tool independent of commercial journal-data products. Users can fill the `--from-map` table from whatever source they personally have access to. An optional built-in lookup (e.g. OpenAlex, which is CC0/open like the Crossref integration already in zot) could be added later without coupling to a commercial product.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pytest tests/` — 676 passed, 1 skipped (22 new in `tests/test_enrich.py`)
- [x] Dry-run validated against the fixture DB
- [ ] Live write against a real library with API credentials (needs a configured key)