### PR TITLE
feat(mcp): expose GROBID-parsed references as a `references` MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reference list (title / authors / year / journal / DOI). Lighter than the
   vision-model extractors; intended for citation verification and metadata
   completion. GROBID is not bundled — the user runs the service.
+- **`references` MCP tool** in `zot mcp serve`: exposes the GROBID-parsed
+  reference list (title / authors / year / journal / DOI) over MCP, so an agent
+  can verify citations without shelling out. Returns `error` + `hint` when no
+  GROBID service is reachable.
 
 ## [0.7.0] - 2026-05-29
 

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -237,6 +237,26 @@ def _handle_annotations(key: str, library: str = "user") -> dict:
     return {"key": key, "annotations": annots, "total": len(annots)}
 
 
+def _handle_references(key: str, library: str = "user") -> dict:
+    reader = _get_reader(library)
+    att = reader.get_pdf_attachment(key)
+    if att is None:
+        return {"error": f"No PDF attachment found for '{key}'"}
+    pdf_path = att.path
+    if not pdf_path or not pdf_path.exists():
+        return {"error": f"PDF file not found at {pdf_path or att.filename}"}
+    try:
+        refs = get_extractor("grobid").extract_references(pdf_path)
+    except PdfExtractionError as e:
+        return {
+            "error": str(e),
+            "context": "references",
+            "hint": "Reference parsing needs a running GROBID service "
+            "(default http://localhost:8070; set pdf.grobid_url or ZOT_GROBID_URL)",
+        }
+    return {"key": key, "references": refs, "total": len(refs)}
+
+
 def _handle_summarize(key: str, library: str = "user") -> dict:
     reader = _get_reader(library)
     item = reader.get_item(key)
@@ -1227,6 +1247,22 @@ def annotations(key: str, library: str = "user") -> dict:
         library: Library — 'user' (default) or 'group:<id>'.
     """
     return _handle_annotations(key, library=library)
+
+
+@mcp.tool()
+def references(key: str, library: str = "user") -> dict:
+    """Extract the parsed reference list (bibliography) from a PDF attachment.
+
+    Returns each reference's title, authors, year, journal, and DOI. Requires a
+    running GROBID service (configured via pdf.grobid_url / ZOT_GROBID_URL); the
+    response carries an 'error' + 'hint' if it is unreachable. Useful for
+    citation verification and detecting fabricated references.
+
+    Args:
+        key: Item key whose PDF attachment to parse references from.
+        library: Library — 'user' (default) or 'group:<id>'.
+    """
+    return _handle_references(key, library=library)
 
 
 @mcp.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -250,6 +250,66 @@ class TestHandlePdf:
             _handle_pdf("ABC123", None)
 
 
+class TestHandleReferences:
+    def _att(self):
+        return Attachment(
+            key="ATT1",
+            parent_key="ABC123",
+            filename="paper.pdf",
+            content_type="application/pdf",
+            path=Path("/fake/zotero/paper.pdf"),
+        )
+
+    @patch("zotero_cli_cc.mcp_server.get_extractor")
+    @patch("zotero_cli_cc.mcp_server._get_reader")
+    def test_returns_references(self, mock_get_reader, mock_get_extractor):
+        from zotero_cli_cc.mcp_server import _handle_references
+
+        reader = MagicMock()
+        reader.get_pdf_attachment.return_value = self._att()
+        mock_get_reader.return_value = reader
+        extractor = MagicMock()
+        extractor.extract_references.return_value = [
+            {"title": "A paper", "authors": ["J Smith"], "year": "2020", "journal": "X", "doi": "10.1/x"}
+        ]
+        mock_get_extractor.return_value = extractor
+
+        with patch.object(Path, "exists", return_value=True):
+            result = _handle_references("ABC123")
+        assert result["total"] == 1
+        assert result["references"][0]["doi"] == "10.1/x"
+        mock_get_extractor.assert_called_once_with("grobid")
+
+    @patch("zotero_cli_cc.mcp_server.get_extractor")
+    @patch("zotero_cli_cc.mcp_server._get_reader")
+    def test_grobid_unreachable_returns_error_with_hint(self, mock_get_reader, mock_get_extractor):
+        from zotero_cli_cc.core.pdf_extractor import PdfExtractionError
+        from zotero_cli_cc.mcp_server import _handle_references
+
+        reader = MagicMock()
+        reader.get_pdf_attachment.return_value = self._att()
+        mock_get_reader.return_value = reader
+        extractor = MagicMock()
+        extractor.extract_references.side_effect = PdfExtractionError("Cannot reach GROBID")
+        mock_get_extractor.return_value = extractor
+
+        with patch.object(Path, "exists", return_value=True):
+            result = _handle_references("ABC123")
+        assert "error" in result
+        assert "GROBID" in result["hint"]
+
+    @patch("zotero_cli_cc.mcp_server._get_reader")
+    def test_no_pdf_returns_error(self, mock_get_reader):
+        from zotero_cli_cc.mcp_server import _handle_references
+
+        reader = MagicMock()
+        reader.get_pdf_attachment.return_value = None
+        mock_get_reader.return_value = reader
+
+        result = _handle_references("ABC123")
+        assert "No PDF attachment" in result["error"]
+
+
 class TestHandleSummarize:
     @patch("zotero_cli_cc.mcp_server._get_reader")
     def test_returns_summary(self, mock_get_reader):


### PR DESCRIPTION
## What

Adds a **`references`** tool to `zot mcp serve` that returns the GROBID-parsed bibliography (title / authors / year / journal / DOI) for an item's PDF attachment. This is the **consumption path** for the GROBID extractor (#59, merged): an agent — e.g. the Innate Zotero host's `verify-citations` skill — gets a real parsed reference list over MCP instead of regexing raw text or shelling out to the CLI.

## Changes

- `_handle_references(key, library)` handler — resolves the PDF, calls `get_extractor("grobid").extract_references()`, returns `{key, references, total}`.
- `@mcp.tool() references(...)` wrapping it.
- Graceful failure: when no GROBID service is reachable it returns `{error, hint}` (not an exception), so the calling agent gets an actionable message.
- 3 tests (mocked reader + extractor, no live GROBID): success, unreachable-with-hint, no-PDF.
- CHANGELOG bullet under `[Unreleased]`.

## Verification

- `uv run pytest tests/test_mcp_server.py` — **86 pass** (incl. the 3 new).
- `mypy` clean · `ruff check` + `ruff format --check` clean.
- Not exercised against a live GROBID server (handler is mocked in tests) — same caveat as #59.

## Depends on / relates to

- Builds on #59 (GROBID extractor + `extract_references`), already merged.
- Pairs with the Innate `verify-citations` skill (pi-office #116) which can now route to this tool.