### PR TITLE
feat(pdf): add GROBID references/structure extractor tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **GROBID extractor** (`pdf.extractor = "grobid"` / `ZOT_GROBID_URL`): a
+  references/structure tier backed by a running GROBID service (default
+  `http://localhost:8070`). Adds `extract_references()` to the extractor
+  interface and a `zot pdf KEY --references` flag that returns the parsed
+  reference list (title / authors / year / journal / DOI). Lighter than the
+  vision-model extractors; intended for citation verification and metadata
+  completion. GROBID is not bundled — the user runs the service.
+
 ## [0.7.0] - 2026-05-29
 
 ### Added

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -66,6 +66,11 @@ def _extract_section(markdown: str, section_num: int) -> str:
 @click.option("--pages", default=None, help="Page range, e.g. '1-5'")
 @click.option("--extractor", default=None, help="PDF extractor to use (mineru, pymupdf). Defaults to auto-detect.")
 @click.option("--annotations", is_flag=True, help="Extract annotations (highlights, notes) instead of text")
+@click.option(
+    "--references",
+    is_flag=True,
+    help="Extract the parsed reference list (requires a running GROBID service)",
+)
 @click.option("--outline", is_flag=True, help="Extract and list all headings as a numbered outline")
 @click.option("--section", type=int, default=None, help="Extract content under the N-th heading from outline")
 @click.argument("key")
