### PR TITLE
feat(attach): auto-detect bridge + honest cloud upload result (#64)

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -321,17 +321,27 @@ bridge or stopped desktop aborts the whole command with `bridge_missing` (3) /
 
 ## Attaching files (`zot attach`)
 
-`zot attach KEY --file paper.pdf` uploads via the Web API, which stores the
-file in **zotero.org cloud storage** (`data.stored: "cloud"`). The binary only
-appears in the local `storage/` folder after the desktop runs a *file* sync
-("Sync attachment files" enabled) — until then the desktop shows "the attached
-file could not be found". For local-first setups (and movers like
-zotero-attanger, which relocate attachments on import), pass `--via-bridge` to
-import through the running desktop via `POST /zot-cli/import-file` →
-`Zotero.Attachments.importFromFile(...)`. That writes straight into local
-storage (`data.stored: "local"`) and syncs *up* afterwards. `--via-bridge`
-requires the bridge plugin **v0.3.0+** and uses the same reachability codes as
-`find-pdf`/`rename` (`not_reachable` (5), `bridge_missing` (3)).
+`zot attach KEY --file paper.pdf` **auto-detects** how to route the file: when
+the Zotero desktop bridge is reachable it imports through the desktop (local
+storage); otherwise it uploads via the Web API (cloud storage). Force a route
+with `--via-bridge` / `--no-via-bridge`.
+
+The **Web-API** path stores the file in **zotero.org cloud storage**
+(`data.stored: "cloud"`). The binary only appears in the local `storage/` folder
+after the desktop runs a *file* sync ("Sync attachment files" enabled) — until
+then the desktop shows "the attached file could not be found". The cloud result
+also reports `data.result`: `"created"` (the file was uploaded) or `"exists"`
+(Zotero already held an identical file, so nothing transferred).
+
+The **bridge** path (auto-selected when the desktop is up, or forced with
+`--via-bridge`) is the local-first option — it cooperates with movers like
+zotero-attanger and imports through the running desktop via
+`POST /zot-cli/import-file` → `Zotero.Attachments.importFromFile(...)`, writing
+straight into local storage (`data.stored: "local"`) and syncing *up* afterwards.
+It requires the bridge plugin **v0.3.0+** and uses the same reachability codes as
+`find-pdf`/`rename` (`not_reachable` (5), `bridge_missing` (3)). Auto-detect
+falls back to the Web API silently when the bridge is not reachable; an explicit
+`--via-bridge` surfaces those codes as errors instead.
 
 ## Orphaned attachments (`zot orphans`)
 

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -44,8 +44,9 @@ zot add --pdf paper.pdf                   # Add from local PDF (auto-extract DOI
 zot --no-interaction delete ITEMKEY
 zot update ITEMKEY --title "New Title"
 zot update ITEMKEY --field volume=42 --field pages=1-10
