### PR TITLE
feat(orphans): zot orphans — find & clean attachments whose file is missing locally

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -181,7 +181,7 @@ Commands are grouped by risk in `zot --help`:
 
 - **Read** — `search`, `list`, `read`, `export`, `recent`, `stats`, `cite`, `pdf`, `collection list`, `tag list`, ...
 - **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `enrich`, `bridge` (mutates local config, not the library)
-- **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`
+- **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`, `orphans` (its `clean` subcommand deletes attachment records)
 
 Each write or destructive command's `--help` carries a `MUTATES LIBRARY` marker. The same classification is available via `zot schema <cmd>.safety_tier`.
 
@@ -332,6 +332,32 @@ import through the running desktop via `POST /zot-cli/import-file` →
 storage (`data.stored: "local"`) and syncs *up* afterwards. `--via-bridge`
 requires the bridge plugin **v0.3.0+** and uses the same reachability codes as
 `find-pdf`/`rename` (`not_reachable` (5), `bridge_missing` (3)).
+
+## Orphaned attachments (`zot orphans`)
+
+The flip side of the cloud-vs-local split: a storage-backed attachment whose
+file is missing from the local `storage/` folder (Zotero shows "the attached
+file could not be found"). `zot orphans list` scans for them (read-only) and
+classifies each:
+
+- `dead` — no copy anywhere (no server hash, not pending download). Safe to remove.
+- `recoverable` — the server still has it (pending download / has a storage hash). Fix by running a Zotero file-sync, **not** by deleting.
+- `unknown` — sync-state columns unavailable (e.g. a minimal database).
+
+```bash
+zot orphans list                       # all missing-file attachments, classified
+zot orphans list --dead-only           # only the truly dead ones
+zot orphans clean --dry-run            # preview deletions (dead only by default)
+zot orphans clean --yes                # delete dead orphans via the Web API
+zot orphans clean --include-recoverable --yes   # also delete server-held ones (discards the cloud copy)
+```
+
+`clean` deletes through the Web API (same path as `zot delete`), so records that
+were never synced to the server come back `not_found` — remove those from the
+Zotero desktop. It honors `--dry-run`, `--yes` / `--no-interaction`, and
+`--idempotency-key`, and reports partial success via the standard
+`envelope_partial` shape. The read scan is also exposed to agents as the MCP
+`find_orphans` tool.
 
 ## Journal metrics (`zot enrich`)
 

--- a/docs/en/mcp/tools.md
+++ b/docs/en/mcp/tools.md
@@ -19,6 +19,7 @@
 | `recent` | Recently added/modified | `days?`, `modified?`, `limit?` |
 | `note_view` | View item notes | `key` |
 | `tag_view` | View item tags | `key` |
+| `find_orphans` | Find attachments whose file is missing locally | `dead_only?` |
 | `collection_list` | List all collections | — |
 | `collection_items` | Items in a collection | `collection_key` |
 | `duplicates` | Find duplicates | `strategy?`, `threshold?`, `limit?` |
@@ -33,7 +34,7 @@
 | `add_from_pdf` | Add from local PDF | `file_path`, `doi_override?` |
 | `delete` | Delete items (trash) | `keys` |
 | `update` | Update metadata | `key`, `title?`, `date?`, `fields?` |
-| `attach` | Upload file attachment | `parent_key`, `file_path` |
+| `attach` | Upload file attachment | `parent_key`, `file_path`, `via_bridge?` |
 | `note_add` | Add note to item | `key`, `content` |
 | `note_update` | Update existing note | `note_key`, `content` |
 | `tag_add` | Add tags to items | `keys`, `tags` |

--- a/docs/zh/mcp/tools.md
+++ b/docs/zh/mcp/tools.md
@@ -19,6 +19,7 @@
 | `recent` | 最近添加/修改的条目 | `days?`, `modified?`, `limit?` |
 | `note_view` | 查看条目笔记 | `key` |
 | `tag_view` | 查看条目标签 | `key` |
+| `find_orphans` | 查找本地缺失文件的附件 | `dead_only?` |
 | `collection_list` | 列出所有集合 | — |
 | `collection_items` | 集合中的条目 | `collection_key` |
 | `duplicates` | 查找重复 | `strategy?`, `threshold?`, `limit?` |
@@ -33,7 +34,7 @@
 | `add_from_pdf` | 从本地 PDF 添加 | `file_path`, `doi_override?` |
 | `delete` | 删除条目（移入回收站） | `keys` |
 | `update` | 更新元数据 | `key`, `title?`, `date?`, `fields?` |
-| `attach` | 上传附件 | `parent_key`, `file_path` |
+| `attach` | 上传附件 | `parent_key`, `file_path`, `via_bridge?` |
 | `note_add` | 添加笔记 | `key`, `content` |
 | `note_update` | 更新笔记 | `note_key`, `content` |
 | `tag_add` | 添加标签 | `keys`, `tags` |

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -55,6 +55,22 @@ zot attach ITEMKEY --file supplement.pdf --via-bridge   # store in LOCAL storage
 > shows as "could not be found", use `--via-bridge` to import through the running
 > desktop so the binary lands in local storage immediately.
 
+#### Cleaning up orphaned attachments
+
+When attachments show "the attached file could not be found" (file missing from
+local `storage/`), scan and clean them:
+
+```bash
+zot orphans list                       # classify: dead / recoverable / unknown
+zot orphans list --dead-only           # only ones with no copy anywhere
+zot orphans clean --dry-run            # preview (targets 'dead' only by default)
+zot orphans clean --yes                # delete dead orphans via the Web API
+```
+
+`recoverable` orphans still have a server copy — run a Zotero file-sync to pull
+them down rather than deleting. `clean --include-recoverable` also deletes those
+(discards the cloud copy too), so use it with care.
+
 ### Safety Flags
 
 ```bash

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -24,6 +24,7 @@ from zotero_cli_cc.commands.list_cmd import list_cmd
 from zotero_cli_cc.commands.mcp import mcp_group
 from zotero_cli_cc.commands.note import note_cmd
 from zotero_cli_cc.commands.open_cmd import open_cmd
+from zotero_cli_cc.commands.orphans import orphans_group
 from zotero_cli_cc.commands.pdf import pdf_cmd
 from zotero_cli_cc.commands.read import read_cmd
 from zotero_cli_cc.commands.recent import recent_cmd
@@ -69,7 +70,7 @@ _READ_COMMANDS = {
     "trash",
 }
 _WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge", "rename", "enrich"}
-_DESTRUCTIVE_COMMANDS = {"delete", "update-status"}
+_DESTRUCTIVE_COMMANDS = {"delete", "update-status", "orphans"}
 
 
 def _hoist_global_flags(args: list[str]) -> list[str]:
@@ -303,6 +304,7 @@ main.add_command(find_pdf_cmd, "find-pdf")
 main.add_command(rename_cmd, "rename")
 main.add_command(enrich_cmd, "enrich")
 main.add_command(bridge_group, "bridge")
+main.add_command(orphans_group, "orphans")
 main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")
 main.add_command(ask_cmd, "ask")

--- a/src/zotero_cli_cc/commands/orphans.py
+++ b/src/zotero_cli_cc/commands/orphans.py
@@ -1,0 +1,236 @@
+"""`zot orphans` — find and clean attachments whose stored file is missing locally.
+
+A Web-API upload (``zot attach``) lands the file in zotero.org cloud storage,
+so it never appears in the local ``storage/`` folder until a desktop file-sync
+pulls it down. Failed retries can also leave attachment records pointing at a
+file that exists nowhere. Those records make Zotero show "the attached file
+could not be found". ``list`` scans for them (read-only); ``clean`` deletes the
+truly dead ones via the Web API.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sys
+
+import click
+
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
+from zotero_cli_cc.formatter import envelope_ok, envelope_partial
+from zotero_cli_cc.models import OrphanAttachment
+
+
+@click.group("orphans")
+def orphans_group() -> None:
+    """Find / clean attachments whose stored file is missing from local storage."""
+
+
+def _scan(ctx: click.Context) -> list[OrphanAttachment]:
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    db_path = get_data_dir(cfg) / "zotero.sqlite"
+    reader = ZoteroReader(
+        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
+    )
+    return reader.find_orphan_attachments()
+
+
+def _counts(orphans: list[OrphanAttachment]) -> dict[str, int]:
+    out = {"dead": 0, "recoverable": 0, "unknown": 0}
+    for o in orphans:
+        out[o.classification] = out.get(o.classification, 0) + 1
+    return out
+
+
+@orphans_group.command("list")
+@click.option("--dead-only", is_flag=True, help="Only show 'dead' orphans (no copy anywhere); hide recoverable ones")
+@click.pass_context
+def orphans_list(ctx: click.Context, dead_only: bool) -> None:
+    """List storage-backed attachments whose file is missing from local storage.
+
+    Each is classified: 'dead' (no copy anywhere — safe to remove with
+    `zot orphans clean`), 'recoverable' (the server still has it — run a Zotero
+    file-sync or open the item to download it), or 'unknown' (sync state
+    unavailable).
+
+    \b
+    Examples:
+      zot orphans list
+      zot orphans list --dead-only
+      zot --json orphans list
+    """
+    json_out = ctx.obj.get("json", False)
+    orphans = _scan(ctx)
+    if dead_only:
+        orphans = [o for o in orphans if o.classification == "dead"]
+
+    data = {"orphans": [dataclasses.asdict(o) for o in orphans], "total": len(orphans), "counts": _counts(orphans)}
+    if json_out:
+        click.echo(json.dumps(envelope_ok(data), indent=2, ensure_ascii=False))
+        return
+
+    if not orphans:
+        click.echo("No orphaned attachments found — every stored file is present locally.")
+        return
+    for o in orphans:
+        parent = f" (parent {o.parent_key}: {o.parent_title})" if o.parent_key else " (top-level)"
+        click.echo(f"[{o.classification}] {o.attachment_key}  {o.filename}{parent}")
+    c = _counts(orphans)
+    click.echo(
+        f"\n{len(orphans)} orphan(s): {c['dead']} dead, {c['recoverable']} recoverable, {c['unknown']} unknown.",
+        err=True,
+    )
+    if c["dead"]:
+        click.echo("Remove the dead ones with: zot orphans clean", err=True)
+    if c["recoverable"]:
+        click.echo("Recoverable ones download on a Zotero file-sync (enable 'Sync attachment files').", err=True)
+
+
+@orphans_group.command("clean")
+@click.option(
+    "--include-recoverable",
+    is_flag=True,
+    help="Also delete 'recoverable' orphans — DISCARDS the server copy too. Use with care.",
+)
+@click.option("--yes", is_flag=True, help="Skip confirmation")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without executing")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
+@click.pass_context
+def orphans_clean(
+    ctx: click.Context,
+    include_recoverable: bool,
+    yes: bool,
+    dry_run: bool,
+    idempotency_key: str | None,
+) -> None:
+    """Delete orphaned attachment records via the Web API. MUTATES LIBRARY.
+
+    By default only removes 'dead' orphans (no file anywhere). Pass
+    --include-recoverable to also delete ones the server still holds (this
+    discards the cloud copy too). Deletion goes through the Zotero Web API, so
+    records that were never synced to the server return 'not_found' — remove
+    those from the Zotero desktop instead.
+
+    \b
+    Examples:
+      zot orphans clean --dry-run
+      zot orphans clean --yes
+      zot orphans clean --include-recoverable --dry-run
+    """
+    json_out = ctx.obj.get("json", False)
+    orphans = _scan(ctx)
+    targets = [o for o in orphans if o.classification == "dead" or (include_recoverable and o.classification != "dead")]
+    keys = [o.attachment_key for o in targets]
+
+    if dry_run:
+        data = {"would_delete": keys, "count": len(keys), "targets": [dataclasses.asdict(o) for o in targets]}
+        if json_out:
+            click.echo(json.dumps(envelope_ok(data, extra={"dry_run": True}), indent=2, ensure_ascii=False))
+        else:
+            for o in targets:
+                click.echo(f"[dry-run] Would delete [{o.classification}] {o.attachment_key} ({o.filename})")
+            click.echo(f"[dry-run] {len(keys)} orphan(s) would be deleted.", err=True)
+        return
+
+    if not keys:
+        msg = "No dead orphans to clean (pass --include-recoverable to target recoverable ones)."
+        if json_out:
+            click.echo(json.dumps(envelope_ok({"deleted": [], "count": 0}), indent=2, ensure_ascii=False))
+        else:
+            click.echo(msg)
+        return
+
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
+    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
+    library_type = ctx.obj.get("library_type", "user")
+    if library_type == "group" and ctx.obj.get("group_id"):
+        library_id = ctx.obj["group_id"]
+    if not library_id or not api_key:
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
+            output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="orphans clean",
+        )
+
+    no_interaction = ctx.obj.get("no_interaction", False)
+    if not yes and not no_interaction:
+        if not sys.stdin.isatty():
+            emit_error(
+                "confirmation_required",
+                f"Refusing to delete {len(keys)} orphan(s) without confirmation on non-interactive stdin",
+                output_json=json_out,
+                hint="Pass --yes to confirm or use --dry-run to preview",
+                context="orphans clean",
+            )
+        if not click.confirm(f"Delete {len(keys)} orphaned attachment(s)?"):
+            if json_out:
+                click.echo(json.dumps(envelope_ok({"cancelled": True}), indent=2, ensure_ascii=False))
+            else:
+                click.echo("Cancelled.", err=True)
+            return
+
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = "orphans-clean:" + ",".join(sorted(keys))
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                click.echo(f"Deleted {len(keys)} orphan(s) (cached).")
+            return
+
+    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    succeeded: list[dict] = []
+    failed: list[dict] = []
+    for key in keys:
+        try:
+            writer.delete_item(key)
+            succeeded.append({"key": key})
+            if not json_out:
+                click.echo(f"Deleted orphan '{key}'.")
+        except ZoteroWriteError as e:
+            failed.append({"key": key, "error": {"code": e.code, "message": str(e), "retryable": e.retryable}})
+            if not json_out:
+                click.echo(f"Error: delete failed for '{key}': {e}", err=True)
+
+    if json_out:
+        if failed and succeeded:
+            env = envelope_partial(succeeded, failed, meta={"sync_required": True})
+        elif failed:
+            click.echo(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": {
+                            "code": "api_error",
+                            "message": f"{len(failed)} delete(s) failed",
+                            "retryable": True,
+                            "failed": failed,
+                        },
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+            raise SystemExit(EXIT_RUNTIME)
+        else:
+            env = envelope_ok(
+                {"deleted": [s["key"] for s in succeeded], "count": len(succeeded), "sync_required": True}
+            )
+        if idempotency_key and not failed:
+            store_cached(cache_scope, idempotency_key, env)
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+    else:
+        if not failed:
+            click.echo(SYNC_REMINDER, err=True)
+        if failed:
+            raise SystemExit(EXIT_RUNTIME)

--- a/src/zotero_cli_cc/commands/schema.py
+++ b/src/zotero_cli_cc/commands/schema.py
@@ -76,6 +76,7 @@ _SAFETY_TIER: dict[str, str] = {
     # destructive
     "delete": "destructive",
     "update-status": "destructive",
+    "orphans": "destructive",
 }
 
 

--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -16,8 +16,13 @@ from zotero_cli_cc.models import (
     DuplicateGroup,
     Item,
     Note,
+    OrphanAttachment,
     SearchResult,
 )
+
+# Zotero file sync states that mean "the server still has a copy to pull down".
+_SYNC_STATE_TO_DOWNLOAD = 1
+_SYNC_STATE_FORCE_DOWNLOAD = 4
 
 # Excluded type names (looked up dynamically per database)
 _EXCLUDED_TYPE_NAMES = ("attachment", "note", "annotation")
@@ -612,6 +617,65 @@ class ZoteroReader:
                 continue
             return att
         return None
+
+    def find_orphan_attachments(self) -> list[OrphanAttachment]:
+        """Find storage-backed attachments whose file is missing from local storage.
+
+        These are the records that make Zotero show "the attached file could not
+        be found" — typically created by a Web-API upload that landed the file
+        in cloud storage only. Each is classified (see `OrphanAttachment`) so a
+        caller can safely delete the truly dead ones while leaving merely
+        not-yet-downloaded files alone.
+        """
+        conn = self._connect()
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(itemAttachments)")}
+        has_sync = "syncState" in cols
+        has_hash = "storageHash" in cols
+        extra = (", ia.syncState" if has_sync else "") + (", ia.storageHash" if has_hash else "")
+        rows = conn.execute(
+            "SELECT i.key, ia.parentItemID, ia.contentType, ia.path" + extra + " "
+            "FROM itemAttachments ia JOIN items i ON ia.itemID = i.itemID "
+            "WHERE ia.path LIKE 'storage:%' "
+            "ORDER BY i.itemID"
+        ).fetchall()
+
+        orphans: list[OrphanAttachment] = []
+        for r in rows:
+            raw_path = r["path"] or ""
+            resolved = self._resolver.resolve(r["key"], raw_path)
+            if resolved and resolved.exists():
+                continue  # file is present locally — not an orphan
+
+            sync_state = r["syncState"] if has_sync else None
+            storage_hash = r["storageHash"] if has_hash else None
+            if not has_sync and not has_hash:
+                classification = "unknown"
+            elif storage_hash or sync_state in (_SYNC_STATE_TO_DOWNLOAD, _SYNC_STATE_FORCE_DOWNLOAD):
+                classification = "recoverable"
+            else:
+                classification = "dead"
+
+            parent_key = None
+            parent_title = None
+            if r["parentItemID"] is not None:
+                prow = conn.execute("SELECT key FROM items WHERE itemID = ?", (r["parentItemID"],)).fetchone()
+                if prow:
+                    parent_key = prow["key"]
+                    parent_item = self.get_item(parent_key)
+                    parent_title = parent_item.title if parent_item else None
+
+            orphans.append(
+                OrphanAttachment(
+                    attachment_key=r["key"],
+                    filename=raw_path.replace("storage:", "").split("/")[-1] if raw_path else "",
+                    content_type=r["contentType"] or "",
+                    classification=classification,
+                    expected_path=str(resolved) if resolved else None,
+                    parent_key=parent_key,
+                    parent_title=parent_title,
+                )
+            )
+        return orphans
 
     def get_arxiv_preprints(
         self,

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -343,6 +343,19 @@ def _handle_recent(days: int, modified: bool, limit: int, library: str = "user")
     return {"items": [_item_to_dict(i) for i in items], "total": len(items)}
 
 
+def _handle_find_orphans(dead_only: bool = False, library: str = "user") -> dict:
+    import dataclasses
+
+    reader = _get_reader(library)
+    orphans = reader.find_orphan_attachments()
+    if dead_only:
+        orphans = [o for o in orphans if o.classification == "dead"]
+    counts = {"dead": 0, "recoverable": 0, "unknown": 0}
+    for o in orphans:
+        counts[o.classification] = counts.get(o.classification, 0) + 1
+    return {"orphans": [dataclasses.asdict(o) for o in orphans], "total": len(orphans), "counts": counts}
+
+
 def _handle_note_view(key: str, library: str = "user") -> dict:
     reader = _get_reader(library)
     notes = reader.get_notes(key)
@@ -1631,6 +1644,23 @@ def attach(parent_key: str, file_path: str, library: str = "user", via_bridge: b
         via_bridge: Import through the local Zotero desktop instead of the Web API.
     """
     return _handle_attach(parent_key, file_path, library=library, via_bridge=via_bridge)
+
+
+@mcp.tool()
+def find_orphans(dead_only: bool = False, library: str = "user") -> dict:
+    """Find storage-backed attachments whose file is missing from local storage.
+
+    These show "the attached file could not be found" in Zotero — usually a
+    Web-API upload that landed the file in cloud storage only. Each is
+    classified: 'dead' (no copy anywhere — safe to delete with the `delete`
+    tool), 'recoverable' (server still has it — run a Zotero file-sync), or
+    'unknown'. Read-only; pair with `delete` to clean up the dead ones.
+
+    Args:
+        dead_only: Only return 'dead' orphans (no copy anywhere).
+        library: Library — 'user' (default) or 'group:<id>'.
+    """
+    return _handle_find_orphans(dead_only=dead_only, library=library)
 
 
 @mcp.tool()

--- a/src/zotero_cli_cc/models.py
+++ b/src/zotero_cli_cc/models.py
@@ -60,6 +60,25 @@ class Attachment:
 
 
 @dataclass
+class OrphanAttachment:
+    """A storage-backed attachment whose file is missing from local storage.
+
+    classification:
+      - 'dead': no copy anywhere (no server hash, not pending download) — safe to remove.
+      - 'recoverable': a server copy exists (pending download / has storage hash) — fix by syncing.
+      - 'unknown': sync state columns unavailable (e.g. a minimal/test database).
+    """
+
+    attachment_key: str
+    filename: str
+    content_type: str
+    classification: str
+    expected_path: str | None = None
+    parent_key: str | None = None
+    parent_title: str | None = None
+
+
+@dataclass
 class ErrorInfo:
     message: str
     context: str = ""

--- a/tests/test_orphans.py
+++ b/tests/test_orphans.py
@@ -1,0 +1,182 @@
+"""Tests for `zot orphans` — missing-file attachment detection and cleanup."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from zotero_cli_cc.cli import main
+from zotero_cli_cc.core.reader import ZoteroReader
+
+
+def _make_db(dir_path: Path, attachments: list[dict], *, with_sync_cols: bool = True) -> Path:
+    """Build a minimal Zotero-like DB + storage tree.
+
+    Each attachment dict: {key, path, present(bool), syncState?, storageHash?}.
+    `present` controls whether the file actually exists under storage/<key>/.
+    """
+    db = dir_path / "zotero.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE items (itemID INTEGER PRIMARY KEY, key TEXT)")
+    if with_sync_cols:
+        con.execute(
+            "CREATE TABLE itemAttachments (itemID INT, parentItemID INT, linkMode INT, "
+            "contentType TEXT, path TEXT, syncState INT, storageHash TEXT)"
+        )
+    else:
+        con.execute(
+            "CREATE TABLE itemAttachments (itemID INT, parentItemID INT, linkMode INT, contentType TEXT, path TEXT)"
+        )
+    storage = dir_path / "storage"
+    for i, a in enumerate(attachments, start=1):
+        con.execute("INSERT INTO items (itemID, key) VALUES (?, ?)", (i, a["key"]))
+        filename = a["path"].replace("storage:", "")
+        if with_sync_cols:
+            con.execute(
+                "INSERT INTO itemAttachments VALUES (?, NULL, 0, ?, ?, ?, ?)",
+                (i, a.get("content_type", "application/pdf"), a["path"], a.get("syncState", 0), a.get("storageHash")),
+            )
+        else:
+            con.execute(
+                "INSERT INTO itemAttachments VALUES (?, NULL, 0, ?, ?)",
+                (i, a.get("content_type", "application/pdf"), a["path"]),
+            )
+        if a["present"]:
+            (storage / a["key"]).mkdir(parents=True, exist_ok=True)
+            (storage / a["key"] / filename).write_bytes(b"%PDF-1.4 x")
+    con.commit()
+    con.close()
+    return db
+
+
+class TestFindOrphanAttachments:
+    def test_classification(self, tmp_path):
+        db = _make_db(
+            tmp_path,
+            [
+                {"key": "PRESENT01", "path": "storage:ok.pdf", "present": True},
+                {"key": "DEAD0001", "path": "storage:gone.pdf", "present": False, "syncState": 0, "storageHash": None},
+                {"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1},
+                {
+                    "key": "RECOV0002",
+                    "path": "storage:hash.pdf",
+                    "present": False,
+                    "syncState": 0,
+                    "storageHash": "abc",
+                },
+            ],
+        )
+        orphans = ZoteroReader(db, library_id=1).find_orphan_attachments()
+        by_key = {o.attachment_key: o.classification for o in orphans}
+        assert "PRESENT01" not in by_key  # file exists locally -> not an orphan
+        assert by_key == {"DEAD0001": "dead", "RECOV0001": "recoverable", "RECOV0002": "recoverable"}
+
+    def test_filename_strips_storage_prefix(self, tmp_path):
+        db = _make_db(tmp_path, [{"key": "D1", "path": "storage:WechatIMG.jpg", "present": False}])
+        orphans = ZoteroReader(db, library_id=1).find_orphan_attachments()
+        assert orphans[0].filename == "WechatIMG.jpg"
+
+    def test_unknown_when_no_sync_columns(self, tmp_path):
+        db = _make_db(tmp_path, [{"key": "X1", "path": "storage:gone.pdf", "present": False}], with_sync_cols=False)
+        orphans = ZoteroReader(db, library_id=1).find_orphan_attachments()
+        assert orphans[0].classification == "unknown"
+
+
+def _invoke(args, data_dir: Path, json_out=True, **kw):
+    base = ["--json"] if json_out else []
+    env = {"ZOT_DATA_DIR": str(data_dir)}
+    return CliRunner().invoke(main, base + args, env=env, **kw)
+
+
+class TestOrphansListCLI:
+    def test_list_reports_counts(self, tmp_path):
+        _make_db(
+            tmp_path,
+            [
+                {"key": "DEAD0001", "path": "storage:gone.pdf", "present": False, "syncState": 0},
+                {"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1},
+            ],
+        )
+        result = _invoke(["orphans", "list"], tmp_path)
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["total"] == 2
+        assert data["counts"] == {"dead": 1, "recoverable": 1, "unknown": 0}
+
+    def test_dead_only_filters(self, tmp_path):
+        _make_db(
+            tmp_path,
+            [
+                {"key": "DEAD0001", "path": "storage:gone.pdf", "present": False, "syncState": 0},
+                {"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1},
+            ],
+        )
+        data = json.loads(_invoke(["orphans", "list", "--dead-only"], tmp_path).output)["data"]
+        assert [o["attachment_key"] for o in data["orphans"]] == ["DEAD0001"]
+
+
+class TestOrphansCleanCLI:
+    def _two_orphans(self, tmp_path):
+        _make_db(
+            tmp_path,
+            [
+                {"key": "DEAD0001", "path": "storage:gone.pdf", "present": False, "syncState": 0},
+                {"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1},
+            ],
+        )
+
+    def test_dry_run_targets_dead_only(self, tmp_path):
+        self._two_orphans(tmp_path)
+        data = json.loads(_invoke(["orphans", "clean", "--dry-run"], tmp_path).output)["data"]
+        assert data["would_delete"] == ["DEAD0001"]
+        assert data["count"] == 1
+
+    def test_dry_run_include_recoverable(self, tmp_path):
+        self._two_orphans(tmp_path)
+        data = json.loads(_invoke(["orphans", "clean", "--dry-run", "--include-recoverable"], tmp_path).output)["data"]
+        assert set(data["would_delete"]) == {"DEAD0001", "RECOV0001"}
+
+    def test_clean_deletes_via_writer(self, tmp_path, monkeypatch):
+        self._two_orphans(tmp_path)
+        deleted: list[str] = []
+
+        class FakeWriter:
+            def __init__(self, *a, **k): ...
+            def delete_item(self, key):
+                deleted.append(key)
+
+        monkeypatch.setattr("zotero_cli_cc.commands.orphans.ZoteroWriter", FakeWriter)
+        env = {"ZOT_DATA_DIR": str(tmp_path), "ZOT_LIBRARY_ID": "123", "ZOT_API_KEY": "abc"}
+        result = CliRunner().invoke(main, ["--json", "orphans", "clean", "--yes"], env=env)
+        assert result.exit_code == 0
+        assert deleted == ["DEAD0001"]
+        data = json.loads(result.output)["data"]
+        assert data["deleted"] == ["DEAD0001"]
+
+    def test_clean_nothing_to_do(self, tmp_path):
+        _make_db(tmp_path, [{"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1}])
+        env = {"ZOT_DATA_DIR": str(tmp_path), "ZOT_LIBRARY_ID": "123", "ZOT_API_KEY": "abc"}
+        result = CliRunner().invoke(main, ["--json", "orphans", "clean", "--yes"], env=env)
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["count"] == 0
+
+
+class TestOrphansMCP:
+    def test_handle_find_orphans(self, tmp_path, monkeypatch):
+        from zotero_cli_cc import mcp_server
+
+        db = _make_db(
+            tmp_path,
+            [
+                {"key": "DEAD0001", "path": "storage:gone.pdf", "present": False, "syncState": 0},
+                {"key": "RECOV0001", "path": "storage:later.pdf", "present": False, "syncState": 1},
+            ],
+        )
+        monkeypatch.setattr(mcp_server, "_get_reader", lambda library="user": ZoteroReader(db, library_id=1))
+        out = mcp_server._handle_find_orphans(dead_only=True)
+        assert out["total"] == 1
+        assert out["orphans"][0]["attachment_key"] == "DEAD0001"


### PR DESCRIPTION
Builds the **orphan-cleanup helper** tracked in #64 (remaining item #1).

## Problem

After a Web-API upload (`zot attach`), the file lives in zotero.org **cloud** storage and never reaches local `storage/` until a desktop file-sync pulls it down. Failed retries also leave attachment records pointing at a file that exists nowhere. Both show **"the attached file could not be found"** in Zotero. The reporter accumulated ~12 such records with no clean way to find or remove them.

## What this adds

**`reader.find_orphan_attachments()`** — a library-wide scan (local SQLite) of storage-backed attachments whose file is missing from local `storage/`, classified using `syncState` / `storageHash`:

| class | meaning | action |
|-------|---------|--------|
| `dead` | no copy anywhere (no server hash, not pending download) | safe to delete |
| `recoverable` | server still has it (to-download / has storage hash) | run a Zotero file-sync — **don't** delete |
| `unknown` | sync-state columns absent (minimal/test DB) | — |

Column presence is detected defensively so it works on databases without the sync columns.

**`zot orphans` command group:**
- `zot orphans list [--dead-only]` — read-only, classified report.
- `zot orphans clean` — deletes orphan records via the Web API (same path as `zot delete`). Targets **`dead` only** by default; `--include-recoverable` also deletes server-held ones (discards the cloud copy). Honors `--dry-run`, `--yes` / `--no-interaction`, `--idempotency-key`, and reports partial success via `envelope_partial`.

Registered in the **destructive** safety tier in both `cli.py` and `schema.py` (kept in sync — the manual checklist from CLAUDE.md). MCP gets a read-only **`find_orphans`** tool mirroring the scan; cleanup reuses the existing `delete` tool.

## Verified on a real library

Scanned a live 2,845-attachment library: correctly found **83 missing-file attachments — 81 `recoverable`** (syncState=to_download, i.e. just not downloaded yet — *not* deleted) and **2 `dead`** (records whose file exists nowhere). `clean --dry-run` targeted only the 2 dead ones. No false positives on the not-yet-downloaded files — which is the key safety property.

## Usage

```bash
zot orphans list                       # dead / recoverable / unknown
zot orphans clean --dry-run            # preview (dead only)
zot orphans clean --yes                # delete dead orphans
zot orphans clean --include-recoverable --yes   # also drop server-held ones
```

## Tests

`uv run pytest` → **754 passed / 1 skipped** (10 new). Covers classification (incl. present-file exclusion and the `unknown` path), `list`/`--dead-only`, `clean` dry-run targeting, real deletion via a mocked writer, the no-op case, and the MCP handler. Lint/format/mypy clean; schema/help drift test green with the new destructive-tier command.