### PR TITLE
feat(attach): group-library support for --via-bridge (#64)

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -343,6 +343,12 @@ It requires the bridge plugin **v0.3.0+** and uses the same reachability codes a
 falls back to the Web API silently when the bridge is not reachable; an explicit
 `--via-bridge` surfaces those codes as errors instead.
 
+Importing into a **group library** (`--library group:<id>`) via the bridge needs
+plugin **v0.4.0+** — the bridge maps the Web-API group id to the desktop's
+internal `libraryID`. The CLI checks the running plugin's version first and fails
+with `bridge_missing` (3) if it is too old, rather than silently importing into
+your personal library.
+
 ## Orphaned attachments (`zot orphans`)
 
 The flip side of the cloud-vs-local split: a storage-backed attachment whose

--- a/extension/zot-cli-bridge/README.md
+++ b/extension/zot-cli-bridge/README.md
@@ -22,7 +22,7 @@ plugin enables. It registers these endpoints on `http://127.0.0.1:23119`:
 | `GET` | `/zot-cli/ping` | Health probe — returns plugin + Zotero version |
 | `POST` | `/zot-cli/find-pdf` | Body: `{"key": "ABCD1234"}`. Triggers `Zotero.Attachments.addAvailableFile(item)` and returns the attached PDF's key on success, or `{found: false}` if no resolver had a hit. |
 | `POST` | `/zot-cli/rename` | Body: `{"attachmentKey": "...", "newName": "X.pdf", "force": false}`. Calls `item.renameAttachmentFile(newName, force)` on the attachment, syncs its title, and returns `{renamed, old_name, new_name}`. Powers `zot rename`. |
-| `POST` | `/zot-cli/import-file` | Body: `{"parentKey": "...", "path": "/abs/file.pdf", "title": "..."}`. Calls `Zotero.Attachments.importFromFile(...)` so the file is copied into **local** storage immediately (vs a Web-API upload that lands cloud-only). Returns `{imported, attachment_key, filename, content_type}`. Powers `zot attach --via-bridge`. |
+| `POST` | `/zot-cli/import-file` | Body: `{"parentKey": "...", "path": "/abs/file.pdf", "groupID": 123, "title": "..."}`. Calls `Zotero.Attachments.importFromFile(...)` so the file is copied into **local** storage immediately (vs a Web-API upload that lands cloud-only). Pass `groupID` (the Web-API group id) to target a group library — it is mapped to the desktop's internal `libraryID`. Returns `{imported, attachment_key, filename, content_type}`. Powers `zot attach --via-bridge` (`v0.4.0+` for group support). |
 
 ## Install
 
@@ -50,7 +50,7 @@ zot bridge status        # verify -> Bridge OK
 3. Verify it's wired up:
    ```bash
    curl http://127.0.0.1:23119/zot-cli/ping
-   # {"ok": true, "bridge_version": "0.3.0", "zotero_version": "9.x.y", ...}
+   # {"ok": true, "bridge_version": "0.4.0", "zotero_version": "9.x.y", ...}
    ```
 
 You can now run `zot find-pdf <item-key>` and `zot attach <key> --file <path> --via-bridge` from the parent repo.

--- a/extension/zot-cli-bridge/bootstrap.js
+++ b/extension/zot-cli-bridge/bootstrap.js
@@ -11,10 +11,13 @@
  *   POST /zot-cli/rename        — body {"attachmentKey","newName","libraryID"?,"force"?}
  *                                  renames the attachment's stored file via
  *                                  renameAttachmentFile and syncs its title
- *   POST /zot-cli/import-file   — body {"parentKey","path","libraryID"?,"title"?}
+ *   POST /zot-cli/import-file   — body {"parentKey","path","libraryID"?,"groupID"?,"title"?}
  *                                  imports a local file as an attachment via
  *                                  Zotero.Attachments.importFromFile so the
- *                                  binary lands in local storage immediately
+ *                                  binary lands in local storage immediately.
+ *                                  Pass "groupID" (the Web-API group id) to
+ *                                  target a group library — it is mapped to the
+ *                                  desktop's internal libraryID.
  *
  * The whole point of going through Zotero (rather than fetching the PDF
  * directly from Python) is that Zotero's "Find Full Text" reuses the user's
@@ -31,7 +34,22 @@
 
 /* global Zotero, ChromeUtils */
 
-const PLUGIN_VERSION = "0.3.0";
+const PLUGIN_VERSION = "0.4.0";
+
+// Map a Web-API group id to the desktop client's internal libraryID. The two
+// differ: the group id is what the Zotero Web API / `--library group:<id>`
+// uses, while items on disk are keyed by libraryID. Both Zotero.Groups
+// accessors are synchronous cache reads populated at startup. Returns null when
+// the group is unknown (not joined / not yet synced on this desktop).
+function libraryIDFromGroupID(groupID) {
+  const gid = parseInt(groupID, 10);
+  if (!gid) return null;
+  if (typeof Zotero.Groups.getLibraryIDFromGroupID === "function") {
+    return Zotero.Groups.getLibraryIDFromGroupID(gid) || null;
+  }
+  const group = Zotero.Groups.get(gid);
+  return group ? group.libraryID : null;
+}
 
 function buildEndpoint(handler, { methods = ["GET"], dataTypes = ["application/json"] } = {}) {
   const Endpoint = function () {};
@@ -240,19 +258,29 @@ async function handleRename(options) {
 }
 
 async function handleImportFile(options) {
-  // Body: {"parentKey": "...", "path": "/abs/file.pdf", "libraryID"?, "title"?}
+  // Body: {"parentKey": "...", "path": "/abs/file.pdf", "libraryID"?, "groupID"?, "title"?}
   let parentKey = null;
   let path = null;
   let libraryID = null;
+  let groupID = null;
   let title = null;
   if (options.data && typeof options.data === "object") {
     parentKey = options.data.parentKey || null;
     path = options.data.path || null;
     libraryID = options.data.libraryID || null;
+    groupID = options.data.groupID || null;
     title = options.data.title || null;
   }
   if (!parentKey || !path) {
     return [400, "application/json", JSON.stringify({ ok: false, error: "missing 'parentKey' or 'path'" })];
+  }
+  // A group library's Web-API id is not the desktop's internal libraryID; map it.
+  if (groupID != null) {
+    const mapped = libraryIDFromGroupID(groupID);
+    if (!mapped) {
+      return [404, "application/json", JSON.stringify({ ok: false, error: "group not found", groupID })];
+    }
+    libraryID = mapped;
   }
   libraryID = libraryID || Zotero.Libraries.userLibraryID;
 

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zot CLI Bridge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Exposes Zotero Find Full Text, attachment rename, and local file import over the local HTTP server for the zot CLI.",
   "author": "zotero-cli-cc",
   "homepage_url": "https://github.com/Agents365-ai/zotero-cli-cc",

--- a/src/zotero_cli_cc/commands/attach.py
+++ b/src/zotero_cli_cc/commands/attach.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import click
 
 from zotero_cli_cc.config import load_config
-from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file, resolve_use_bridge
+from zotero_cli_cc.core.local_bridge import (
+    LocalBridgeError,
+    ensure_group_import_supported,
+    import_file,
+    resolve_use_bridge,
+)
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
@@ -77,8 +82,16 @@ def attach_cmd(
         return
 
     if use_bridge:
+        group_id = ctx.obj.get("group_id")  # set only for --library group:<id>
         try:
-            result = import_file(key, str(fp.resolve()), title=fp.name)
+            if group_id is not None:
+                ensure_group_import_supported()
+            result = import_file(
+                key,
+                str(fp.resolve()),
+                title=fp.name,
+                group_id=int(group_id) if group_id is not None else None,
+            )
         except LocalBridgeError as e:
             emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="attach")
         att_key = result.get("attachment_key")

--- a/src/zotero_cli_cc/core/local_bridge.py
+++ b/src/zotero_cli_cc/core/local_bridge.py
@@ -89,6 +89,34 @@ def ping(timeout: float = PING_TIMEOUT) -> dict[str, Any]:
 
 AUTODETECT_TIMEOUT = 2.0
 
+# Group-library import (groupID -> internal libraryID mapping) landed in the
+# bridge plugin at this version. Older plugins silently ignore the groupID field
+# and import into the user library, so guard before a group import.
+GROUP_IMPORT_MIN_VERSION = (0, 4, 0)
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(p) for p in v.split(".")[:3])
+    except (ValueError, AttributeError):
+        return (0, 0, 0)
+
+
+def ensure_group_import_supported() -> None:
+    """Verify the running bridge can map a group id to a libraryID (v0.4.0+).
+
+    Raises LocalBridgeError (`bridge_missing`) if the desktop is unreachable or
+    the installed plugin is too old — without this an old bridge would silently
+    import a group file into the user library.
+    """
+    info = ping()
+    if _version_tuple(str(info.get("bridge_version", ""))) < GROUP_IMPORT_MIN_VERSION:
+        raise LocalBridgeError(
+            "Group-library import needs zot-cli-bridge v0.4.0+ — run 'zot bridge install' to update.",
+            code="bridge_missing",
+            retryable=False,
+        )
+
 
 def resolve_use_bridge(preference: bool | None) -> bool:
     """Decide whether an attach should route through the local desktop bridge.
@@ -262,6 +290,7 @@ def import_file(
     path: str,
     *,
     library_id: int | None = None,
+    group_id: int | None = None,
     title: str | None = None,
     timeout: float = IMPORT_TIMEOUT,
 ) -> dict[str, Any]:
@@ -274,6 +303,10 @@ def import_file(
     `path` must be an absolute path the desktop process can read (the CLI and
     Zotero share the machine).
 
+    Pass `group_id` (the Web-API group id, from `--library group:<id>`) to import
+    into a group library; the bridge maps it to the desktop's internal libraryID
+    (needs plugin v0.4.0+ — check first with `ensure_group_import_supported`).
+
     Returns a dict with `imported`, `attachment_key`, `parent_key`, `filename`,
     `content_type`.
 
@@ -285,6 +318,8 @@ def import_file(
     payload: dict[str, Any] = {"parentKey": parent_key, "path": path}
     if library_id is not None:
         payload["libraryID"] = library_id
+    if group_id is not None:
+        payload["groupID"] = group_id
     if title is not None:
         payload["title"] = title
     try:

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -616,11 +616,14 @@ def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_b
     from zotero_cli_cc.core.local_bridge import resolve_use_bridge
 
     if resolve_use_bridge(via_bridge):
-        from zotero_cli_cc.core.local_bridge import LocalBridgeError, import_file
+        from zotero_cli_cc.core.local_bridge import LocalBridgeError, ensure_group_import_supported, import_file
 
         fp = Path(file_path)
+        group_id = int(library.split(":", 1)[1]) if library.startswith("group:") else None
         try:
-            result = import_file(parent_key, str(fp.resolve()), title=fp.name)
+            if group_id is not None:
+                ensure_group_import_supported()
+            result = import_file(parent_key, str(fp.resolve()), title=fp.name, group_id=group_id)
         except LocalBridgeError as e:
             return {"error": str(e), "context": "attach", "code": e.code}
         return {

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -203,6 +203,23 @@ class TestAttachMCP:
             assert result["stored"] == "local"
             mock_import.assert_called_once()
 
+    def test_handle_attach_group_via_bridge(self, tmp_path, monkeypatch):
+        from zotero_cli_cc import mcp_server
+
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.ping", lambda *a, **k: {"bridge_version": "0.4.0"})
+        captured: dict = {}
+
+        def fake_import(parent, path, **kw):
+            captured["group_id"] = kw.get("group_id")
+            return {"attachment_key": "ATTG", "filename": "paper.pdf"}
+
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.import_file", fake_import)
+        result = mcp_server._handle_attach("PARENT1", str(pdf), library="group:123", via_bridge=True)
+        assert result["key"] == "ATTG"
+        assert captured["group_id"] == 123
+
 
 class TestResolveUseBridge:
     def test_explicit_true_skips_ping(self, monkeypatch):
@@ -285,3 +302,91 @@ class TestAttachWebResultCLI:
         result = CliRunner().invoke(main, ["--json", "attach", "P1", "--file", str(pdf)])
         assert result.exit_code == 0
         assert json.loads(result.output)["data"]["stored"] == "cloud"
+
+
+class TestGroupImportSupport:
+    def test_import_file_sends_group_id(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        captured: dict = {}
+
+        def fake_post(url, **kw):
+            captured["json"] = kw.get("json")
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {"ok": True, "attachment_key": "ATT1", "imported": True}
+            r.text = "{}"
+            return r
+
+        monkeypatch.setattr(local_bridge.httpx, "post", fake_post)
+        local_bridge.import_file("PARENT1", "/abs/p.pdf", group_id=123)
+        assert captured["json"]["groupID"] == 123
+        assert "libraryID" not in captured["json"]
+
+    def test_ensure_ok_on_new_bridge(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge, "ping", lambda *a, **k: {"bridge_version": "0.4.0"})
+        local_bridge.ensure_group_import_supported()  # must not raise
+
+    def test_ensure_raises_on_old_bridge(self, monkeypatch):
+        from zotero_cli_cc.core import local_bridge
+
+        monkeypatch.setattr(local_bridge, "ping", lambda *a, **k: {"bridge_version": "0.3.0"})
+        with pytest.raises(LocalBridgeError) as ei:
+            local_bridge.ensure_group_import_supported()
+        assert ei.value.code == "bridge_missing"
+
+
+class TestAttachGroupBridgeCLI:
+    @staticmethod
+    def _pdf(tmp_path):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        return pdf
+
+    def test_group_import_passes_group_id(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.ping", lambda *a, **k: {"bridge_version": "0.4.0"})
+        captured: dict = {}
+
+        def fake_import(parent, path, **kw):
+            captured.update(parent=parent, group_id=kw.get("group_id"))
+            return {"imported": True, "attachment_key": "ATTG", "filename": "paper.pdf"}
+
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.import_file", fake_import)
+        result = CliRunner().invoke(
+            main, ["--json", "--library", "group:123", "attach", "P1", "--file", str(pdf), "--via-bridge"]
+        )
+        assert result.exit_code == 0
+        assert captured["group_id"] == 123
+        assert json.loads(result.output)["data"]["stored"] == "local"
+
+    def test_group_import_old_bridge_exits_3(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        monkeypatch.setattr("zotero_cli_cc.core.local_bridge.ping", lambda *a, **k: {"bridge_version": "0.3.0"})
+        monkeypatch.setattr(
+            "zotero_cli_cc.commands.attach.import_file",
+            lambda *a, **k: pytest.fail("import_file must not run when the bridge is too old"),
+        )
+        result = CliRunner().invoke(
+            main, ["--library", "group:123", "attach", "P1", "--file", str(pdf), "--via-bridge"]
+        )
+        assert result.exit_code == 3
+
+    def test_user_import_does_not_check_version(self, tmp_path, monkeypatch):
+        pdf = self._pdf(tmp_path)
+        monkeypatch.setattr(
+            "zotero_cli_cc.core.local_bridge.ping",
+            lambda *a, **k: pytest.fail("user-library import must not version-check"),
+        )
+        captured: dict = {}
+
+        def fake_import(parent, path, **kw):
+            captured["group_id"] = kw.get("group_id")
+            return {"imported": True, "attachment_key": "ATTU", "filename": "paper.pdf"}
+
+        monkeypatch.setattr("zotero_cli_cc.commands.attach.import_file", fake_import)
+        result = CliRunner().invoke(main, ["--json", "attach", "P1", "--file", str(pdf), "--via-bridge"])
+        assert result.exit_code == 0
+        assert captured["group_id"] is None


### PR DESCRIPTION
The last remaining item from #64. The `--via-bridge` import path targeted the desktop's **default user library only** — a Web-API group id (`--library group:<id>`) is *not* the desktop's internal `libraryID`, so a group import either failed or silently landed in the personal library.

## Changes

**Bridge plugin → v0.4.0** (`bootstrap.js`, `manifest.json`)
- `/zot-cli/import-file` now accepts a `groupID` (the Web-API group id) and maps it to the desktop's internal `libraryID` via `Zotero.Groups.getLibraryIDFromGroupID(gid)` (with a `Zotero.Groups.get(gid).libraryID` fallback for older builds — both are synchronous cache reads populated at startup).
- Returns `404 {error: "group not found"}` for an unknown / not-joined group.

**CLI + MCP**
- `local_bridge.import_file()` gains a `group_id` kwarg → sends `groupID` in the body.
- `zot attach` and the MCP `attach` tool pass the group id parsed from `--library group:<id>` / `library="group:<id>"`.
- **Version guard:** an old (≤0.3.0) plugin silently ignores an unknown `groupID` field and would import into the user library. To prevent that data-misplacement, the CLI/MCP probe the running plugin's version first (`ensure_group_import_supported`) and fail with `bridge_missing` (3) if it is < 0.4.0. User-library imports are unchanged and skip the probe.

**Docs:** `docs/agent-interface.md` (contract) + bridge `README.md` updated; bridge version bumped in the ping example.

## Tests

- `import_file` sends `groupID` (and no `libraryID`) when `group_id` is passed.
- `ensure_group_import_supported`: passes on v0.4.0, raises `bridge_missing` on v0.3.0.
- CLI: `--library group:123 ... --via-bridge` forwards `group_id=123` and reports `stored: local`; an old bridge exits 3; a user-library import never version-checks and passes `group_id=None`.
- MCP: `_handle_attach(library="group:123", via_bridge=True)` forwards `group_id=123`.

Lint/format/mypy clean; full local suite green (modulo the known local SOCKS-proxy quirk in unrelated `resolve_doi` network tests, which pass with the proxy off as in CI).

## ⚠️ Verification note

The Python side is fully unit-tested, but the **`bootstrap.js` group→libraryID mapping cannot be self-verified** here (no JS test harness, and I don't write to the live library). It needs a real group library + a bridge reinstall (`zot bridge install`, then restart Zotero) to confirm end-to-end. I reviewed the JS against the Zotero 7 `Zotero.Groups` API and `node --check`'d it, but please run a live group import before relying on it.

Closes #64.