-zot attach ITEMKEY --file supplement.pdf
-zot attach ITEMKEY --file supplement.pdf --via-bridge   # store in LOCAL storage (needs Zotero desktop + bridge)
+zot attach ITEMKEY --file supplement.pdf                 # auto: bridge if desktop up (local), else cloud
+zot attach ITEMKEY --file supplement.pdf --via-bridge    # force LOCAL storage (needs Zotero desktop + bridge)
+zot attach ITEMKEY --file supplement.pdf --no-via-bridge # force cloud (Web API); reports result=created|exists
 ```
 
 > **`zot attach` storage note.** The default path uploads via the Web API into

--- a/src/zotero_cli_cc/commands/add.py
+++ b/src/zotero_cli_cc/commands/add.py
@@ -276,7 +276,7 @@ def _add_from_pdf(
     att_key = None
     attach_error: str | None = None
     try:
-        att_key = writer.upload_attachment(key, pdf_path)
+        att_key, _ = writer.upload_attachment(key, pdf_path)
     except ZoteroWriteError as e:
         attach_error = str(e)
 

--- a/src/zotero_cli_cc/commands/attach.py
+++ b/src/zotero_cli_cc/commands/attach.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 
 from zotero_cli_cc.config import load_config
-from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file
+from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file, resolve_use_bridge
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
@@ -19,10 +19,12 @@ _BRIDGE_HINT = "Start Zotero desktop; run 'zot bridge install' to (re)install th
 @click.argument("key")
 @click.option("--file", "file_path", required=True, type=click.Path(exists=True), help="File to upload")
 @click.option(
-    "--via-bridge",
-    is_flag=True,
+    "--via-bridge/--no-via-bridge",
+    "via_bridge",
+    default=None,
     help="Import through the running Zotero desktop (zot-cli-bridge plugin) so the "
-    "file lands in local storage instead of cloud-only. Plays nice with zotero-attanger.",
+    "file lands in local storage instead of cloud-only (plays nice with zotero-attanger). "
+    "Default: auto-detect — use the bridge when the desktop is reachable, else the Web API.",
 )
 @click.option("--dry-run", is_flag=True, help="Preview the upload without calling the API")
 @click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
@@ -31,24 +33,30 @@ def attach_cmd(
     ctx: click.Context,
     key: str,
     file_path: str,
-    via_bridge: bool,
+    via_bridge: bool | None,
     dry_run: bool,
     idempotency_key: str | None,
 ) -> None:
     """Upload a file attachment to an existing Zotero item. MUTATES LIBRARY.
 
-    The default path uploads via the Zotero Web API, which stores the file in
-    zotero.org cloud storage — it only appears in your local `storage/` after
-    the desktop syncs the file down (requires "Sync attachment files" enabled).
-    Use `--via-bridge` to import through the running desktop instead, so the
-    file is written to local storage immediately and cooperates with plugins
-    that relocate attachments (e.g. zotero-attanger).
+    The Web-API path stores the file in zotero.org cloud storage — it only
+    appears in your local `storage/` after the desktop syncs the file down
+    (requires "Sync attachment files" enabled). The bridge path imports through
+    the running desktop instead, so the file is written to local storage
+    immediately and cooperates with plugins that relocate attachments (e.g.
+    zotero-attanger).
+
+    By default the route is auto-detected: the bridge is used when the Zotero
+    desktop is reachable, otherwise the Web API. Force a route with
+    `--via-bridge` or `--no-via-bridge`. The result reports `stored` as `local`
+    (bridge) or `cloud` (Web API); cloud uploads also report `result` as
+    `created` or `exists` (the file was already present, so nothing transferred).
 
     \b
     Examples:
-      zot attach ABC123 --file paper.pdf
-      zot attach ABC123 --file paper.pdf --via-bridge   # store locally via desktop
-      zot attach ABC123 --file ~/Downloads/supplement.pdf
+      zot attach ABC123 --file paper.pdf                # auto: bridge if desktop up, else cloud
+      zot attach ABC123 --file paper.pdf --via-bridge   # force local import via desktop
+      zot attach ABC123 --file paper.pdf --no-via-bridge  # force Web-API cloud upload
       zot attach ABC123 --file paper.pdf --dry-run
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
@@ -57,16 +65,18 @@ def attach_cmd(
     fp = Path(file_path)
     size = fp.stat().st_size if fp.exists() else None
 
+    use_bridge = resolve_use_bridge(via_bridge)
+
     if dry_run:
-        sink = "Zotero desktop (local storage)" if via_bridge else "the Web API (cloud storage)"
-        data = {"would": {"parent": key, "file": str(fp), "size_bytes": size, "via_bridge": via_bridge}}
+        sink = "Zotero desktop (local storage)" if use_bridge else "the Web API (cloud storage)"
+        data = {"would": {"parent": key, "file": str(fp), "size_bytes": size, "via_bridge": use_bridge}}
         if json_out:
             click.echo(json.dumps(envelope_ok(data, extra={"dry_run": True}), indent=2, ensure_ascii=False))
         else:
             click.echo(f"[dry-run] Would attach {fp} ({size} bytes) to '{key}' via {sink}")
         return
 
-    if via_bridge:
+    if use_bridge:
         try:
             result = import_file(key, str(fp.resolve()), title=fp.name)
         except LocalBridgeError as e:
@@ -111,7 +121,7 @@ def attach_cmd(
 
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
-        att_key = writer.upload_attachment(key, fp)
+        att_key, upload_result = writer.upload_attachment(key, fp)
     except ZoteroWriteError as e:
         emit_error(
             e.code,
@@ -123,7 +133,14 @@ def attach_cmd(
         )
 
     env = envelope_ok(
-        {"attachment_key": att_key, "parent_key": key, "file": str(fp), "stored": "cloud", "sync_required": True},
+        {
+            "attachment_key": att_key,
+            "parent_key": key,
+            "file": str(fp),
+            "stored": "cloud",
+            "result": upload_result,
+            "sync_required": True,
+        },
         extra={"next": [f"zot read {key}"]},
     )
     if idempotency_key:
@@ -131,7 +148,10 @@ def attach_cmd(
     if json_out:
         click.echo(json.dumps(env, indent=2, ensure_ascii=False))
     else:
-        click.echo(f"Attachment uploaded: {att_key}")
+        if upload_result == "exists":
+            click.echo(f"Attachment already present (unchanged): {att_key}")
+        else:
+            click.echo(f"Attachment uploaded: {att_key}")
         click.echo(
             "Stored in zotero.org cloud; it reaches local storage/ only after a desktop file-sync. "
             "Use --via-bridge to import into local storage directly.",

--- a/src/zotero_cli_cc/core/local_bridge.py
+++ b/src/zotero_cli_cc/core/local_bridge.py
@@ -87,6 +87,26 @@ def ping(timeout: float = PING_TIMEOUT) -> dict[str, Any]:
     return _parse_json(resp)
 
 
+AUTODETECT_TIMEOUT = 2.0
+
+
+def resolve_use_bridge(preference: bool | None) -> bool:
+    """Decide whether an attach should route through the local desktop bridge.
+
+    ``preference`` is the user's explicit choice: ``True`` forces the bridge,
+    ``False`` forces the Web API, and ``None`` means auto-detect — prefer the
+    bridge when the running desktop is reachable, otherwise fall back to the
+    Web API. The probe is a fast loopback ping; any failure means "not up".
+    """
+    if preference is not None:
+        return preference
+    try:
+        ping(timeout=AUTODETECT_TIMEOUT)
+        return True
+    except LocalBridgeError:
+        return False
+
+
 def find_pdf(
     item_key: str,
     *,

--- a/src/zotero_cli_cc/core/writer.py
+++ b/src/zotero_cli_cc/core/writer.py
@@ -183,16 +183,22 @@ class ZoteroWriter:
         except PyZoteroError as e:
             raise _friendly_api_error(e) from e
 
-    def upload_attachment(self, parent_key: str, file_path: Path) -> str:
-        """Upload a file attachment to an existing item. Returns attachment key."""
+    def upload_attachment(self, parent_key: str, file_path: Path) -> tuple[str, str]:
+        """Upload a file attachment to an existing item.
+
+        Returns ``(attachment_key, result)`` where ``result`` is ``"created"``
+        (the file was newly uploaded) or ``"exists"`` (Zotero already held an
+        identical file, so nothing was transferred). A genuine failure raises
+        ``ZoteroWriteError`` instead of returning.
+        """
         if not file_path.exists():
             raise ZoteroWriteError(f"File not found: {file_path}", code="validation_error", retryable=False)
         try:
             resp = self._zot.attachment_simple([str(file_path)], parentid=parent_key)
             if resp.get("success"):
-                return str(resp["success"][0]["key"])
+                return str(resp["success"][0]["key"]), "created"
             if resp.get("unchanged"):
-                return str(resp["unchanged"][0]["key"])
+                return str(resp["unchanged"][0]["key"]), "exists"
             if resp.get("failure"):
                 msg = resp["failure"][0].get("message", "Upload failed")
                 raise ZoteroWriteError(f"Attachment upload failed: {msg}", code="api_error", retryable=True)

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.7.0"
+SCHEMA_VERSION = "1.8.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -612,8 +612,10 @@ def _handle_trash_restore(key: str, library: str = "user") -> dict:
         return {"error": str(e), "context": "trash_restore"}
 
 
-def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool = False) -> dict:
-    if via_bridge:
+def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool | None = None) -> dict:
+    from zotero_cli_cc.core.local_bridge import resolve_use_bridge
+
+    if resolve_use_bridge(via_bridge):
         from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file
 
         fp = Path(file_path)
@@ -629,8 +631,14 @@ def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_b
         }
     try:
         writer = _get_writer(library)
-        att_key = writer.upload_attachment(parent_key, Path(file_path))
-        return {"key": att_key, "parent_key": parent_key, "filename": Path(file_path).name, "stored": "cloud"}
+        att_key, upload_result = writer.upload_attachment(parent_key, Path(file_path))
+        return {
+            "key": att_key,
+            "parent_key": parent_key,
+            "filename": Path(file_path).name,
+            "stored": "cloud",
+            "result": upload_result,
+        }
     except ZoteroWriteError as e:
         return {"error": str(e), "context": "attach"}
 
@@ -658,7 +666,7 @@ def _handle_add_from_pdf(file_path: str, doi_override: str | None = None, librar
         return {"error": str(e), "context": "add_from_pdf"}
 
     try:
-        att_key = writer.upload_attachment(item_key, Path(file_path))
+        att_key, _ = writer.upload_attachment(item_key, Path(file_path))
         result: dict = {
             "item_key": item_key,
             "attachment_key": att_key,
@@ -1629,19 +1637,24 @@ def trash_restore(key: str, library: str = "user") -> dict:
 
 
 @mcp.tool()
-def attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool = False) -> dict:
+def attach(parent_key: str, file_path: str, library: str = "user", via_bridge: bool | None = None) -> dict:
     """Upload a file attachment to an existing Zotero item.
 
-    By default uploads via the Web API into zotero.org cloud storage, which only
-    reaches the local storage/ folder after a desktop file-sync. Set via_bridge=True
-    to import through the running Zotero desktop (zot-cli-bridge plugin) so the file
-    lands in local storage immediately and cooperates with attachment-moving plugins.
+    The Web-API path uploads into zotero.org cloud storage, which only reaches the
+    local storage/ folder after a desktop file-sync. The bridge path imports through
+    the running Zotero desktop (zot-cli-bridge plugin) so the file lands in local
+    storage immediately and cooperates with attachment-moving plugins.
+
+    The route is auto-detected by default (via_bridge=None): the bridge is used when
+    the desktop is reachable, else the Web API. Returns 'stored' as 'local' (bridge)
+    or 'cloud' (Web API); cloud results also report 'result' as 'created' or 'exists'.
 
     Args:
         parent_key: The item key to attach the file to.
         file_path: Path to the file to upload.
         library: Library — 'user' (default) or 'group:<id>'.
-        via_bridge: Import through the local Zotero desktop instead of the Web API.
+        via_bridge: True forces the desktop bridge, False forces the Web API,
+            None (default) auto-detects a running bridge.
     """
     return _handle_attach(parent_key, file_path, library=library, via_bridge=via_bridge)
 

--- a/tests/test_add_pdf.py
+++ b/tests/test_add_pdf.py
@@ -44,7 +44,7 @@ class TestAddPdfMCP:
             mock_writer = MagicMock()
             mock_get.return_value = mock_writer
             mock_writer.add_item.return_value = "NEW001"
-            mock_writer.upload_attachment.return_value = "ATT001"
+            mock_writer.upload_attachment.return_value = ("ATT001", "created")
             result = _handle_add_from_pdf("/tmp/test.pdf", doi_override="10.1234/test")
             mock_writer.add_item.assert_called_once_with(doi="10.1234/test", extra_fields={"title": "T"})
             assert result["item_key"] == "NEW001"

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -27,8 +27,9 @@ class TestAttachWriter:
             "unchanged": [],
         }
         writer = ZoteroWriter(library_id="123", api_key="abc")
-        key = writer.upload_attachment("PARENT1", pdf)
+        key, result = writer.upload_attachment("PARENT1", pdf)
         assert key == "ATT001"
+        assert result == "created"
         mock_zot.attachment_simple.assert_called_once()
 
     @patch("zotero_cli_cc.core.writer.zotero.Zotero")
@@ -43,8 +44,9 @@ class TestAttachWriter:
             "unchanged": [{"key": "ATT001"}],
         }
         writer = ZoteroWriter(library_id="123", api_key="abc")
-        key = writer.upload_attachment("PARENT1", pdf)
+        key, result = writer.upload_attachment("PARENT1", pdf)
         assert key == "ATT001"
+        assert result == "exists"
 
     @patch("zotero_cli_cc.core.writer.zotero.Zotero")
     def test_upload_attachment_failure(self, mock_zotero_cls, tmp_path):
@@ -183,10 +185,11 @@ class TestAttachMCP:
         with patch("zotero_cli_cc.mcp_server._get_writer") as mock_get:
             mock_writer = MagicMock()
             mock_get.return_value = mock_writer
-            mock_writer.upload_attachment.return_value = "ATT001"
-            result = _handle_attach("PARENT1", "/tmp/test.pdf")
+            mock_writer.upload_attachment.return_value = ("ATT001", "created")
+            result = _handle_attach("PARENT1", "/tmp/test.pdf", via_bridge=False)
             assert result["key"] == "ATT001"
             assert result["stored"] == "cloud"
+            assert result["result"] == "created"
 
     def test_handle_attach_via_bridge(self, tmp_path):
         from zotero_cli_cc import mcp_server
@@ -199,3 +202,86 @@ class TestAttachMCP:
             assert result["key"] == "ATTLOCAL"
             assert result["stored"] == "local"
             mock_import.assert_called_once()
+
+
+class TestResolveUseBridge:
+    def test_explicit_true_skips_ping(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge, "ping", lambda *a, **k: pytest.fail("ping must not run when forced on"))
+        assert local_bridge.resolve_use_bridge(True) is True
+
+    def test_explicit_false_skips_ping(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge, "ping", lambda *a, **k: pytest.fail("ping must not run when forced off"))
+        assert local_bridge.resolve_use_bridge(False) is False
+
+    def test_auto_uses_bridge_when_reachable(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge, "ping", lambda *a, **k: {"ok": True})
+        assert local_bridge.resolve_use_bridge(None) is True
+
+    def test_auto_falls_back_when_down(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        def boom(*a, **k):
+            raise LocalBridgeError("down", code="not_reachable", retryable=True)
+
+        monkeypatch.setattr(local_bridge, "ping", boom)
+        assert local_bridge.resolve_use_bridge(None) is False
+
+
+class TestAttachWebResultCLI:
+    @staticmethod
+    def _pdf(tmp_path):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        return pdf
+
+    def _mock_writer(self, monkeypatch, key, result):
+        monkeypatch.setenv("ZOT_LIBRARY_ID", "123")
+        monkeypatch.setenv("ZOT_API_KEY", "abc")
+        writer = MagicMock()
+        writer.upload_attachment.return_value = (key, result)
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.ZoteroWriter", lambda **k: writer)
+
+    def test_cloud_result_created(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        self._mock_writer(monkeypatch, "ATTCLOUD", "created")
+        result = CliRunner().invoke(main, ["--json", "attach", "P1", "--file", str(pdf), "--no-via-bridge"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["stored"] == "cloud"
+        assert data["result"] == "created"
+
+    def test_cloud_result_exists_human(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        self._mock_writer(monkeypatch, "ATTCLOUD", "exists")
+        result = CliRunner().invoke(main, ["attach", "P1", "--file", str(pdf), "--no-via-bridge"])
+        assert result.exit_code == 0
+        assert "already present" in result.output
+
+    def test_auto_prefers_bridge_when_up(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.ping", lambda *a, **k: {"ok": True})
+        monkeypatch.setattr(
+            "zotero_cli_cc.commands.attach.import_file",
+            lambda *a, **k: {"imported": True, "attachment_key": "ATTL", "filename": "paper.pdf"},
+        )
+        result = CliRunner().invoke(main, ["--json", "attach", "P1", "--file", str(pdf)])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["data"]["stored"] == "local"
+
+    def test_auto_falls_back_to_cloud_when_down(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+
+        def boom(*a, **k):
+            raise LocalBridgeError("down", code="not_reachable", retryable=True)
+
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.ping", boom)
+        self._mock_writer(monkeypatch, "ATTCLOUD", "created")
+        result = CliRunner().invoke(main, ["--json", "attach", "P1", "--file", str(pdf)])
+        assert result.exit_code == 0
+        assert json.loads(result.output)["data"]["stored"] == "cloud"


### PR DESCRIPTION
Implements two of the three remaining items from #64. The third (group-library `--via-bridge`) is split into a follow-up because it needs a bridge-plugin change + a live group library to verify.

## 1. Honest Web-API upload result (#64 analysis item 2)

`writer.upload_attachment()` already inspected pyzotero's `success` / `unchanged` / `failure` buckets but **collapsed** them to a bare key — so "uploaded to cloud" was indistinguishable from "Zotero already had this file."

It now returns `(key, result)` where `result` is:
- `"created"` — the file was newly uploaded
- `"exists"` — Zotero already held an identical file (nothing transferred)
- a genuine failure still raises `ZoteroWriteError` (unchanged)

The CLI and MCP `attach` envelope surface this as `data.result` on cloud uploads. Human output now says "Attachment already present (unchanged)" vs "Attachment uploaded".

## 2. Auto-detect a running bridge (#64 analysis item 4)

`zot attach` (and the MCP `attach` tool) now pick the route automatically instead of requiring an explicit flag:

- **default (auto)** — fast loopback ping; use the desktop bridge when reachable (`stored: "local"`), else the Web API (`stored: "cloud"`).
- `--via-bridge` — force the bridge (surfaces `not_reachable`/`bridge_missing` as errors).
- `--no-via-bridge` — force the Web API.

The flag is now tri-state (`--via-bridge/--no-via-bridge`, default `None`). Auto-detect falls back to the Web API **silently** when the bridge is down; forcing `--via-bridge` keeps the old hard-error behavior. Shared resolver `local_bridge.resolve_use_bridge()` is used by both the CLI and MCP paths.

## Contract / behavior change

- `schema_version` **1.7.0 → 1.8.0** — new `data.result` field on cloud attach, plus the default routing of a *mutating* command now depends on whether the desktop is up. The `stored` field always reports where the file actually landed, so the outcome stays inspectable from the envelope. Documented in `docs/agent-interface.md`.

## Tests

- `upload_attachment` returns `(key, result)` — updated existing writer/MCP tests; added `created`/`exists` assertions.
- New `TestResolveUseBridge` (explicit on/off skip the ping; auto uses bridge when reachable, falls back when down).
- New CLI tests: cloud `result` created/exists, auto prefers bridge when up, auto falls back to cloud when down.
- Full suite green locally (the only failures were a pre-existing local SOCKS-proxy quirk in two `resolve_doi` network tests, unrelated to this change — they pass with the proxy disabled, as in CI).

Refs #64.