### PR TITLE
chore: release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-05-29
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.6.0"
+version = "0.7.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "CC-BY-NC-4.0"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2133,7 +2133,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 0.7.0

Promotes the `[Unreleased]` changes and bumps the version 0.6.0 → 0.7.0.

### Added
- **`zot ask "QUESTION" --workspace NAME`** — citation-keyed **evidence pack** from a workspace RAG index (hybrid BM25 + embedding via RRF) with `answer_instructions`; the agent synthesizes the cited answer (no LLM inside the tool). `--evidence-k`, `--mode`. Schema version → `1.6.0`.

### Changed
- **Default PDF extractor is now `pdfium`** (pypdfium2, BSD/Apache). PyMuPDF (AGPL/Artifex) moves to the optional `[pymupdf]` extra and is lazy-imported, so a plain `pip install zotero-cli-cc` ships **no AGPL code**. Annotations/highlights + best markdown need `pip install 'zotero-cli-cc[pymupdf]'`.

Lint + mypy clean; `zot --version` → 0.7.0. Merging triggers `publish.yml` (tag `v0.7.0` → PyPI).