@@ -75,6 +80,7 @@ def pdf_cmd(
     pages: str | None,
     extractor: str | None,
     annotations: bool,
+    references: bool,
     outline: bool,
     section: int | None,
     key: str,
@@ -89,6 +95,7 @@ def pdf_cmd(
       zot pdf ABC123 --pages 1-5    Extract pages 1-5
       zot pdf ABC123 --outline      List all headings as numbered outline
       zot pdf ABC123 --section 3    Extract content under 3rd heading
+      zot pdf ABC123 --references   Parsed reference list (needs GROBID)
       zot --json pdf ABC123         JSON output with metadata
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
@@ -152,6 +159,33 @@ def pdf_cmd(
                     click.echo("No annotations found.")
                 return
             click.echo(format_pdf_annotations(annots, output_json=json_out))
+            return
+        if references:
+            # References are a structure tier; only the grobid backend supports them.
+            try:
+                refs = get_extractor("grobid").extract_references(pdf_path)
+            except PdfExtractionError as e:
+                emit_error(
+                    "runtime_error",
+                    str(e),
+                    output_json=json_out,
+                    hint="Reference parsing needs a running GROBID service "
+                    "(default http://localhost:8070; set pdf.grobid_url or ZOT_GROBID_URL)",
+                    context="pdf",
+                )
+            if not refs:
+                click.echo("[]" if json_out else "No references found.")
+                return
+            if json_out:
+                click.echo(json.dumps({"key": key, "references": refs}, ensure_ascii=False))
+            else:
+                lines = []
+                for i, r in enumerate(refs, 1):
+                    authors = ", ".join(r["authors"][:3]) + (" et al." if len(r["authors"]) > 3 else "")
+                    head = " — ".join(p for p in (authors or None, r.get("year") or None) if p)
+                    doi = f"  doi:{r['doi']}" if r.get("doi") else ""
+                    lines.append(f"{i}. {r.get('title') or '(no title)'}" + (f" [{head}]" if head else "") + doi)
+                click.echo("\n".join(lines))
             return
         from zotero_cli_cc.core.pdf_cache import PdfCache
 

--- a/src/zotero_cli_cc/config.py
+++ b/src/zotero_cli_cc/config.py
@@ -140,6 +140,7 @@ def load_embedding_config(path: Path | None = None, *, apply_env_overrides: obje
 class PdfConfig:
     extractor: str = "pdfium"
     mineru_token: str = ""
+    grobid_url: str = "http://localhost:8070"
 
 
 def load_pdf_config(path: Path | None = None) -> PdfConfig:
@@ -152,9 +153,11 @@ def load_pdf_config(path: Path | None = None) -> PdfConfig:
         defaults = PdfConfig(
             extractor=pdf.get("extractor", defaults.extractor),
             mineru_token=pdf.get("mineru_token", defaults.mineru_token),
+            grobid_url=pdf.get("grobid_url", defaults.grobid_url),
         )
     defaults.extractor = os.environ.get("ZOT_PDF_EXTRACTOR", defaults.extractor)
     defaults.mineru_token = os.environ.get("MINERU_TOKEN", defaults.mineru_token)
+    defaults.grobid_url = os.environ.get("ZOT_GROBID_URL", defaults.grobid_url)
     return defaults
 
 

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -6,6 +6,7 @@ import re
 import sys
 import time
 import warnings
+import xml.etree.ElementTree as ET
 import zipfile
 from abc import ABC, abstractmethod
 from collections import deque
@@ -76,6 +77,21 @@ class BasePdfExtractor(ABC):
     def name(self) -> str:
         """Return the extractor name (e.g. 'pymupdf')."""
         ...
+
+    def extract_references(self, pdf_path: Path) -> list[dict]:
+        """Extract parsed bibliographic references from a PDF.
+
+        Only the 'grobid' extractor implements this; others raise so callers can
+        surface a clear message (reference parsing is a structure tier, not plain
+        text extraction).
+
+        Returns:
+            List of dicts with keys: title, authors (list[str]), year, journal, doi.
+        """
+        raise PdfExtractionError(
+            f"reference extraction is not supported by the '{self.name()}' extractor; "
+            "use the 'grobid' extractor with a running GROBID service"
+        )
 
 
 class PyMuPdfExtractor(BasePdfExtractor):
@@ -669,6 +685,153 @@ def _clean_markdown_images(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# GrobidExtractor - references/structure tier via a running GROBID service
+# ---------------------------------------------------------------------------
+
+_TEI_NS = {"tei": "http://www.tei-c.org/ns/1.0"}
+
+
+def _tei_text(el: Any) -> str:
+    """Collapsed text content of a TEI element (empty string for None)."""
+    if el is None:
+        return ""
+    return " ".join("".join(el.itertext()).split())
+
+
+def _parse_tei_references(xml_text: str) -> list[dict]:
+    """Parse GROBID processReferences TEI XML into reference dicts.
+
+    Pure function (no network) so it is unit-testable against fixture XML.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        raise PdfExtractionError(f"GROBID returned unparseable TEI: {e}") from e
+    refs: list[dict] = []
+    for bibl in root.iterfind(".//tei:biblStruct", _TEI_NS):
+        analytic_title = bibl.find(".//tei:analytic/tei:title", _TEI_NS)
+        title_el = analytic_title if analytic_title is not None else bibl.find(".//tei:title", _TEI_NS)
+        authors: list[str] = []
+        for pers in bibl.iterfind(".//tei:author/tei:persName", _TEI_NS):
+            forename = _tei_text(pers.find("tei:forename", _TEI_NS))
+            surname = _tei_text(pers.find("tei:surname", _TEI_NS))
+            full = " ".join(p for p in (forename, surname) if p)
+            if full:
+                authors.append(full)
+        year = ""
+        date_el = bibl.find(".//tei:date", _TEI_NS)
+        if date_el is not None:
+            m = re.search(r"\d{4}", date_el.get("when") or _tei_text(date_el))
+            if m:
+                year = m.group(0)
+        doi = ""
+        for idno in bibl.iterfind(".//tei:idno", _TEI_NS):
+            if (idno.get("type") or "").upper() == "DOI":
+                doi = _tei_text(idno)
+                break
+        refs.append(
+            {
+                "title": _tei_text(title_el),
+                "authors": authors,
+                "year": year,
+                "journal": _tei_text(bibl.find(".//tei:title[@level='j']", _TEI_NS)),
+                "doi": doi,
+            }
+        )
+    return refs
+
+
+def _parse_tei_header_doi(xml_text: str) -> str | None:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+    for idno in root.iterfind(".//tei:idno", _TEI_NS):
+        if (idno.get("type") or "").upper() == "DOI":
+            text = _tei_text(idno)
+            if text:
+                return text
+    return None
+
+
+def _parse_tei_fulltext(xml_text: str) -> str:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        raise PdfExtractionError(f"GROBID returned unparseable TEI: {e}") from e
+    body = root.find(".//tei:text/tei:body", _TEI_NS)
+    if body is None:
+        return ""
+    parts: list[str] = []
+    for el in body.iter():
+        if el.tag.split("}")[-1] in ("head", "p"):
+            text = _tei_text(el)
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts)
+
+
+class GrobidExtractor(BasePdfExtractor):
+    """References/structure tier backed by a running GROBID service.
+
+    GROBID (https://github.com/kermitt2/grobid) parses scholarly PDFs into TEI
+    XML: header metadata, section structure, and a parsed reference list. It is
+    much lighter than the vision-model extractors and is the right backend for
+    citation verification and metadata completion. Requires a running GROBID
+    service (default http://localhost:8070); zot does not bundle it.
+    """
+
+    def __init__(self, base_url: str = "http://localhost:8070") -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session = Session()
+
+    def name(self) -> str:
+        return "grobid"
+
+    def _post(self, endpoint: str, pdf_path: Path) -> str:
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"PDF not found: {pdf_path}")
+        url = f"{self._base_url}/api/{endpoint}"
+        try:
+            with open(pdf_path, "rb") as f:
+                resp = self._session.post(
+                    url,
+                    files={"input": (pdf_path.name, f, "application/pdf")},
+                    timeout=300,
+                )
+        except Exception as e:
+            raise PdfExtractionError(
+                f"Cannot reach GROBID at {self._base_url}: {e}. "
+                "Start a GROBID service or set pdf.grobid_url / ZOT_GROBID_URL."
+            ) from e
+        if resp.status_code != 200:
+            raise PdfExtractionError(f"GROBID {endpoint} failed: {resp.status_code} {resp.text[:200]}")
+        return str(resp.text)
+
+    def extract_text(
+        self,
+        pdf_path: Path,
+        pages: tuple[int, int] | None = None,
+        progress_callback: Callable[[str, int, int, int], None] | None = None,
+    ) -> str:
+        if pages is not None:
+            raise PdfExtractionError("the 'grobid' extractor does not support page ranges")
+        return _parse_tei_fulltext(self._post("processFulltextDocument", pdf_path))
+
+    def extract_annotations(self, pdf_path: Path) -> list[dict]:
+        return []
+
+    def extract_doi(self, pdf_path: Path) -> str | None:
+        try:
+            return _parse_tei_header_doi(self._post("processHeaderDocument", pdf_path))
+        except (FileNotFoundError, PdfExtractionError):
+            return None
+
+    def extract_references(self, pdf_path: Path) -> list[dict]:
+        return _parse_tei_references(self._post("processReferences", pdf_path))
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -677,6 +840,7 @@ _EXTRACTORS: dict[str, type[BasePdfExtractor]] = {
     "pdfium": PdfiumExtractor,
     "pymupdf": PyMuPdfExtractor,
     "mineru": MinerUExtractor,
+    "grobid": GrobidExtractor,
 }
 
 
@@ -703,6 +867,11 @@ def get_extractor(name: str | None = None) -> BasePdfExtractor:
 
         cfg = load_pdf_config()
         return extractor_cls(cfg.mineru_token)  # type: ignore[call-arg]
+    if name == "grobid":
+        from zotero_cli_cc.config import load_pdf_config
+
+        cfg = load_pdf_config()
+        return extractor_cls(cfg.grobid_url)  # type: ignore[call-arg]
     return extractor_cls()
 
 

--- a/tests/test_extractor_grobid.py
+++ b/tests/test_extractor_grobid.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+
+from zotero_cli_cc.core.pdf_extractor import (
+    GrobidExtractor,
+    PdfExtractionError,
+    _parse_tei_fulltext,
+    _parse_tei_header_doi,
+    _parse_tei_references,
+    get_extractor,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+_NS = 'xmlns="http://www.tei-c.org/ns/1.0"'
+
+REFERENCES_TEI = f"""<TEI {_NS}>
+  <text><back><div><listBibl>
+    <biblStruct>
+      <analytic>
+        <title level="a">Attention Is All You Need</title>
+        <author><persName><forename>Ashish</forename><surname>Vaswani</surname></persName></author>
+        <author><persName><forename>Noam</forename><surname>Shazeer</surname></persName></author>
+      </analytic>
+      <monogr>
+        <title level="j">NeurIPS</title>
+        <imprint><date type="published" when="2017">2017</date></imprint>
+      </monogr>
+      <idno type="DOI">10.5555/3295222.3295349</idno>
+    </biblStruct>
+    <biblStruct>
+      <analytic><title level="a">A second paper</title></analytic>
+      <monogr><imprint><date when="2021-06">June 2021</date></imprint></monogr>
+    </biblStruct>
+  </listBibl></div></back></text>
+</TEI>"""
+
+HEADER_TEI = f"""<TEI {_NS}>
+  <teiHeader><fileDesc><sourceDesc><biblStruct>
+    <idno type="DOI">10.1000/xyz123</idno>
+  </biblStruct></sourceDesc></fileDesc></teiHeader>
+</TEI>"""
+
+FULLTEXT_TEI = f"""<TEI {_NS}>
+  <text><body>
+    <div><head>Introduction</head><p>First paragraph.</p><p>Second paragraph.</p></div>
+  </body></text>
+</TEI>"""
+
+
+class TestTeiParsing:
+    def test_references_parsed(self):
+        refs = _parse_tei_references(REFERENCES_TEI)
+        assert len(refs) == 2
+        first = refs[0]
+        assert first["title"] == "Attention Is All You Need"
+        assert first["authors"] == ["Ashish Vaswani", "Noam Shazeer"]
+        assert first["year"] == "2017"
+        assert first["journal"] == "NeurIPS"
+        assert first["doi"] == "10.5555/3295222.3295349"
+
+    def test_reference_year_from_partial_date(self):
+        refs = _parse_tei_references(REFERENCES_TEI)
+        assert refs[1]["year"] == "2021"
+        assert refs[1]["authors"] == []
+
+    def test_references_bad_xml_raises(self):
+        with pytest.raises(PdfExtractionError):
+            _parse_tei_references("<not-xml")
+
+    def test_header_doi(self):
+        assert _parse_tei_header_doi(HEADER_TEI) == "10.1000/xyz123"
+
+    def test_header_doi_missing_returns_none(self):
+        assert _parse_tei_header_doi(f"<TEI {_NS}></TEI>") is None
+
+    def test_header_doi_bad_xml_returns_none(self):
+        assert _parse_tei_header_doi("<nope") is None
+
+    def test_fulltext_joins_heads_and_paragraphs(self):
+        text = _parse_tei_fulltext(FULLTEXT_TEI)
+        assert "Introduction" in text
+        assert "First paragraph." in text
+        assert "Second paragraph." in text
+
+
+class TestGrobidExtractor:
+    def setup_method(self):
+        self.extractor = GrobidExtractor("http://localhost:8070")
+
+    def test_name(self):
+        assert self.extractor.name() == "grobid"
+
+    def test_registered(self):
+        assert isinstance(get_extractor("grobid"), GrobidExtractor)
+
+    def test_annotations_empty(self):
+        assert self.extractor.extract_annotations(FIXTURES / "test.pdf") == []
+
+    def test_page_range_unsupported(self):
+        with pytest.raises(PdfExtractionError):
+            self.extractor.extract_text(FIXTURES / "test.pdf", pages=(1, 2))
+
+    def test_base_url_trailing_slash_stripped(self):
+        assert GrobidExtractor("http://localhost:8070/")._base_url == "http://localhost:8070"
+
+
+class TestReferencesNotSupportedByOthers:
+    def test_pdfium_references_raise(self):
+        from zotero_cli_cc.core.pdf_extractor import PdfiumExtractor
+
+        with pytest.raises(PdfExtractionError):
+            PdfiumExtractor().extract_references(FIXTURES / "test.pdf")


### PR DESCRIPTION
## What

Adds a **`grobid`** PDF extractor tier — a references/structure backend powered by a running [GROBID](https://github.com/kermitt2/grobid) service. GROBID parses scholarly PDFs into TEI XML (header metadata, sections, and a **parsed reference list**) and is far lighter than the vision-model extractors, making it the right backend for **citation verification** and **metadata completion**.

This is item 2 of the tiered-extraction design (`goal-pdf-extraction-tiers.md`, local): keep the default featherweight (`pdfium`), add targeted tiers as opt-in.

## Changes

- **`extract_references(pdf) -> list[dict]`** added to `BasePdfExtractor` — default raises `PdfExtractionError`; only `grobid` implements it. Returns `{title, authors, year, journal, doi}`.
- **`GrobidExtractor`** (`processFulltextDocument` / `processHeaderDocument` / `processReferences`) with pure TEI-parsing helpers (`_parse_tei_references` / `_parse_tei_header_doi` / `_parse_tei_fulltext`) so parsing is unit-testable without a live service.
- **`zot pdf KEY --references`** flag — text + `--json` output.
- Registered `"grobid"` in `_EXTRACTORS`; `PdfConfig.grobid_url` (default `http://localhost:8070`) via `pdf.grobid_url` / `ZOT_GROBID_URL`.
- **Default stays `pdfium`.** GROBID is **not bundled** — the user runs the service.

## Why GROBID (vs MinerU) for this tier

MinerU (already wired, cloud-only) is the heavy formula/table/figure tier. References/metadata don't need a vision stack — GROBID is lighter, scholarly-specialized, and gives a clean parsed bibliography, which is exactly what citation-integrity and metadata features consume. The two are complementary tiers, not competitors.

## Verification

- `uv run mypy src/zotero_cli_cc/` — clean.
- `uv run ruff check` + `ruff format --check` — clean.
- `uv run pytest tests/test_extractor_grobid.py` — 13 pass (TEI parsing offline; no GROBID needed).
- Related tests (`test_extractor_pdfium`, `test_extractor_fallback`, `test_agent_interface` schema-drift) — pass.
- `zot pdf --help` shows the new flag.
- **Not exercised against a live GROBID server** — the HTTP calls (`/api/process*`, multipart `input`) follow GROBID's documented API but a manual round-trip against a running instance is worth doing before relying on it.

## Follow-ups (not in this PR)

- Expose references via an **MCP tool** in `zot mcp serve` (the consumption path for the Innate Zotero host's `verify-citations` skill).
- `mineru-local` backend (local-first high-fidelity) — item 1 of the same design.