### PR TITLE
docs(skill): fix CLI drift in bundled skill docs (#69)

### DIFF
--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -21,7 +21,7 @@ zot workspace query "RLHF" --workspace my-ws  # RAG search
 1. **Always use `--json`** for programmatic processing (auto-enabled when stdout is not a TTY).
 2. **Windows CJK encoding**: On Windows with a CJK locale, recent `zot` versions auto-reconfigure stdout to UTF-8. For older versions or subprocess calls, set `PYTHONIOENCODING=utf-8`. See `references/windows-encoding.md`.
 3. **Write safety**: Use `--dry-run` to preview mutations. Pass `--idempotency-key` on retries.
-4. **Large PDFs**: Use `--outline` first, then `--section SECID` to extract selectively. Avoid pulling full text when >20k chars.
+4. **Large PDFs**: Use `--outline` first, then `--section N` (the heading number from the outline) to extract selectively. Avoid pulling full text when >20k chars.
 5. **Workspace RAG index**: Do not `--force` rebuild without user confirmation — it is slow.
 6. **Find Full Text**: `zot find-pdf KEY` fetches paywalled PDFs but needs Zotero desktop running + the bridge plugin. One-time setup: `zot bridge install`. See `references/commands.md`.
 7. **Canonical schema**: Run `zot schema <cmd>` for exhaustive flags, types, and safety tiers.
@@ -40,7 +40,7 @@ zot workspace query "RLHF" --workspace my-ws  # RAG search
 | Delete item | `zot --no-interaction delete KEY` |
 | PDF full text | `zot --json pdf KEY` |
 | PDF outline | `zot --json pdf --outline KEY` |
-| PDF section | `zot --json pdf --section SECID KEY` |
+| PDF section | `zot --json pdf --section N KEY` |
 | Fetch/attach missing PDF | `zot find-pdf KEY` (needs Zotero desktop + bridge) |
 | Rename attachment files | `zot rename KEY --dry-run` (needs bridge; preview first) |
 | Add journal metrics (IF/分区) | `zot enrich KEY --set "JCR=Q1"` or `--from-map journals.toml` |

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -173,7 +173,7 @@ zot collection delete COLLECTIONKEY
 zot --json duplicates                # DOI + title matching
 zot --json duplicates --by title     # Title-only matching
 zot --json recent --days 7           # Recently added
-zot --json recent --sort dateModified
+zot --json recent --modified         # Sort by date modified instead of date added
 zot --json trash list                # View trashed items
 zot trash restore ITEMKEY            # Restore from trash
 ```
@@ -182,8 +182,8 @@ zot trash restore ITEMKEY            # Restore from trash
 
 ```bash
 zot --json pdf ITEMKEY                      # Full text extraction
-zot --json pdf --outline ITEMKEY            # Section headings + secid
-zot --json pdf --section SECID ITEMKEY      # Extract specific section
+zot --json pdf --outline ITEMKEY            # Numbered section headings
+zot --json pdf --section N ITEMKEY          # Extract content under the N-th heading
 zot pdf ITEMKEY --annotations               # PDF annotations
 zot --json summarize ITEMKEY
 zot summarize-all

--- a/skill/zotero-cli-cc/references/workflows.md
+++ b/skill/zotero-cli-cc/references/workflows.md
@@ -10,7 +10,7 @@ zot --json search "single cell RNA sequencing"
 zot --json read K853PGUG
 
 # Step 3: PDF — check structure first, extract selectively
-zot --json pdf --outline K853PGUG             # Get section headings + secid
+zot --json pdf --outline K853PGUG             # Get numbered section headings
 zot --json pdf --section 10 K853PGUG          # Extract only the section you need
 zot --json pdf K853PGUG                       # Full text (only if short or necessary)
 ```
@@ -35,7 +35,7 @@ zot --json workspace query "mechanisms of acquired resistance" --workspace drug-
 
 # Step 4: Drill into specific chunks for more context
 zot --json pdf --outline ITEMKEY
-zot --json pdf --section SECID ITEMKEY
+zot --json pdf --section N ITEMKEY
 ```
 
 ## Pattern 3: Batch Export from Collections

--- a/skill/zotero-cli-cc/references/workspaces.md
+++ b/skill/zotero-cli-cc/references/workspaces.md
@@ -95,8 +95,8 @@ RAG results return chunks structured as:
 When a chunk is incomplete, drill into the source:
 
 ```bash
-zot --json pdf --outline ITEMKEY            # Get section headings + secid
-zot --json pdf --section SECID ITEMKEY      # Extract full section
+zot --json pdf --outline ITEMKEY            # Get numbered section headings
+zot --json pdf --section N ITEMKEY          # Extract content under the N-th heading
 ```
 
 ## Configuration


### PR DESCRIPTION
Fixes the still-valid items from #69. The bundled Claude Code skill (`skill/zotero-cli-cc/`) documented flags that don't match the CLI.

## Fixed

- **`recent`** — docs showed `zot --json recent --sort dateModified`, but there is no `--sort`. The flag is `--modified`. (`references/commands.md`)
- **`pdf --section`** — docs called the argument `SECID` and described `--outline` as emitting a "secid", implying you copy an identifier out of the outline. `--section` actually takes an **integer** (the N-th heading from the numbered outline). Reworded to `--section N` / "numbered section headings" across `SKILL.md`, `references/commands.md`, `references/workflows.md`, `references/workspaces.md`.

## Already resolved (no change needed)

The other two items in #69 were doc-vs-CLI drift that has since been closed by shipping the commands:

- `zot orphans` — shipped in #66, present in 0.8.0.
- `attach --via-bridge` — shipped in #65, present in 0.8.0.

Closes #69.