### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-05-28
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.5.0"
+version = "0.6.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "CC-BY-NC-4.0"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2104,7 +2104,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release **0.6.0**. Bumps `pyproject.toml` + `uv.lock` and promotes the CHANGELOG `[Unreleased]` section to `[0.6.0]`. Everything since v0.5.0:

### Added
- **`zot rename`** — rename PDF attachment files from item metadata via the bridge plugin; PDF-only, supplementary PDFs get an `_SI` suffix, source-side naming with clean filenames (drop empty tokens, prefer Short Title, single-word venues kept whole, length-capped) (#51, #53). Requires the `zot-cli-bridge` plugin **v0.2.0+**.
- **`zot enrich`** — write journal metrics (IF/quartile/partition/core flags) into an item's Extra field. **Source-neutral**: values come from `--set` or a user-maintained `--from-map` table; no bundled data, no third-party API, no key (#52).

(See the CHANGELOG entry for full details. `meta.schema_version` is 1.5.0.)

## Verification
- Both features verified live against real Zotero 9.0.4: `rename` via a reversible round-trip through the 0.2.0 bridge; `enrich` via a real Web-API write (existing Extra content preserved), then restored.
- `0.6.0` wheel builds and bundles the 0.2.0 bridge assets (`manifest.json` v0.2.0 + rename endpoint).

## Release steps (after merge)
- [ ] Merge this PR
- [ ] Tag `v0.6.0` on the merge commit and push → `publish.yml` builds + publishes to PyPI

## Test plan
- [x] `ruff` / `mypy` clean (the publish gate)
- [x] `uv build` → `0.6.0` wheel + sdist; wheel bundles `bridge_assets/` at v0.2.0
- [x] `uv.lock` synced to 0.6.0