### PR TITLE
feat(ask): citation-keyed evidence pack for grounded answers over a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `zot ask "QUESTION" --workspace NAME` retrieves a citation-keyed **evidence
+  pack** from a workspace's RAG index (hybrid BM25 + embedding retrieval via
+  reciprocal rank fusion) and returns it with `answer_instructions`, so the
+  calling agent can synthesize a grounded, cited answer. Unlike
+  `workspace query` (which dumps ranked chunks), each evidence entry is tagged
+  with its Zotero item key as the `cite_key` and carries per-method scores.
+  Following the same contract as `summarize`, `zot` prepares the context but
+  calls **no generative LLM** itself — the agent is the model. Options:
+  `--evidence-k` (default 12) and `--mode auto|bm25|semantic|hybrid`.
+- Schema version bumped to `1.6.0`.
+
 ## [0.6.0] - 2026-05-28
 
 ### Added

--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -52,9 +52,10 @@ zot workspace query "RLHF" --workspace my-ws  # RAG search
 | Library stats | `zot --json stats` |
 | Workspace create | `zot workspace new NAME` |
 | Workspace RAG query | `zot workspace query "q" --workspace NAME` |
+| Ask (evidence pack) | `zot --json ask "question" --workspace NAME` |
 | Group library | `zot --library group:ID search "q"` |
 
-**Rule of thumb**: `zot search` for quick metadata lookups. `zot workspace query` for deep content search over curated papers.
+**Rule of thumb**: `zot search` for quick metadata lookups. `zot workspace query` for deep content search over curated papers. `zot ask` when you need a citation-keyed evidence pack to write a grounded answer — it returns chunks tagged with their Zotero item key plus `answer_instructions`; `zot` does not call an LLM, so *you* synthesize and cite the answer from the evidence.
 
 ## Global Flags
 

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -8,6 +8,7 @@ import click
 
 from zotero_cli_cc import __version__
 from zotero_cli_cc.commands.add import add_cmd
+from zotero_cli_cc.commands.ask import ask_cmd
 from zotero_cli_cc.commands.attach import attach_cmd
 from zotero_cli_cc.commands.bridge import bridge_group
 from zotero_cli_cc.commands.cite import cite_cmd
@@ -63,6 +64,7 @@ _READ_COMMANDS = {
     "completions",
     "mcp",
     "workspace",
+    "ask",
     "schema",
     "trash",
 }
@@ -303,6 +305,7 @@ main.add_command(enrich_cmd, "enrich")
 main.add_command(bridge_group, "bridge")
 main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")
+main.add_command(ask_cmd, "ask")
 main.add_command(schema_cmd, "schema")
 
 

