### PR TITLE
chore: release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-03
+
 ### Added
 
+- **`zot orphans`** — find and clean attachments whose stored file is missing
+  from local `storage/` (Zotero's "the attached file could not be found").
+  `orphans list` classifies each as `dead` (no copy anywhere — safe to remove),
+  `recoverable` (server still has it — fix by file-sync), or `unknown`;
+  `orphans clean` deletes the dead ones via the Web API (`--dry-run` / `--yes` /
+  `--idempotency-key`; `--include-recoverable` to also drop server-held ones).
+  Mirrored as the read-only `find_orphans` MCP tool.
+- **`zot attach --via-bridge`** — import a file through the running Zotero
+  desktop (the `zot-cli-bridge` plugin's new `POST /zot-cli/import-file`
+  endpoint → `Zotero.Attachments.importFromFile`) so the binary lands in local
+  storage immediately instead of cloud-only, cooperating with attachment movers
+  like zotero-attanger. Bridge plugin bumped to **v0.3.0**; also exposed as
+  `attach(via_bridge=True)` over MCP.
 - **GROBID extractor** (`pdf.extractor = "grobid"` / `ZOT_GROBID_URL`): a
   references/structure tier backed by a running GROBID service (default
   `http://localhost:8070`). Adds `extract_references()` to the extractor
@@ -28,6 +43,17 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`pymupdf4llm` bundled into the `[pymupdf]` extra**: installing the extra now
   also enables higher-quality local Markdown output (no API / network — the
   `PyMuPdfExtractor` already uses it when present).
+
+### Changed
+
+- **License**: relicensed from CC-BY-NC-4.0 to a dual license —
+  **AGPL-3.0-or-later** for open-source use plus a separate **commercial
+  license** (see `LICENSE` / `LICENSE-COMMERCIAL`). The base install ships no
+  AGPL runtime code (default `pdfium` extractor; `pymupdf` is opt-in).
+- **`zot attach`** now reports where the file landed via `data.stored`
+  (`"cloud"` for the default Web-API upload, `"local"` for `--via-bridge`), and
+  warns that a cloud upload only reaches local `storage/` after a desktop
+  file-sync. `schema_version` 1.6.0 → 1.7.0.
 
 ## [0.7.0] - 2026-05-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.7.0"
+version = "0.8.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release prep for **0.8.0** (0.7.0 is already on PyPI). Bumps `pyproject.toml` + `uv.lock` and finalizes the `CHANGELOG.md` `[Unreleased]` section into `[0.8.0]`.

## Included since 0.7.0
**Added**
- `zot orphans` (list/clean) — find & remove attachments whose stored file is missing from local `storage/`; classifies dead / recoverable / unknown. + `find_orphans` MCP tool. (#66)
- `zot attach --via-bridge` — import through the running desktop into local storage (bridge v0.3.0 `import-file` endpoint); + `attach(via_bridge=True)` over MCP. (#65)
- GROBID extractor + `references` tool; pdfplumber tables + `tables` tool; `pymupdf4llm` in `[pymupdf]`. (#59–#62)

**Changed**
- Relicensed CC-BY-NC-4.0 → **AGPL-3.0-or-later + commercial** dual license. (#56)
- `zot attach` reports `data.stored` (`cloud`/`local`); `schema_version` 1.6.0 → 1.7.0.

## Verified
- `uv lock --check` consistent.
- Publish gate (`ruff check` / `ruff format --check` / `mypy`) clean.
- `zot --version` → `0.8.0`; schema `cli_version` → `0.8.0`.

## ⚠️ Release step (manual, after merge)
Pushing a `v*` tag triggers `publish.yml` → **PyPI publish (irreversible)**. After this merges to `main`:
```
git tag v0.8.0 <merge-commit> && git push origin v0.8.0
```
Then create the GitHub release for `v0.8.0`. Not done here per request — review/merge/tag at your discretion.