### PR TITLE
fix(rename): cleaner filenames (drop empty tokens, truncate, prefer short title)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   content. Supports `--dry-run`.
 - `zot rename KEY...` renames an item's PDF attachment files from its metadata
   via the bridge plugin. The default template is `{journal}_{year}_{title}`
-  (tokens `{journal} {year} {title} {shorttitle} {author}`); `{journal}` is
-  resolved from a `Jab/#` tag or an item-type-aware abbreviation (arXiv →
-  `Pre`). Non-PDF attachments (Excel/Word/snapshots) are filtered out by
-  content type; supplementary PDFs are detected by filename and get an `_SI`
-  suffix so names never collide. Supports `--dry-run`, `--main-only`,
+  (tokens `{journal} {year} {title} {fulltitle} {shorttitle} {author}`;
+  `{title}` prefers the Short Title field when set). `{journal}` is resolved
+  from a `Jab/#` tag or an item-type-aware abbreviation (arXiv → `Pre`,
+  single-word venues kept whole so `Nature` stays `Nature`). Empty tokens are
+  collapsed (no `Pre__x`) and names are truncated to a filesystem-safe length.
+  Non-PDF attachments (Excel/Word/snapshots) are filtered out by content type;
+  supplementary PDFs are detected by filename and get an `_SI` suffix so names
+  never collide. Supports `--dry-run`, `--main-only`,
   `--force`, `--template`, and `--attachment/--name` for explicit single-file
   renames. Requires the `zot-cli-bridge` plugin **v0.2.0+** (re-run
   `zot bridge install`). `meta.schema_version` is bumped 1.4.0 → 1.5.0.

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -303,7 +303,10 @@ zot rename --attachment ATT0001 --name "X.pdf"  # rename one file explicitly
 
 `zot` builds the new names from SQLite metadata (no network): the default
 template is `{journal}_{year}_{title}` (tokens: `{journal} {year} {title}
-{shorttitle} {author}`). Attachments are filtered to PDFs by content type, so
+{fulltitle} {shorttitle} {author}`; `{title}` prefers the Short Title field
+when set). Empty tokens are collapsed (no `Pre__x`), single-word venues keep
+the whole word (`Nature`, not `N`), and the name is truncated to a filesystem-
+safe length. Attachments are filtered to PDFs by content type, so
 Excel/Word/snapshots are skipped. Among PDFs, supplementary files are detected
 by filename keywords (`supp`, `supplement`, `supporting`, `appendix`, a
 standalone `si`); the main PDF gets the template name and each supplementary

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -94,7 +94,8 @@ installation, so the CLI cannot sideload silently).
 
 `zot rename` renames an item's PDF attachment files from its metadata. Default
 template `{journal}_{year}_{title}.pdf` (tokens: `{journal} {year} {title}
-{shorttitle} {author}`). Non-PDF files (Excel/Word/snapshots) are skipped;
+{fulltitle} {shorttitle} {author}`; `{title}` prefers Short Title when set).
+Non-PDF files (Excel/Word/snapshots) are skipped;
 supplementary PDFs are detected by filename and get an `_SI` suffix. Goes
 through the bridge plugin (needs v0.2.0+), so Zotero must be running.
 

--- a/src/zotero_cli_cc/commands/rename.py
+++ b/src/zotero_cli_cc/commands/rename.py
@@ -24,7 +24,7 @@ _ABORT_CODES = {"not_reachable", "bridge_missing"}
     "--template",
     default="{journal}_{year}_{title}",
     show_default=True,
