### PR TITLE
feat(pdf): default to permissive pdfium extractor; pymupdf becomes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Default PDF extractor is now `pdfium`** (pypdfium2, BSD/Apache-licensed)
+  instead of `pymupdf`. PyMuPDF is AGPL/Artifex-licensed, so it is no longer a
+  core dependency — a plain `pip install zotero-cli-cc` now ships no AGPL code,
+  making it usable in commercial/closed-source products without an Artifex
+  license. PyMuPDF moves to an optional extra:
+
+  ```
+  pip install 'zotero-cli-cc[pymupdf]'
+  ```
+
+  Install the extra to enable the `pymupdf` extractor, which adds PDF
+  annotation/highlight extraction and higher-quality markdown. The default
+  `pdfium` extractor covers text and DOI extraction; it returns an empty list
+  for annotations. The MinerU fallback now falls back to `pdfium`. Select an
+  extractor explicitly with `extractor = "..."` in config or
+  `ZOT_PDF_EXTRACTOR`.
+
 ## [0.6.0] - 2026-05-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ This split is load-bearing for the project's value proposition. Preserve it when
 
 - `reader.py` — SQLite read layer (search, list, read, collections, tags, attachments metadata).
 - `writer.py` — pyzotero-backed writes (add, update, delete, note, tag mutations, attachment upload).
-- `pdf_extractor.py` + `pdf_cache.py` — pluggable extraction backends (`pymupdf` default, `mineru` opt-in with auto-fallback) with on-disk cache keyed per-extractor; feeds `zot pdf`, `summarize`, and the workspace RAG indexer.
+- `pdf_extractor.py` + `pdf_cache.py` — pluggable extraction backends (`pdfium` default — permissive BSD/Apache; `pymupdf` opt-in via the `[pymupdf]` extra for annotations/highlights + better markdown; `mineru` opt-in with auto-fallback to `pdfium`) with on-disk cache keyed per-extractor; feeds `zot pdf`, `summarize`, and the workspace RAG indexer. pymupdf is lazy-imported so the base install ships no AGPL code.
 - `workspace.py` — local-only TOML-backed workspaces at `~/.config/zot/workspaces/<name>.toml` (no API key, no Zotero sync). Workspaces are lightweight cross-cutting groupings, distinct from Zotero collections.
 - `rag.py` + `rag_index.py` — BM25 index over workspace metadata + PDF text, with optional embedding-based hybrid retrieval. The embedding layer is provider-routed (`core/embedding_router.py`) — choose via `[embedding] provider` (jina/aliyun) plus `ZOT_EMBEDDING_URL` / `ZOT_EMBEDDING_KEY`.
 - `idempotency.py` — supports `--idempotency-key` on mutating commands so agent retries are safe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     "click>=8.1",
     "pyzotero>=1.5",
-    "pymupdf>=1.24",
+    "pypdfium2>=4.30",
     "rich>=13.0",
     "tomli>=2.0; python_version < '3.11'",
     "markdownify>=1.2.2",