--- a/src/zotero_cli_cc/commands/ask.py
+++ b/src/zotero_cli_cc/commands/ask.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import click
+
+from zotero_cli_cc.config import load_embedding_config
+from zotero_cli_cc.core.rag import (
+    bm25_score_chunks,
+    build_evidence_pack,
+    embed_texts,
+    semantic_score_chunks,
+)
+from zotero_cli_cc.core.rag_index import RagIndex
+from zotero_cli_cc.core.workspace import workspace_exists, workspaces_dir
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import emit_progress, format_ask
+
+
+@click.command("ask")
+@click.argument("question")
+@click.option("--workspace", "ws_name", required=True, help="Workspace to ask against")
+@click.option("--evidence-k", default=12, help="Number of evidence chunks to retrieve (default: 12)")
+@click.option(
+    "--mode",
+    type=click.Choice(["auto", "bm25", "semantic", "hybrid"]),
+    default="auto",
+    help="Retrieval mode",
+)
+@click.pass_context
+def ask_cmd(ctx: click.Context, question: str, ws_name: str, evidence_k: int, mode: str) -> None:
+    """Retrieve a citation-keyed evidence pack to answer a question from a workspace.
+
+    Unlike `workspace query` (which dumps ranked chunks), `ask` returns evidence
+    tagged with Zotero item keys plus answer instructions, so the calling agent
+    can synthesize a grounded, cited answer. zot does not call an LLM itself.
+
+    \b
+    Examples:
+      zot ask "how does attention scale?" --workspace transformers
+      zot --json ask "what dataset was used?" --workspace papers --evidence-k 8
+    """
+    json_out = ctx.obj.get("json", False)
+    if not workspace_exists(ws_name):
+        emit_error(
+            "not_found",
+            f"Workspace '{ws_name}' not found",
+            output_json=json_out,
+            hint="Use 'zot workspace list' to see available workspaces",
+            context="ask",
+        )
+
+    idx_path = workspaces_dir() / f"{ws_name}.idx.sqlite"
+    if not idx_path.exists():
+        emit_error(
+            "not_found",
+            f"No index found for workspace '{ws_name}'",
+            output_json=json_out,
+            hint=f"Run 'zot workspace index {ws_name}' first",
+            context="ask",
+        )
+
+    idx = RagIndex(idx_path)
+    try:
+        has_emb = idx._conn.execute("SELECT 1 FROM chunks WHERE embedding IS NOT NULL LIMIT 1").fetchone() is not None
+        if mode == "auto":
+            effective_mode = "hybrid" if has_emb else "bm25"
+        else:
+            effective_mode = mode
+
+        bm25_results: list[tuple[int, float, dict]] = []
+        semantic_results: list[tuple[int, float, dict]] = []
+
+        if effective_mode in ("bm25", "hybrid"):
+            emit_progress("progress", phase="ask", step="bm25")
+            bm25_results = bm25_score_chunks(idx, question)
+
+        if effective_mode in ("semantic", "hybrid") and has_emb:
+            emb_cfg = load_embedding_config()
+            if emb_cfg.is_configured:
+                emit_progress("progress", phase="ask", step="semantic")
+                q_vecs = embed_texts([question], emb_cfg)
+                if q_vecs:
+                    semantic_results = semantic_score_chunks(idx, q_vecs[0])
+
+        evidence = build_evidence_pack(bm25_results, semantic_results, effective_mode, evidence_k)
+        click.echo(format_ask(question, evidence, effective_mode, output_json=json_out))
+    finally:
+        idx.close()

