### PR TITLE
feat(pdf): drop all-empty tables from pdfplumber extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`pdfplumber` table extractor** (`zotero-cli-cc[pdfplumber]`): pure-Python
   table extraction (no ML / GPU / network). Adds `extract_tables()` to the
   extractor interface, a `zot pdf KEY --tables` flag, and a `tables` MCP tool.
+  All-empty tables (spurious grids pdfplumber detects on figure-heavy pages)
+  are filtered out so only tables with real cell content are returned.
 - **`pymupdf4llm` bundled into the `[pymupdf]` extra**: installing the extra now
   also enables higher-quality local Markdown output (no API / network — the
   `PyMuPdfExtractor` already uses it when present).

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -343,11 +343,20 @@ class PdfplumberExtractor(BasePdfExtractor):
             for page in _select_pages(pdf.pages, pages):
                 for idx, table in enumerate(page.extract_tables() or []):
                     rows = [["" if cell is None else str(cell) for cell in row] for row in table]
+                    # pdfplumber detects spurious all-empty grids on figure-heavy
+                    # pages; drop tables with no actual cell content.
+                    if not _table_has_content(rows):
+                        continue
                     out.append({"page": page.page_number, "index": idx, "rows": rows})
         return out
 
     def name(self) -> str:
         return "pdfplumber"
+
+
+def _table_has_content(rows: list[list[str]]) -> bool:
+    """True if any cell in the table has non-whitespace text."""
+    return any(cell.strip() for row in rows for cell in row)
 
 
 def _select_pages(page_list: Any, pages: tuple[int, int] | None) -> Any:

--- a/tests/test_extractor_pdfplumber.py
+++ b/tests/test_extractor_pdfplumber.py
@@ -7,10 +7,25 @@ from zotero_cli_cc.core.pdf_extractor import (
     PdfiumExtractor,
     PdfplumberExtractor,
     _select_pages,
+    _table_has_content,
     get_extractor,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestTableHasContent:
+    def test_all_empty_is_false(self):
+        assert _table_has_content([["", ""], ["", ""]]) is False
+
+    def test_whitespace_only_is_false(self):
+        assert _table_has_content([[" ", "\n"], ["\t", ""]]) is False
+
+    def test_any_content_is_true(self):
+        assert _table_has_content([["", ""], ["", "x"]]) is True
+
+    def test_empty_table_is_false(self):
+        assert _table_has_content([]) is False
 
 
 class TestSelectPages:


### PR DESCRIPTION
## What

Follow-up to #61, surfaced by a live test. pdfplumber detects **spurious all-empty grids** on figure-heavy scientific PDFs, and they dominated the `--tables` / `tables` MCP output (rows of `["",""]`). This filters out any table with no non-whitespace cell content.

## Change

- New `_table_has_content(rows)` helper; `PdfplumberExtractor.extract_tables` skips tables that fail it.
- 4 unit tests for the helper (all-empty / whitespace-only / has-content / empty-list).
- CHANGELOG note under the existing `[Unreleased]` pdfplumber entry.

## Verified live

Ran `zot pdf <key> --tables` on a real paper (single-cell colon-cancer, many figures): **45 → 25 tables**, with the genuine reagent and cell-cluster tables retained and the empty figure-grid noise removed.

## Gate

`mypy` / `ruff` / `ruff format --check` clean; `tests/test_extractor_pdfplumber.py` 16 pass.