### PR TITLE
feat(attach): --via-bridge for local-storage imports (fixes cloud-only attach + attanger conflict)

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -319,6 +319,20 @@ The envelope's `data.results[]` carries a per-attachment `status`
 bridge or stopped desktop aborts the whole command with `bridge_missing` (3) /
 `not_reachable` (5).
 
+## Attaching files (`zot attach`)
+
+`zot attach KEY --file paper.pdf` uploads via the Web API, which stores the
+file in **zotero.org cloud storage** (`data.stored: "cloud"`). The binary only
+appears in the local `storage/` folder after the desktop runs a *file* sync
+("Sync attachment files" enabled) — until then the desktop shows "the attached
+file could not be found". For local-first setups (and movers like
+zotero-attanger, which relocate attachments on import), pass `--via-bridge` to
+import through the running desktop via `POST /zot-cli/import-file` →
+`Zotero.Attachments.importFromFile(...)`. That writes straight into local
+storage (`data.stored: "local"`) and syncs *up* afterwards. `--via-bridge`
+requires the bridge plugin **v0.3.0+** and uses the same reachability codes as
+`find-pdf`/`rename` (`not_reachable` (5), `bridge_missing` (3)).
+
 ## Journal metrics (`zot enrich`)
 
 `zot enrich` writes journal metrics (impact factor, JCR/CAS quartile, core-journal

--- a/extension/zot-cli-bridge/README.md
+++ b/extension/zot-cli-bridge/README.md
@@ -22,6 +22,7 @@ plugin enables. It registers these endpoints on `http://127.0.0.1:23119`:
 | `GET` | `/zot-cli/ping` | Health probe — returns plugin + Zotero version |
 | `POST` | `/zot-cli/find-pdf` | Body: `{"key": "ABCD1234"}`. Triggers `Zotero.Attachments.addAvailableFile(item)` and returns the attached PDF's key on success, or `{found: false}` if no resolver had a hit. |
 | `POST` | `/zot-cli/rename` | Body: `{"attachmentKey": "...", "newName": "X.pdf", "force": false}`. Calls `item.renameAttachmentFile(newName, force)` on the attachment, syncs its title, and returns `{renamed, old_name, new_name}`. Powers `zot rename`. |
+| `POST` | `/zot-cli/import-file` | Body: `{"parentKey": "...", "path": "/abs/file.pdf", "title": "..."}`. Calls `Zotero.Attachments.importFromFile(...)` so the file is copied into **local** storage immediately (vs a Web-API upload that lands cloud-only). Returns `{imported, attachment_key, filename, content_type}`. Powers `zot attach --via-bridge`. |
 
 ## Install
 
@@ -49,10 +50,10 @@ zot bridge status        # verify -> Bridge OK
 3. Verify it's wired up:
    ```bash
    curl http://127.0.0.1:23119/zot-cli/ping
-   # {"ok": true, "bridge_version": "0.2.0", "zotero_version": "9.x.y", ...}
+   # {"ok": true, "bridge_version": "0.3.0", "zotero_version": "9.x.y", ...}
    ```
 
-You can now run `zot find-pdf <item-key>` from the parent repo.
+You can now run `zot find-pdf <item-key>` and `zot attach <key> --file <path> --via-bridge` from the parent repo.
 
 > **Manifest note:** the plugin manifest must include `icons` and
 > `applications.zotero.update_url`. Zotero 8/9 reject a manifest without them

--- a/extension/zot-cli-bridge/bootstrap.js
+++ b/extension/zot-cli-bridge/bootstrap.js
@@ -11,18 +11,27 @@
  *   POST /zot-cli/rename        — body {"attachmentKey","newName","libraryID"?,"force"?}
  *                                  renames the attachment's stored file via
  *                                  renameAttachmentFile and syncs its title
+ *   POST /zot-cli/import-file   — body {"parentKey","path","libraryID"?,"title"?}
+ *                                  imports a local file as an attachment via
+ *                                  Zotero.Attachments.importFromFile so the
+ *                                  binary lands in local storage immediately
  *
  * The whole point of going through Zotero (rather than fetching the PDF
  * directly from Python) is that Zotero's "Find Full Text" reuses the user's
  * configured PDF resolvers AND the authenticated sessions / proxies they've
- * set up in the desktop app, which Web-API access cannot do.
+ * set up in the desktop app, which Web-API access cannot do. import-file
+ * exists for the same reason in reverse: a Web-API upload only lands the file
+ * in zotero.org cloud storage, so it never appears in local storage/ until a
+ * file-sync pulls it back down — and that race breaks plugins that move
+ * attachments on import (e.g. zotero-attanger). Importing through the desktop
+ * writes straight to local storage and syncs *up*.
  *
  * License: CC-BY-NC-4.0 (matches the parent zotero-cli-cc repo).
  */
 
 /* global Zotero, ChromeUtils */
 
-const PLUGIN_VERSION = "0.2.0";
+const PLUGIN_VERSION = "0.3.0";
 
 function buildEndpoint(handler, { methods = ["GET"], dataTypes = ["application/json"] } = {}) {
   const Endpoint = function () {};
@@ -230,6 +239,98 @@ async function handleRename(options) {
   ];
 }
 
+async function handleImportFile(options) {
+  // Body: {"parentKey": "...", "path": "/abs/file.pdf", "libraryID"?, "title"?}
+  let parentKey = null;
+  let path = null;
+  let libraryID = null;
+  let title = null;
+  if (options.data && typeof options.data === "object") {
+    parentKey = options.data.parentKey || null;
+    path = options.data.path || null;
+    libraryID = options.data.libraryID || null;
+    title = options.data.title || null;
+  }
+  if (!parentKey || !path) {
+    return [400, "application/json", JSON.stringify({ ok: false, error: "missing 'parentKey' or 'path'" })];
+  }
+  libraryID = libraryID || Zotero.Libraries.userLibraryID;
+
+  // The CLI and Zotero share the machine (loopback), so the desktop can read
+  // the absolute path directly. Reject early if it can't see the file.
+  let fileExists = false;
+  try {
+    fileExists = Zotero.File.pathToFile(path).exists();
+  } catch (_) {
+    fileExists = false;
+  }
+  if (!fileExists) {
+    return [404, "application/json", JSON.stringify({ ok: false, error: "file not found on disk", path })];
+  }
+
+  let parent;
+  try {
+    parent = await Zotero.Items.getByLibraryAndKeyAsync(libraryID, parentKey);
+  } catch (e) {
+    return [500, "application/json", JSON.stringify({ ok: false, error: "lookup failed: " + e })];
+  }
+  if (!parent) {
+    return [
+      404,
+      "application/json",
+      JSON.stringify({ ok: false, error: "parent item not found", key: parentKey, libraryID }),
+    ];
+  }
+  if (!parent.isRegularItem()) {
+    return [
+      400,
+      "application/json",
+      JSON.stringify({ ok: false, error: "parent is not a regular item (note/attachment)", key: parentKey }),
+    ];
+  }
+
+  const fn = Zotero.Attachments && Zotero.Attachments.importFromFile;
+  if (!fn) {
+    return [
+      500,
+      "application/json",
+      JSON.stringify({ ok: false, error: "Zotero.Attachments.importFromFile is unavailable on this build" }),
+    ];
+  }
+
+  let attachment;
+  try {
+    const opts = { file: path, parentItemID: parent.id, libraryID };
+    if (title) opts.title = title;
+    attachment = await fn.call(Zotero.Attachments, opts);
+  } catch (e) {
+    Zotero.logError(e);
+    return [500, "application/json", JSON.stringify({ ok: false, error: "import failed: " + e, key: parentKey })];
+  }
+
+  let filename = null;
+  let contentType = null;
+  try {
+    filename = attachment.attachmentFilename;
+    contentType = attachment.attachmentContentType;
+  } catch (_) {
+    /* tolerate missing accessors on older builds */
+  }
+
+  return [
+    200,
+    "application/json",
+    JSON.stringify({
+      ok: true,
+      imported: true,
+      parent_key: parentKey,
+      attachment_key: attachment.key,
+      filename,
+      content_type: contentType,
+    }),
+  ];
+}
+
 const PING_ENDPOINT = buildEndpoint(handlePing, { methods: ["GET"] });
 const RENAME_ENDPOINT = buildEndpoint(handleRename, {
   methods: ["POST"],
@@ -238,6 +339,10 @@ const RENAME_ENDPOINT = buildEndpoint(handleRename, {
 const FIND_PDF_ENDPOINT = buildEndpoint(handleFindPdf, {
   methods: ["POST", "GET"],
   dataTypes: ["application/json", "application/x-www-form-urlencoded"],
+});
+const IMPORT_FILE_ENDPOINT = buildEndpoint(handleImportFile, {
+  methods: ["POST"],
+  dataTypes: ["application/json"],
 });
 
 function install() {}
@@ -248,6 +353,7 @@ async function startup({ id, version }) {
   Zotero.Server.Endpoints["/zot-cli/ping"] = PING_ENDPOINT;
   Zotero.Server.Endpoints["/zot-cli/find-pdf"] = FIND_PDF_ENDPOINT;
   Zotero.Server.Endpoints["/zot-cli/rename"] = RENAME_ENDPOINT;
+  Zotero.Server.Endpoints["/zot-cli/import-file"] = IMPORT_FILE_ENDPOINT;
 }
 
 function shutdown() {
@@ -256,5 +362,6 @@ function shutdown() {
     delete Zotero.Server.Endpoints["/zot-cli/ping"];
     delete Zotero.Server.Endpoints["/zot-cli/find-pdf"];
     delete Zotero.Server.Endpoints["/zot-cli/rename"];
+    delete Zotero.Server.Endpoints["/zot-cli/import-file"];
   }
 }

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "Zot CLI Bridge",
-  "version": "0.2.0",
-  "description": "Exposes Zotero Find Full Text and attachment rename over the local HTTP server for the zot CLI.",
+  "version": "0.3.0",
+  "description": "Exposes Zotero Find Full Text, attachment rename, and local file import over the local HTTP server for the zot CLI.",
   "author": "zotero-cli-cc",
   "homepage_url": "https://github.com/Agents365-ai/zotero-cli-cc",
   "icons": {

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -45,7 +45,15 @@ zot --no-interaction delete ITEMKEY
 zot update ITEMKEY --title "New Title"
 zot update ITEMKEY --field volume=42 --field pages=1-10
 zot attach ITEMKEY --file supplement.pdf
+zot attach ITEMKEY --file supplement.pdf --via-bridge   # store in LOCAL storage (needs Zotero desktop + bridge)
 ```
+
+> **`zot attach` storage note.** The default path uploads via the Web API into
+> zotero.org **cloud** storage — the file only appears in your local `storage/`
+> after the desktop runs a file-sync (and "Sync attachment files" is enabled).
+> If you keep files locally (or use a mover like zotero-attanger) and the file
+> shows as "could not be found", use `--via-bridge` to import through the running
+> desktop so the binary lands in local storage immediately.
 
 ### Safety Flags
 

--- a/src/zotero_cli_cc/commands/attach.py
+++ b/src/zotero_cli_cc/commands/attach.py
@@ -7,14 +7,23 @@ from pathlib import Path
 import click
 
 from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
+
+_BRIDGE_HINT = "Start Zotero desktop; run 'zot bridge install' to (re)install the bridge plugin (import needs v0.3.0+)"
 
 
 @click.command("attach")
 @click.argument("key")
 @click.option("--file", "file_path", required=True, type=click.Path(exists=True), help="File to upload")
+@click.option(
+    "--via-bridge",
+    is_flag=True,
+    help="Import through the running Zotero desktop (zot-cli-bridge plugin) so the "
+    "file lands in local storage instead of cloud-only. Plays nice with zotero-attanger.",
+)
 @click.option("--dry-run", is_flag=True, help="Preview the upload without calling the API")
 @click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
@@ -22,14 +31,23 @@ def attach_cmd(
     ctx: click.Context,
     key: str,
     file_path: str,
+    via_bridge: bool,
     dry_run: bool,
     idempotency_key: str | None,
 ) -> None:
     """Upload a file attachment to an existing Zotero item. MUTATES LIBRARY.
 
+    The default path uploads via the Zotero Web API, which stores the file in
+    zotero.org cloud storage — it only appears in your local `storage/` after
+    the desktop syncs the file down (requires "Sync attachment files" enabled).
+    Use `--via-bridge` to import through the running desktop instead, so the
+    file is written to local storage immediately and cooperates with plugins
+    that relocate attachments (e.g. zotero-attanger).
+
     \b
     Examples:
       zot attach ABC123 --file paper.pdf
+      zot attach ABC123 --file paper.pdf --via-bridge   # store locally via desktop
       zot attach ABC123 --file ~/Downloads/supplement.pdf
       zot attach ABC123 --file paper.pdf --dry-run
     """
@@ -40,11 +58,29 @@ def attach_cmd(
     size = fp.stat().st_size if fp.exists() else None
 
     if dry_run:
-        data = {"would": {"parent": key, "file": str(fp), "size_bytes": size}}
+        sink = "Zotero desktop (local storage)" if via_bridge else "the Web API (cloud storage)"
+        data = {"would": {"parent": key, "file": str(fp), "size_bytes": size, "via_bridge": via_bridge}}
         if json_out:
             click.echo(json.dumps(envelope_ok(data, extra={"dry_run": True}), indent=2, ensure_ascii=False))
         else:
-            click.echo(f"[dry-run] Would upload {fp} ({size} bytes) as attachment to '{key}'")
+            click.echo(f"[dry-run] Would attach {fp} ({size} bytes) to '{key}' via {sink}")
+        return
+
+    if via_bridge:
+        try:
+            result = import_file(key, str(fp.resolve()), title=fp.name)
+        except LocalBridgeError as e:
+            emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="attach")
+        att_key = result.get("attachment_key")
+        env = envelope_ok(
+            {"attachment_key": att_key, "parent_key": key, "file": str(fp), "stored": "local", "sync_required": True},
+            extra={"next": [f"zot read {key}"]},
+        )
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            click.echo(f"Attachment imported to local storage: {att_key}")
+            click.echo(SYNC_REMINDER, err=True)
         return
 
     library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
@@ -87,7 +123,7 @@ def attach_cmd(
         )
 
     env = envelope_ok(
-        {"attachment_key": att_key, "parent_key": key, "file": str(fp), "sync_required": True},
+        {"attachment_key": att_key, "parent_key": key, "file": str(fp), "stored": "cloud", "sync_required": True},
         extra={"next": [f"zot read {key}"]},
     )
     if idempotency_key:
@@ -96,4 +132,9 @@ def attach_cmd(
         click.echo(json.dumps(env, indent=2, ensure_ascii=False))
     else:
         click.echo(f"Attachment uploaded: {att_key}")
+        click.echo(
+            "Stored in zotero.org cloud; it reaches local storage/ only after a desktop file-sync. "
+            "Use --via-bridge to import into local storage directly.",
+            err=True,
+        )
         click.echo(SYNC_REMINDER, err=True)

--- a/src/zotero_cli_cc/core/local_bridge.py
+++ b/src/zotero_cli_cc/core/local_bridge.py
@@ -234,6 +234,84 @@ def rename_attachment(
     return _parse_json(resp)
 
 
+IMPORT_TIMEOUT = 120.0
+
+
+def import_file(
+    parent_key: str,
+    path: str,
+    *,
+    library_id: int | None = None,
+    title: str | None = None,
+    timeout: float = IMPORT_TIMEOUT,
+) -> dict[str, Any]:
+    """Import a local file as an attachment via the bridge's `importFromFile`.
+
+    Unlike the Web-API upload path (`writer.upload_attachment`), this asks the
+    running desktop to copy the file straight into its local storage, so the
+    binary exists on disk immediately, cooperates with attachment-moving
+    plugins (e.g. zotero-attanger), and syncs *up* to zotero.org afterwards.
+    `path` must be an absolute path the desktop process can read (the CLI and
+    Zotero share the machine).
+
+    Returns a dict with `imported`, `attachment_key`, `parent_key`, `filename`,
+    `content_type`.
+
+    Raises:
+        LocalBridgeError. `bridge_missing` means the endpoint isn't registered
+        (the installed plugin predates import — re-run `zot bridge install`,
+        needs v0.3.0+); `not_found` means the parent item or the file is gone.
+    """
+    payload: dict[str, Any] = {"parentKey": parent_key, "path": path}
+    if library_id is not None:
+        payload["libraryID"] = library_id
+    if title is not None:
+        payload["title"] = title
+    try:
+        resp = httpx.post(
+            f"{LOCAL_BASE}/zot-cli/import-file",
+            json=payload,
+            timeout=timeout,
+            headers={"User-Agent": _user_agent()},
+            trust_env=_TRUST_ENV,
+        )
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+        raise LocalBridgeError(
+            f"Cannot reach Zotero at {LOCAL_BASE} — is the desktop app running?",
+            code="not_reachable",
+            retryable=True,
+        ) from e
+    except httpx.HTTPError as e:
+        raise LocalBridgeError(f"Bridge request failed: {e}", code="network_error", retryable=True) from e
+
+    if resp.status_code == 404:
+        # Disambiguate "endpoint missing" (old plugin) from "parent/file gone".
+        body = _parse_json_or_none(resp)
+        if body and body.get("error"):
+            raise LocalBridgeError(str(body["error"]), code="not_found", retryable=False)
+        raise LocalBridgeError(
+            "The /zot-cli/import-file endpoint is missing — update the bridge plugin with 'zot bridge install'.",
+            code="bridge_missing",
+            retryable=False,
+        )
+    if resp.status_code == 400:
+        body = _parse_json_or_none(resp) or {}
+        raise LocalBridgeError(
+            f"Bridge rejected request: {body.get('error', resp.text)}",
+            code="validation_error",
+            retryable=False,
+        )
+    if resp.status_code >= 500:
+        raise LocalBridgeError(f"Bridge returned HTTP {resp.status_code}", code="bridge_error", retryable=True)
+    if resp.status_code != 200:
+        raise LocalBridgeError(
+            f"Bridge returned HTTP {resp.status_code}: {resp.text}",
+            code="bridge_error",
+            retryable=False,
+        )
+    return _parse_json(resp)
+
+
 def _parse_json(resp: httpx.Response) -> dict[str, Any]:
     try:
         data = resp.json()

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.6.0"
+SCHEMA_VERSION = "1.7.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -599,11 +599,25 @@ def _handle_trash_restore(key: str, library: str = "user") -> dict:
         return {"error": str(e), "context": "trash_restore"}
 
 
-def _handle_attach(parent_key: str, file_path: str, library: str = "user") -> dict:
+def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool = False) -> dict:
+    if via_bridge:
+        from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file
+
+        fp = Path(file_path)
+        try:
+            result = import_file(parent_key, str(fp.resolve()), title=fp.name)
+        except LocalBridgeError as e:
+            return {"error": str(e), "context": "attach", "code": e.code}
+        return {
+            "key": result.get("attachment_key"),
+            "parent_key": parent_key,
+            "filename": result.get("filename") or fp.name,
+            "stored": "local",
+        }
     try:
         writer = _get_writer(library)
         att_key = writer.upload_attachment(parent_key, Path(file_path))
-        return {"key": att_key, "parent_key": parent_key, "filename": Path(file_path).name}
+        return {"key": att_key, "parent_key": parent_key, "filename": Path(file_path).name, "stored": "cloud"}
     except ZoteroWriteError as e:
         return {"error": str(e), "context": "attach"}
 
@@ -1602,15 +1616,21 @@ def trash_restore(key: str, library: str = "user") -> dict:
 
 
 @mcp.tool()
-def attach(parent_key: str, file_path: str, library: str = "user") -> dict:
+def attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool = False) -> dict:
     """Upload a file attachment to an existing Zotero item.
+
+    By default uploads via the Web API into zotero.org cloud storage, which only
+    reaches the local storage/ folder after a desktop file-sync. Set via_bridge=True
+    to import through the running Zotero desktop (zot-cli-bridge plugin) so the file
+    lands in local storage immediately and cooperates with attachment-moving plugins.
 
     Args:
         parent_key: The item key to attach the file to.
         file_path: Path to the file to upload.
         library: Library — 'user' (default) or 'group:<id>'.
+        via_bridge: Import through the local Zotero desktop instead of the Web API.
     """
-    return _handle_attach(parent_key, file_path, library=library)
+    return _handle_attach(parent_key, file_path, library=library, via_bridge=via_bridge)
 
 
 @mcp.tool()

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
+from zotero_cli_cc.cli import main
+from zotero_cli_cc.core.local_bridge import LocalBridgeError
 from zotero_cli_cc.core.writer import ZoteroWriteError, ZoteroWriter
 
 
@@ -79,6 +83,99 @@ class TestAttachWriter:
             writer.upload_attachment("PARENT1", pdf)
 
 
+class TestImportFileClient:
+    @staticmethod
+    def _resp(status: int, body: dict | None):
+        r = MagicMock()
+        r.status_code = status
+        r.json.return_value = body if body is not None else {}
+        r.text = json.dumps(body) if body is not None else ""
+        return r
+
+    def test_success_returns_payload(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(
+            local_bridge.httpx,
+            "post",
+            lambda *a, **k: self._resp(200, {"ok": True, "attachment_key": "ATT1", "imported": True}),
+        )
+        out = local_bridge.import_file("PARENT1", "/abs/paper.pdf")
+        assert out["attachment_key"] == "ATT1"
+
+    def test_404_with_error_is_not_found(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(
+            local_bridge.httpx,
+            "post",
+            lambda *a, **k: self._resp(404, {"ok": False, "error": "file not found on disk"}),
+        )
+        with pytest.raises(LocalBridgeError) as ei:
+            local_bridge.import_file("PARENT1", "/abs/missing.pdf")
+        assert ei.value.code == "not_found"
+
+    def test_404_without_error_is_bridge_missing(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge.httpx, "post", lambda *a, **k: self._resp(404, None))
+        with pytest.raises(LocalBridgeError) as ei:
+            local_bridge.import_file("PARENT1", "/abs/paper.pdf")
+        assert ei.value.code == "bridge_missing"
+
+
+class TestAttachViaBridgeCLI:
+    def test_via_bridge_success(self, tmp_path, monkeypatch):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        captured: dict = {}
+
+        def fake_import(parent_key, path, **kw):
+            captured.update(parent=parent_key, path=path, title=kw.get("title"))
+            return {"imported": True, "attachment_key": "ATTLOCAL", "filename": "paper.pdf"}
+
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.import_file", fake_import)
+        result = CliRunner().invoke(main, ["--json", "attach", "PARENT1", "--file", str(pdf), "--via-bridge"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["attachment_key"] == "ATTLOCAL"
+        assert data["stored"] == "local"
+        assert captured == {"parent": "PARENT1", "path": str(pdf.resolve()), "title": "paper.pdf"}
+
+    def test_via_bridge_missing_plugin_exits_3(self, tmp_path, monkeypatch):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+
+        def boom(*a, **k):
+            raise LocalBridgeError("no endpoint", code="bridge_missing", retryable=False)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.import_file", boom)
+        result = CliRunner().invoke(main, ["attach", "PARENT1", "--file", str(pdf), "--via-bridge"])
+        assert result.exit_code == 3
+
+    def test_via_bridge_not_reachable_exits_5(self, tmp_path, monkeypatch):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+
+        def boom(*a, **k):
+            raise LocalBridgeError("down", code="not_reachable", retryable=True)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.import_file", boom)
+        result = CliRunner().invoke(main, ["attach", "PARENT1", "--file", str(pdf), "--via-bridge"])
+        assert result.exit_code == 5
+
+    def test_via_bridge_dry_run_does_not_call(self, tmp_path, monkeypatch):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        monkeypatch.setattr(
+            "zotero_cli_cc.commands.attach.import_file",
+            lambda *a, **k: pytest.fail("import_file must not run on dry-run"),
+        )
+        result = CliRunner().invoke(main, ["attach", "PARENT1", "--file", str(pdf), "--via-bridge", "--dry-run"])
+        assert result.exit_code == 0
+        assert "local storage" in result.output
+
+
 class TestAttachMCP:
     def test_handle_attach(self):
         from zotero_cli_cc.mcp_server import _handle_attach
@@ -89,3 +186,16 @@ class TestAttachMCP:
             mock_writer.upload_attachment.return_value = "ATT001"
             result = _handle_attach("PARENT1", "/tmp/test.pdf")
             assert result["key"] == "ATT001"
+            assert result["stored"] == "cloud"
+
+    def test_handle_attach_via_bridge(self, tmp_path):
+        from zotero_cli_cc import mcp_server
+
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        with patch("zotero_cli_cc.core.local_bridge.import_file") as mock_import:
+            mock_import.return_value = {"attachment_key": "ATTLOCAL", "filename": "paper.pdf"}
+            result = mcp_server._handle_attach("PARENT1", str(pdf), via_bridge=True)
+            assert result["key"] == "ATTLOCAL"
+            assert result["stored"] == "local"
+            mock_import.assert_called_once()


### PR DESCRIPTION
Fixes #64.

## Problem

`zot attach KEY --file x.pdf` and `zot add --pdf x.pdf` upload via the Zotero **Web API**, which stores the file in **zotero.org cloud storage**. The binary never lands in the local `~/Zotero/storage/{key}/` folder until the desktop runs a *file* sync (and "Sync attachment files" is enabled). So the desktop shows *"The attached file could not be found"*, and with [zotero-attanger](https://github.com/MuiseDestiny/zotero-attanger) installed the attachment ends up in **neither** the default storage path **nor** attanger's moved path — the import race breaks the link on both sides.

## Fix

Add a bridge-routed **local import** path, mirroring how `find-pdf`/`rename` already reuse the desktop:

- **Bridge plugin → v0.3.0**: new `POST /zot-cli/import-file` endpoint calling `Zotero.Attachments.importFromFile(...)`, so the file is copied straight into local storage and syncs *up* afterwards (cooperates with attanger).
- **`local_bridge.import_file()`** client with the same error mapping as `rename_attachment` (`not_reachable` / `bridge_missing` / `not_found` / `validation_error`).
- **`zot attach --via-bridge`** and **MCP `attach(via_bridge=True)`** route through it.
- The default Web-API path now reports `data.stored: "cloud"` and prints a one-line warning that the file is cloud-only until a desktop sync; the bridge path reports `data.stored: "local"`.

Schema bumped `1.6.0 → 1.7.0` (new flag + `stored` field). Docs (`agent-interface.md`), the bridge README, and the skill command reference are updated.

## Usage

```bash
zot attach ABC123 --file paper.pdf --via-bridge   # writes into local storage via the running desktop
```

Requires Zotero desktop running with the bridge plugin **v0.3.0+** (`zot bridge install`).

## Tests

`uv run pytest` → 744 passed / 1 skipped. New tests cover the `import_file` status-code mapping (incl. the `bridge_missing` vs `not_found` 404 disambiguation) and the CLI/MCP `--via-bridge` paths (success, dry-run no-op, `bridge_missing`→3, `not_reachable`→5). Lint/format/mypy clean; bridge `bootstrap.js` passes `node --check` and the `.xpi` builds.

## Note

This is additive — the default `zot attach` behaviour is unchanged (still a Web-API cloud upload), just better-labelled. `--via-bridge` is opt-in and targets the user's default library (group-library import via the bridge can be a follow-up).