--- a/src/zotero_cli_cc/core/rag.py
+++ b/src/zotero_cli_cc/core/rag.py
@@ -318,6 +318,49 @@ def semantic_score_chunks(
     return results
 
 
+def build_evidence_pack(
+    bm25_results: list[tuple[int, float, dict]],
+    semantic_results: list[tuple[int, float, dict]],
+    mode: str,
+    k: int,
+) -> list[dict]:
+    """Merge retrieval rankings into a citation-keyed evidence list for an agent.
+
+    Each entry carries the Zotero item key as the citation anchor, the source
+    label, the full chunk text, and whichever per-method scores apply. zot does
+    not run a generative LLM — it prepares this context and the calling agent
+    does the contextual scoring and synthesis (same contract as `summarize`).
+    """
+    bm25_score = {cid: s for cid, s, _ in bm25_results}
+    sem_score = {cid: s for cid, s, _ in semantic_results}
+    used_rrf = mode == "hybrid" and bool(bm25_results) and bool(semantic_results)
+    if used_rrf:
+        merged = reciprocal_rank_fusion(bm25_results, semantic_results)
+    elif semantic_results and mode in ("semantic", "hybrid"):
+        merged = semantic_results
+    else:
+        merged = bm25_results
+
+    pack: list[dict] = []
+    for cid, score, chunk in merged[:k]:
+        scores: dict[str, float] = {}
+        if cid in bm25_score:
+            scores["bm25"] = round(bm25_score[cid], 4)
+        if cid in sem_score:
+            scores["semantic"] = round(sem_score[cid], 4)
+        if used_rrf:
+            scores["rrf"] = round(score, 4)
+        pack.append(
+            {
+                "cite_key": chunk["item_key"],
+                "source": chunk["source"],
+                "text": chunk["content"],
+                "scores": scores,
+            }
+        )
+    return pack
+
+
 def reciprocal_rank_fusion(*rankings: list[tuple[int, float, dict]], k: int = 60) -> list[tuple[int, float, dict]]:
     scores: dict[int, float] = {}
     chunk_map: dict[int, dict] = {}

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.5.0"
+SCHEMA_VERSION = "1.6.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)
@@ -359,6 +359,35 @@ def format_workspace_query(results: list, mode: str, output_json: bool = False) 
         preview = chunk["content"][:120].replace("\n", " ")
         console.print(f"[{i + 1}] Score: {score:.2f} | {chunk['item_key']} | {chunk['source']}")
         console.print(f"    {preview}...")
+    return buf.getvalue()
+
+
+ANSWER_INSTRUCTIONS = (
+    "Answer the question using ONLY the evidence below. Cite each claim with its "
+    "cite_key in parentheses, e.g. (ABCD1234). Judge each chunk for relevance and "
+    "ignore unrelated ones. If the evidence is insufficient, say so rather than guessing."
+)
+
+
+def format_ask(question: str, evidence: list[dict], mode: str, output_json: bool = False) -> str:
+    data = {
+        "question": question,
+        "mode": mode,
+        "evidence": evidence,
+        "answer_instructions": ANSWER_INSTRUCTIONS,
+    }
+    if output_json:
+        return _dump(envelope_ok(data, meta={"retrieved": len(evidence)}))
+    if not evidence:
+        return "No evidence found."
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    for i, e in enumerate(evidence, 1):
+        scores = " ".join(f"{k}={v}" for k, v in e["scores"].items())
+        console.print(f"[{i}] ({e['cite_key']}) {e['source']}  {scores}")
+        preview = e["text"][:300].replace("\n", " ")
+        console.print(f"    {preview}...")
+    console.print(f"\n{ANSWER_INSTRUCTIONS}")
     return buf.getvalue()
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,132 @@
+"""Tests for `zot ask` — evidence-pack builder and the CLI command."""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from zotero_cli_cc.cli import main
+from zotero_cli_cc.core.rag import build_evidence_pack
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _chunk(cid: int, key: str) -> dict:
+    return {"id": cid, "item_key": key, "source": "metadata", "content": f"text {cid}"}
+
+
+# ---------------------------------------------------------------------------
+# build_evidence_pack
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEvidencePack:
+    def test_bm25_only(self):
+        bm25 = [(1, 7.0, _chunk(1, "A")), (2, 3.0, _chunk(2, "B"))]
+        pack = build_evidence_pack(bm25, [], "bm25", 5)
+        assert [e["cite_key"] for e in pack] == ["A", "B"]
+        assert pack[0]["scores"] == {"bm25": 7.0}
+        assert pack[0]["text"] == "text 1"
+        assert "rrf" not in pack[0]["scores"]
+
+    def test_hybrid_fuses_and_keeps_both_scores(self):
+        bm25 = [(1, 7.0, _chunk(1, "A"))]
+        sem = [(1, 0.9, _chunk(1, "A"))]
+        pack = build_evidence_pack(bm25, sem, "hybrid", 5)
+        assert pack[0]["scores"]["bm25"] == 7.0
+        assert pack[0]["scores"]["semantic"] == 0.9
+        assert "rrf" in pack[0]["scores"]
+
+    def test_semantic_only(self):
+        sem = [(1, 0.5, _chunk(1, "A"))]
+        pack = build_evidence_pack([], sem, "semantic", 5)
+        assert pack[0]["scores"] == {"semantic": 0.5}
+
+    def test_respects_k(self):
+        bm25 = [(i, float(10 - i), _chunk(i, f"K{i}")) for i in range(5)]
+        pack = build_evidence_pack(bm25, [], "bm25", 2)
+        assert len(pack) == 2
+
+    def test_empty(self):
+        assert build_evidence_pack([], [], "hybrid", 5) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _invoke(args: list[str], json_output: bool = False):
+    runner = CliRunner()
+    base = ["--json"] if json_output else []
+    env = {"ZOT_DATA_DIR": str(FIXTURES_DIR), "ZOT_FORMAT": "table"}
+    return runner.invoke(main, base + args, env=env)
+
+
+def _envelope(output: str) -> dict:
+    """`ask` emits NDJSON progress events before the final pretty-printed
+    envelope; parse the trailing JSON document."""
+    start = output.rfind("\n{\n")
+    text = output[start + 1 :] if start >= 0 else output
+    return json.loads(text)
+
+
+def _patch_ws_dir(tmp_path):
+    stack = ExitStack()
+    stack.enter_context(patch("zotero_cli_cc.core.workspace.workspaces_dir", return_value=tmp_path))
+    stack.enter_context(patch("zotero_cli_cc.commands.workspace.workspaces_dir", return_value=tmp_path))
+    stack.enter_context(patch("zotero_cli_cc.commands.ask.workspaces_dir", return_value=tmp_path))
+    return stack
+
+
+class TestAskCLI:
+    def test_ask_table(self, tmp_path):
+        with _patch_ws_dir(tmp_path):
+            _invoke(["workspace", "new", "test-ask"])
+            _invoke(["workspace", "add", "test-ask", "ATTN001"])
+            _invoke(["workspace", "index", "test-ask"])
+            result = _invoke(["ask", "attention", "--workspace", "test-ask"])
+        assert result.exit_code == 0
+        assert "ATTN001" in result.output
+        assert "cite_key" in result.output or "ABCD1234" in result.output
+
+    def test_ask_json_envelope(self, tmp_path):
+        with _patch_ws_dir(tmp_path):
+            _invoke(["workspace", "new", "test-ask"])
+            _invoke(["workspace", "add", "test-ask", "ATTN001"])
+            _invoke(["workspace", "index", "test-ask"])
+            result = _invoke(["ask", "attention", "--workspace", "test-ask"], json_output=True)
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        data = env["data"]
+        assert data["question"] == "attention"
+        assert "answer_instructions" in data
+        assert isinstance(data["evidence"], list) and len(data["evidence"]) > 0
+        assert "cite_key" in data["evidence"][0]
+        assert env["meta"]["retrieved"] == len(data["evidence"])
+
+    def test_ask_evidence_k_caps(self, tmp_path):
+        with _patch_ws_dir(tmp_path):
+            _invoke(["workspace", "new", "test-ask"])
+            _invoke(["workspace", "add", "test-ask", "ATTN001"])
+            _invoke(["workspace", "index", "test-ask"])
+            result = _invoke(["ask", "attention", "--workspace", "test-ask", "--evidence-k", "1"], json_output=True)
+        data = _envelope(result.output)["data"]
+        assert len(data["evidence"]) <= 1
+
+    def test_ask_no_index(self, tmp_path):
+        with _patch_ws_dir(tmp_path):
+            _invoke(["workspace", "new", "test-ask"])
+            result = _invoke(["ask", "x", "--workspace", "test-ask"])
+        assert result.exit_code == 4
+        assert "index" in result.output.lower()
+
+    def test_ask_nonexistent_workspace(self, tmp_path):
+        with _patch_ws_dir(tmp_path):
+            result = _invoke(["ask", "x", "--workspace", "nope"])
+        assert result.exit_code == 4
+        assert "not found" in result.output.lower()


### PR DESCRIPTION
## What

Adds a top-level `zot ask` command — the answer-grounding layer borrowed (in agent-native form) from paper-qa.

```
zot ask "how does attention scale?" --workspace transformers [--evidence-k 12] [--mode auto|bm25|semantic|hybrid]
```

It reuses the existing hybrid retrieval (`bm25_score_chunks` + `semantic_score_chunks` + reciprocal rank fusion) and, instead of dumping ranked chunks like `workspace query`, returns an **evidence pack**: each chunk tagged with its Zotero item key as `cite_key`, per-method scores, and an `answer_instructions` string.

## Design note — no LLM in the tool

paper-qa's RCS + map-reduce answering need a generative LLM *inside* the tool. `zot` deliberately never calls a chat model (the only AI dep is the embedding client); `summarize` already follows the contract "`zot` prepares context, the agent reasons." `ask` keeps that contract: the calling agent (Claude) does the contextual relevance judgment and synthesis. This avoids adding chat-model config/keys/deps and avoids duplicating the agent that's already calling `zot`.

## Changes

- `core/rag.py`: `build_evidence_pack()` — merges rankings, keeps per-method scores.
- `commands/ask.py`: the command (tier: **read**).
- `formatter.py`: `format_ask()` + `ANSWER_INSTRUCTIONS`; `SCHEMA_VERSION` → `1.6.0`.
- `cli.py`: register + `_READ_COMMANDS`.
- Docs: SKILL.md; CHANGELOG `[Unreleased]`.

## Tests

`tests/test_ask.py` (10): `build_evidence_pack` unit tests + CLI (table/JSON envelope, `--evidence-k`, not-found exit codes). Full suite: 691 passed, 1 skipped. ruff + mypy clean; agent-interface drift test passes.