@@ -24,6 +24,10 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0"]
+# PyMuPDF is AGPL/Artifex-licensed, so it is opt-in. Installing this extra
+# enables the 'pymupdf' extractor (PDF annotation/highlight extraction and
+# higher-quality markdown). The default 'pdfium' extractor needs none of this.
+pymupdf = ["pymupdf>=1.24"]
 docs = [
     "mkdocs-material>=9.5",
     "mkdocs-static-i18n>=1.2",
@@ -56,6 +60,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "ruff>=0.9",
     "mypy>=1.14",
+    "pymupdf>=1.24",
 ]
 
 [tool.ruff]

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -168,9 +168,9 @@ def pdf_cmd(
                         cache.put(pdf_path, extractor, text)
                     except PdfExtractionError:
                         if extractor == "mineru":
-                            pdf_extractor = get_extractor("pymupdf")
+                            pdf_extractor = get_extractor("pdfium")
                             text = pdf_extractor.extract_text(pdf_path)
-                            cache.put(pdf_path, "pymupdf", text)
+                            cache.put(pdf_path, "pdfium", text)
                         else:
                             raise
             else:
@@ -179,7 +179,7 @@ def pdf_cmd(
                     text = pdf_extractor.extract_text(pdf_path, pages=page_range)
                 except PdfExtractionError:
                     if extractor == "mineru":
-                        pdf_extractor = get_extractor("pymupdf")
+                        pdf_extractor = get_extractor("pdfium")
                         text = pdf_extractor.extract_text(pdf_path, pages=page_range)
                     else:
                         raise

--- a/src/zotero_cli_cc/config.py
+++ b/src/zotero_cli_cc/config.py
@@ -138,7 +138,7 @@ def load_embedding_config(path: Path | None = None, *, apply_env_overrides: obje
 
 @dataclass
 class PdfConfig:
-    extractor: str = "pymupdf"
+    extractor: str = "pdfium"
     mineru_token: str = ""
 
 

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -14,13 +14,28 @@ from pathlib import Path
 from threading import Lock
 from typing import Any
 
-import pymupdf
-
 
 class PdfExtractionError(Exception):
     """Raised when PDF text extraction fails."""
 
     pass
+
+
+def _import_pymupdf() -> Any:
+    """Lazily import pymupdf, which is an optional dependency.
+
+    pymupdf is AGPL/Artifex-licensed, so it is shipped as the optional
+    ``[pymupdf]`` extra rather than a core dependency; the default extractor is
+    the permissively-licensed pdfium backend.
+    """
+    try:
+        import pymupdf
+    except ImportError as e:
+        raise PdfExtractionError(
+            "The 'pymupdf' extractor requires the optional dependency. "
+            "Install it with: pip install 'zotero-cli-cc[pymupdf]'"
+        ) from e
+    return pymupdf
 
 
 class BasePdfExtractor(ABC):
@@ -77,7 +92,12 @@ class PyMuPdfExtractor(BasePdfExtractor):
                 self._pymupdf4llm_available = False
         return bool(self._pymupdf4llm_available)
 
-    def extract_text(self, pdf_path: Path, pages: tuple[int, int] | None = None) -> str:
+    def extract_text(
+        self,
+        pdf_path: Path,
+        pages: tuple[int, int] | None = None,
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> str:
         if not pdf_path.exists():
             raise FileNotFoundError(f"PDF not found: {pdf_path}")
 
@@ -94,6 +114,7 @@ class PyMuPdfExtractor(BasePdfExtractor):
             except Exception:
                 pass
 
+        pymupdf = _import_pymupdf()
         try:
             doc = pymupdf.open(str(pdf_path))
         except Exception as e:
@@ -116,6 +137,7 @@ class PyMuPdfExtractor(BasePdfExtractor):
     def extract_annotations(self, pdf_path: Path) -> list[dict]:
         if not pdf_path.exists():
             raise FileNotFoundError(f"PDF not found: {pdf_path}")
+        pymupdf = _import_pymupdf()
         try:
             doc = pymupdf.open(str(pdf_path))
         except Exception as e:
@@ -159,6 +181,68 @@ class PyMuPdfExtractor(BasePdfExtractor):
 
     def name(self) -> str:
         return "pymupdf"
+
+
+class PdfiumExtractor(BasePdfExtractor):
+    """Default extractor backed by pypdfium2 (BSD/Apache, no AGPL).
+
+    Covers plain text and DOI extraction. Annotation/highlight extraction is
+    not supported here (it requires the optional pymupdf backend); it returns an
+    empty list so callers degrade gracefully.
+    """
+
+    def extract_text(
+        self,
+        pdf_path: Path,
+        pages: tuple[int, int] | None = None,
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> str:
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF not found: {pdf_path}")
+        import pypdfium2 as pdfium
+
+        try:
+            doc = pdfium.PdfDocument(str(pdf_path))
+        except Exception as e:
+            raise PdfExtractionError(f"Cannot open PDF: {e}") from e
+        try:
+            n = len(doc)
+            if pages:
+                start, end = pages
+                if start > n:
+                    raise PdfExtractionError(f"Start page {start} exceeds document length ({n} pages)")
+                page_range = range(start - 1, min(end, n))
+            else:
+                page_range = range(n)
+            total = len(page_range)
+            texts: list[str] = []
+            for done, i in enumerate(page_range, start=1):
+                page = doc[i]
+                textpage = page.get_textpage()
+                texts.append(textpage.get_text_range())
+                textpage.close()
+                page.close()
+                if progress_callback:
+                    progress_callback("extract", done, total, 0)
+            return "\n".join(texts)
+        finally:
+            doc.close()
+
+    def extract_annotations(self, pdf_path: Path) -> list[dict]:
+        return []
+
+    def extract_doi(self, pdf_path: Path) -> str | None:
+        try:
+            text = self.extract_text(pdf_path, pages=(1, 2))
+        except (FileNotFoundError, OSError, PdfExtractionError):
+            return None
+        match = re.search(r"10\.\d{4,9}/[^\s]+", text)
+        if match:
+            return match.group(0).rstrip(".,;)]}>'\"")
+        return None
+
+    def name(self) -> str:
+        return "pdfium"
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +396,7 @@ class MinerUExtractor(BasePdfExtractor):
         return _clean_markdown_images(raw_md)
 
     def _split_pdf(self, pdf_path: Path, max_pages: int) -> list[Path]:
+        pymupdf = _import_pymupdf()
         doc = pymupdf.open(str(pdf_path))
         total_pages = len(doc)
         chunks: list[Path] = []
@@ -366,6 +451,7 @@ class MinerUExtractor(BasePdfExtractor):
         if file_size > 200 * 1024 * 1024:
             raise PdfExtractionError("PDF exceeds 200MB limit")
 
+        pymupdf = _import_pymupdf()
         doc = pymupdf.open(str(pdf_path))
         total_pages = len(doc)
         doc.close()
@@ -422,6 +508,7 @@ class MinerUExtractor(BasePdfExtractor):
         pdf_paths: list[Path],
         progress_callback: Callable[[str, int, int, int], None] | None = None,
     ) -> dict[Path, str | Exception]:
+        pymupdf = _import_pymupdf()
         results: dict[Path, str | Exception] = {}
         temp_files: list[Path] = []
         original_to_chunks: dict[Path, list[Path]] = {}
@@ -586,7 +673,11 @@ def _clean_markdown_images(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-_EXTRACTORS: dict[str, type[BasePdfExtractor]] = {"pymupdf": PyMuPdfExtractor, "mineru": MinerUExtractor}
+_EXTRACTORS: dict[str, type[BasePdfExtractor]] = {
+    "pdfium": PdfiumExtractor,
+    "pymupdf": PyMuPdfExtractor,
+    "mineru": MinerUExtractor,
+}
 
 
 def get_extractor(name: str | None = None) -> BasePdfExtractor:
@@ -631,6 +722,7 @@ def extract_text_from_pdf(
     )
     if not pdf_path.exists():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
+    pymupdf = _import_pymupdf()
     try:
         doc = pymupdf.open(str(pdf_path))
     except Exception as e:
@@ -667,6 +759,7 @@ def extract_annotations(pdf_path: Path) -> list[dict]:
     )
     if not pdf_path.exists():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
+    pymupdf = _import_pymupdf()
     try:
         doc = pymupdf.open(str(pdf_path))
     except Exception as e:

--- a/src/zotero_cli_cc/core/rag.py
+++ b/src/zotero_cli_cc/core/rag.py
@@ -173,7 +173,7 @@ def chunk_text(text: str, paper_title: str, max_tokens: int = 500, overlap: int 
 
 def convert_pdf_to_text(
     pdf_path: Path,
-    extractor_name: str = "pymupdf",
+    extractor_name: str = "pdfium",
     progress_callback: Callable[[str, int, int, int], None] | None = None,
 ) -> str:
     cache = PdfCache()
@@ -188,7 +188,7 @@ def convert_pdf_to_text(
 
 def convert_pdfs_to_text(
     pdf_paths: list[Path],
-    extractor_name: str = "pymupdf",
+    extractor_name: str = "pdfium",
     progress_callback: Callable[[str, int, int, int], None] | None = None,
 ) -> dict[Path, str | Exception]:
     cache = PdfCache()

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -206,11 +206,11 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
             text = pdf_extractor.extract_text(pdf_path, pages=page_range)
     except PdfExtractionError as e:
         if extractor_name == "mineru":
-            pdf_extractor = get_extractor("pymupdf")
+            pdf_extractor = get_extractor("pdfium")
             try:
                 if page_range is None:
                     text = pdf_extractor.extract_text(pdf_path)
-                    cache.put(pdf_path, "pymupdf", text)
+                    cache.put(pdf_path, "pdfium", text)
                 else:
                     text = pdf_extractor.extract_text(pdf_path, pages=page_range)
             except PdfExtractionError:

--- a/tests/test_extractor_pdfium.py
+++ b/tests/test_extractor_pdfium.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+
+from zotero_cli_cc.core.pdf_extractor import PdfiumExtractor, get_extractor
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestPdfiumExtractor:
+    def setup_method(self):
+        self.extractor = PdfiumExtractor()
+
+    def test_is_default_extractor(self):
+        # The permissively-licensed pdfium backend is the default (no AGPL).
+        assert get_extractor().name() == "pdfium"
+
+    def test_name(self):
+        assert self.extractor.name() == "pdfium"
+
+    def test_extract_text_returns_string(self):
+        text = self.extractor.extract_text(FIXTURES / "test.pdf")
+        assert isinstance(text, str)
+
+    def test_extract_text_contains_content(self):
+        text = self.extractor.extract_text(FIXTURES / "test.pdf")
+        assert "test PDF" in text
+
+    def test_extract_text_with_pages(self):
+        text = self.extractor.extract_text(FIXTURES / "test.pdf", pages=(1, 1))
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+    def test_extract_text_accepts_progress_callback(self):
+        calls: list[tuple] = []
+        text = self.extractor.extract_text(
+            FIXTURES / "test.pdf",
+            progress_callback=lambda *a: calls.append(a),
+        )
+        assert isinstance(text, str)
+        assert calls  # at least one page reported
+
+    def test_extract_text_nonexistent_raises(self):
+        with pytest.raises(FileNotFoundError):
+            self.extractor.extract_text(FIXTURES / "nonexistent.pdf")
+
+    def test_extract_annotations_empty(self):
+        # Annotation extraction needs the optional pymupdf backend.
+        assert self.extractor.extract_annotations(FIXTURES / "test.pdf") == []
+
+    def test_extract_doi_returns_string_or_none(self):
+        result = self.extractor.extract_doi(FIXTURES / "test.pdf")
+        assert result is None or isinstance(result, str)
+
+    def test_extract_doi_nonexistent_returns_none(self):
+        assert self.extractor.extract_doi(FIXTURES / "nonexistent.pdf") is None

--- a/uv.lock
+++ b/uv.lock
@@ -1406,6 +1406,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3d/dc934d3b606c51c3ecc95b6731d84b7dd7ab8e513a50b0e98a4da6c8a719/pypdfium2-5.8.0.tar.gz", hash = "sha256:049397c647e50f83115ee951c49394dab9e9ba52ebdd5a11ab1109390eb3d34e", size = 271934, upload-time = "2026-05-04T17:39:43.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8c/6b75b923cb81368fa3ea7c48a0616b839620a3aeff899885bd930449b89e/pypdfium2-5.8.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:f67b6c74b716d9ac725ad1af49ae786ad813ac20823d45606d59f1fc06caa8af", size = 3374554, upload-time = "2026-05-04T17:39:05.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/61/a885c7f36efba89ec98e3d1fe95c83b48c2d6dea321e9194ac6460e7a834/pypdfium2-5.8.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:53e82bf3e6a2da170b1bda83f93b7eec57cb6efe3cacd05cba78823879a85203", size = 2831667, upload-time = "2026-05-04T17:39:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/04b5627f6dba312d3e707e5b019c9f24d8b03b5aa366866a9e02ec00f8d4/pypdfium2-5.8.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:085e633dcc89b65ff4035a4787e98ce7ae636836eb39c83dd0db26113d9774bc", size = 3450815, upload-time = "2026-05-04T17:39:09.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/77/8e3a2aba2bc4aef5abe1b1306d05b00588dc0bf7f5c850d1adf6164c786b/pypdfium2-5.8.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bc84b7c6efede88fcfb9467f81daf416f26b973a54fc1cf4d3410d622fda6d7a", size = 3634395, upload-time = "2026-05-04T17:39:11.225Z" },
+    { url = "https://files.pythonhosted.org/packages/93/11/6f2b1847d9fa457b3b7251afc2bba2706d104a0c6f01431dfae5d679a839/pypdfium2-5.8.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a63bf09b2e13ba8545c930d243f0650c664a1b51314daa3b5f38df6d1a17b4bc", size = 3617413, upload-time = "2026-05-04T17:39:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/fd/99ce639de5ca06d21743c740dd988cd209dda623bc763ae10b8a162022e1/pypdfium2-5.8.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:937881c1698456749ed203a58db1895baa5eb7178cdb837ef84867790638da28", size = 3347639, upload-time = "2026-05-04T17:39:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/47/82864cc6e26dd8969d5594c168635acb16458d35cf5fed65d6b2e32abb42/pypdfium2-5.8.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6be9dc2b84a8694ad7e626bab133244e8241014d5ed1930d865a9bdf90df1e24", size = 3746404, upload-time = "2026-05-04T17:39:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/82/58/e41e49bba951f61921bac7289e67fe02af5ac57192d0bbfb5f459dc3691d/pypdfium2-5.8.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f27bd82891ae302dd02d736b14809661f6d1220ee1e96dbed9b23e2811922a3", size = 4177893, upload-time = "2026-05-04T17:39:18.729Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/15/fa7031010d5cf6853dadb4864680a0bfb7782c5bb6a1a401e0c25c4fca87/pypdfium2-5.8.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26c1089cdbbdc7fe1248f6d17fe3f30214be4f287dd0196b31aaee18a1564240", size = 3665152, upload-time = "2026-05-04T17:39:20.207Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/5a3520a8b0cfa8d7fdc3f03a07ad9d6146c28ffd519330706f64fd8939a8/pypdfium2-5.8.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c038a9290864aaa4862dd32e591993d82551ca4d152b4e8ce6d43ba37dc04a8", size = 3095365, upload-time = "2026-05-04T17:39:22.054Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d3/845bae4de3cfa36865959046156edb5bf9baea400ccdecdd84fdd911b0f5/pypdfium2-5.8.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f104bc1a6d8bfc1ff088aa50db13b9729cfdb3722b44975c3c457e9a7b9c7318", size = 2961801, upload-time = "2026-05-04T17:39:23.817Z" },
+    { url = "https://files.pythonhosted.org/packages/99/76/cf54eabee4a172241dfcfe63533bd1e11e2162114a983453a5a40bfec114/pypdfium2-5.8.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:04ca7c57a553facf8d46c6ea8ba6fa557e698670cfa4a58e0e01fdae2f6be87d", size = 4133067, upload-time = "2026-05-04T17:39:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/77/66/dcf871d19187ca04ea184a99801a6e7e556d8347aa49540fee33cda6dfc5/pypdfium2-5.8.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ad42b9c22477b32dbedcbc8232833f385d92fd0cf92822547b02383cf9a476d7", size = 3749100, upload-time = "2026-05-04T17:39:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/0d456c79660959ca45ad307b4d67161d29f9ed4083ee1e8fe8c6925b7c82/pypdfium2-5.8.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:388e3119cf5ca0979b7d5f6d40b7fcd5ab49e17ed4e6de6af89ba116061acfda", size = 4339212, upload-time = "2026-05-04T17:39:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/76/89/e5b0e0f7936be341c91c0f45cd70d693878894ed62aed93a6ee32e9c43c4/pypdfium2-5.8.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:aa05bbfa485ce7916217aa78d856c9f9cd86b08b20846c650392a67975ee72e9", size = 4383943, upload-time = "2026-05-04T17:39:31.287Z" },
+    { url = "https://files.pythonhosted.org/packages/82/21/4502ed255f082f579cd3537c2971cf1a57778d43703a08bcd1a92253189f/pypdfium2-5.8.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:f0813a16bb39d5ebd173ea5484430bb67a89b4b181db0a636c73b64ad063c3ea", size = 3925680, upload-time = "2026-05-04T17:39:33.241Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4f/2e59723e7a07779439bd885c1b4960079c9710603308888d29ac926ae69a/pypdfium2-5.8.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:a3c78f7d20dd821bec6c072efdb21a1370b9efe10fdeeb68c969e67608e25385", size = 4269560, upload-time = "2026-05-04T17:39:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4e/7b6b1bde3788c8b880d4b8131d95d9d339cebafb3ad9102d82e234bb65be/pypdfium2-5.8.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:86d302e207c138c827b885a72784f7b306d840646ebeae07e8efdbc39321c629", size = 4182434, upload-time = "2026-05-04T17:39:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7b/6ed4782e0d7a5278330598ce8c4b2df7255f4585a0b3d04520fa580d6507/pypdfium2-5.8.0-py3-none-win32.whl", hash = "sha256:3f25fd436920a907291462b41bdc0ab9f8235c3944b4c9c15398da595ffd1fed", size = 3636680, upload-time = "2026-05-04T17:39:38.49Z" },
+    { url = "https://files.pythonhosted.org/packages/19/55/da7223d4202b2461f4f889b0baf10dddec3db7f88e6fd8c52db4a516eecd/pypdfium2-5.8.0-py3-none-win_amd64.whl", hash = "sha256:55592af0bddd2d62bed18e0053c546c9b72041430c5115e54870f7f6163125b0", size = 3754962, upload-time = "2026-05-04T17:39:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/f3dcefe6ee7389aad3ca1488c177e8fbf978206de21c7a99ccf487ea38ab/pypdfium2-5.8.0-py3-none-win_arm64.whl", hash = "sha256:3f17ed97ae8a5a1705301ca93af256a5b02f9009dee4e99c5e175831d46ebd7c", size = 3548362, upload-time = "2026-05-04T17:39:42.304Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2110,7 +2139,7 @@ dependencies = [
     { name = "click" },
     { name = "markdownify" },
     { name = "openai" },
-    { name = "pymupdf" },
+    { name = "pypdfium2" },
     { name = "pyzotero" },
     { name = "requests" },
     { name = "rich" },
@@ -2126,10 +2155,14 @@ docs = [
 mcp = [
     { name = "mcp" },
 ]
+pymupdf = [
+    { name = "pymupdf" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pymupdf" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -2144,17 +2177,19 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocs-static-i18n", marker = "extra == 'docs'", specifier = ">=1.2" },
     { name = "openai", specifier = ">=2.33.0" },
-    { name = "pymupdf", specifier = ">=1.24" },
+    { name = "pymupdf", marker = "extra == 'pymupdf'", specifier = ">=1.24" },
+    { name = "pypdfium2", specifier = ">=4.30" },
     { name = "pyzotero", specifier = ">=1.5" },
     { name = "requests", specifier = ">=2.31" },
     { name = "rich", specifier = ">=13.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
-provides-extras = ["mcp", "docs"]
+provides-extras = ["mcp", "pymupdf", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.14" },
+    { name = "pymupdf", specifier = ">=1.24" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.9" },


### PR DESCRIPTION
## Why

PyMuPDF is **AGPL-3.0-or-later / Artifex commercial** — a closed-source commercial product (pi-office) can't ship it without an Artifex license. This PR removes that hard dependency so a plain `pip install zotero-cli-cc` ships **zero AGPL code**.

## What

- **New `PdfiumExtractor`** (pypdfium2 — BSD/Apache) for text + DOI extraction. It is now the **default** extractor.
- **PyMuPDF → optional `[pymupdf]` extra**, lazy-imported everywhere (extractor, MinerU split helpers, deprecated module functions). Importing the package no longer pulls in pymupdf.
- Default config extractor + `rag.py` defaults flip `pymupdf` → `pdfium`; the MinerU auto-fallback now falls back to `pdfium`.
- `pypdfium2` added as a core dep; `pymupdf` kept in the dev group so CI still exercises the pymupdf path.

## Tradeoff (documented)

The `pdfium` default does **text + DOI**. **Annotation/highlight extraction and higher-quality markdown require the extra:**

```
pip install 'zotero-cli-cc[pymupdf]'
```

`PdfiumExtractor.extract_annotations` returns `[]`. Select an extractor explicitly via `extractor = "..."` in config or `ZOT_PDF_EXTRACTOR`.

## Verified

- New `tests/test_extractor_pdfium.py` (default-extractor, text, pages, progress callback, empty annotations, DOI).
- Full suite: **691 passed, 1 skipped**. ruff + mypy clean.
- Wheel METADATA: `Requires-Dist: pypdfium2>=4.30`; `pymupdf>=1.24; extra == 'pymupdf'` — no pymupdf in core.

Pairs with the relicense PR (#56): together they make zot AGPL-free and dual-licensed for commercial use.