-    help="Filename template; tokens: {journal} {year} {title} {shorttitle} {author}",
+    help="Filename template; tokens: {journal} {year} {title} (short title if set, else full) {fulltitle} {shorttitle} {author}",
 )
 @click.option("--main-only", is_flag=True, help="Rename only the main PDF (default also renames supplementary PDFs)")
 @click.option(

--- a/src/zotero_cli_cc/core/rename.py
+++ b/src/zotero_cli_cc/core/rename.py
@@ -16,12 +16,18 @@ from zotero_cli_cc.models import Attachment, Item
 
 # Tokens a template may reference. Anything else is rejected so a typo surfaces
 # as a validation error instead of a literal "{titel}" in a filename.
-_KNOWN_TOKENS = frozenset({"journal", "year", "title", "shorttitle", "author"})
+_KNOWN_TOKENS = frozenset({"journal", "year", "title", "shorttitle", "fulltitle", "author"})
 
 # Characters that are illegal in filenames on Windows / unsafe on POSIX.
 _ILLEGAL_FS = re.compile(r'[/\\:*?"<>|\x00-\x1f]')
 _HTML_TAG = re.compile(r"<[^>]+>")
 _WS = re.compile(r"\s+")
+_MULTI_SEP = re.compile(r"[_\-]{2,}")
+
+# Cap the base name so the final filename (base + optional _SI suffix + ".pdf")
+# stays well under the 255-byte limit common to ext4/APFS/NTFS — measured in
+# UTF-8 bytes so CJK titles (3 bytes/char) are also safe.
+_MAX_BASE_BYTES = 180
 
 # Filename markers that identify a supplementary / supporting-information PDF.
 _SUPP_WORDS = re.compile(r"supp|supporting|appendix|appendices", re.IGNORECASE)
@@ -60,6 +66,20 @@ def _sanitize(value: str) -> str:
     return _WS.sub(" ", value).strip()
 
 
+def _truncate_bytes(value: str, max_bytes: int) -> str:
+    """Truncate to at most `max_bytes` UTF-8 bytes, not splitting a character."""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    cut = encoded[:max_bytes]
+    while cut:
+        try:
+            return cut.decode("utf-8").rstrip()
+        except UnicodeDecodeError:
+            cut = cut[:-1]
+    return ""
+
+
 def extract_year(item: Item) -> str:
     """First 4-digit year found in the item's date field, else empty."""
     m = re.search(r"\d{4}", item.date or "")
@@ -74,8 +94,12 @@ def _first_caps_abbrev(name: str) -> str:
     Intelligence" -> "TPAMI".
     """
     skip = {"IEEE", "ACM", "The"}
-    initials = [w[0] for w in name.split() if w and w[0].isupper() and w not in skip and not re.search(r"\d", w)]
-    return "".join(initials)
+    words = [w for w in name.split() if w and w[0].isupper() and w not in skip and not re.search(r"\d", w)]
+    # A single significant word abbreviates to one useless letter (Nature -> N);
+    # keep the whole word instead. Multi-word venues use the initials (TPAMI).
+    if len(words) == 1:
+        return words[0]
+    return "".join(w[0] for w in words)
 
 
 def journal_short(item: Item) -> str:
@@ -108,13 +132,16 @@ def journal_short(item: Item) -> str:
 
 
 def _tokens(item: Item) -> dict[str, str]:
+    # `{title}` prefers the Short Title field when present (it's the human-chosen
+    # concise form, e.g. "ResNet"); `{fulltitle}` always gives the full title.
     short = item.extra.get("shortTitle") or item.title
     author = item.creators[0].last_name if item.creators else ""
     return {
         "journal": journal_short(item),
         "year": extract_year(item),
-        "title": _sanitize(item.title),
+        "title": _sanitize(short),
         "shorttitle": _sanitize(short),
+        "fulltitle": _sanitize(item.title),
         "author": _sanitize(author),
     }
 
@@ -131,9 +158,12 @@ def resolve_template(template: str, item: Item) -> str:
     tokens = _tokens(item)
     base = re.sub(r"\{(\w+)\}", lambda m: tokens[m.group(1)], template)
     base = _sanitize(base)
-    if not base or base.strip("_-. ") == "":
+    # Empty tokens (missing year/journal) leave doubled separators like
+    # "Pre__title" or a leading "_2016_x"; collapse and trim them away.
+    base = _MULTI_SEP.sub("_", base).strip("_-. ")
+    if not base:
         raise RenameError("Template produced an empty filename (item is missing title/metadata)")
-    return base
+    return _truncate_bytes(base, _MAX_BASE_BYTES).strip("_-. ")
 
 
 def classify_pdfs(attachments: list[Attachment]) -> tuple[Attachment | None, list[Attachment]]:

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -77,6 +77,10 @@ class TestJournalShort:
     def test_unknown_falls_back(self):
         assert journal_short(_item(item_type="thesis")) == "Pre"
 
+    def test_single_word_journal_kept_whole(self):
+        # "Nature" must not collapse to a useless single letter "N".
+        assert journal_short(_item(publicationTitle="Nature")) == "Nature"
+
 
 class TestYearAndTemplate:
     def test_extract_year(self):
@@ -98,6 +102,28 @@ class TestYearAndTemplate:
     def test_author_and_shorttitle_tokens(self):
         item = _item(creators=[Creator("Kaiming", "He", "author")], shortTitle="ResNet")
         assert resolve_template("{author}_{shorttitle}", item) == "He_ResNet"
+
+    def test_empty_year_collapses_separators(self):
+        # No date -> the {year} slot is empty; must not leave "TPAMI__X".
+        item = _item(
+            publicationTitle="IEEE Transactions on Pattern Analysis and Machine Intelligence",
+            title="X",
+            date=None,
+        )
+        assert resolve_template("{journal}_{year}_{title}", item) == "TPAMI_X"
+
+    def test_title_prefers_short_title(self):
+        item = _item(title="A Very Long Full Title Here", shortTitle="Short")
+        assert resolve_template("{title}", item) == "Short"
+
+    def test_fulltitle_token_uses_full(self):
+        item = _item(title="A Very Long Full Title Here", shortTitle="Short")
+        assert resolve_template("{fulltitle}", item) == "A Very Long Full Title Here"
+
+    def test_long_title_truncated_to_byte_cap(self):
+        item = _item(publicationTitle="Nature", title="word " * 100)
+        base = resolve_template("{title}", item)
+        assert len(base.encode("utf-8")) <= 180
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #51. Live dry-runs against a real library surfaced rough edges in the generated filenames; this tightens the naming logic in `core/rename.py`:

- **Drop empty tokens** — a missing `{year}`/`{journal}` left doubled separators (`Pre__title`). Runs of separators are now collapsed and trimmed → `Pre_title`.
- **Single-word venues kept whole** — `Nature` abbreviated to a useless `N`. A lone significant word is now kept as-is (`Nature`), while multi-word venues still use initials (`TPAMI`).
- **Prefer Short Title** — `{title}` now resolves to the item's Short Title when set (matching common practice), with a new `{fulltitle}` token for the full title explicitly.
- **Filesystem-safe length** — names are truncated to 180 UTF-8 bytes (CJK-aware), so long titles can't exceed the 255-byte limit (with room for `_SI`/`.pdf`).

Verified against the real items that were broken before:

```
before:  Pre__Abstract citation ID ... (200+ chars)   |  N_2026_An AI system...
after:   Pre_Abstract citation ID ... (182 bytes)      |  Nature_2026_An AI system...
```

## Test plan
- [x] `ruff` / `mypy` clean
- [x] `pytest tests/` — 681 passed, 1 skipped (5 new naming tests in `test_rename.py`)
- [x] Dry-run re-verified on the real library items that previously produced bad names
- [x] Live rename endpoint already validated end-to-end (reversible round-trip via bridge 0.2.0)