### PR TITLE
Clarify root-level --detail usage in SKILL.md

### DIFF
--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -10,10 +10,12 @@ description: Use when user mentions papers, references, citations, Zotero, liter
 ## Quick Start
 
 ```bash
-zot search "transformer attention"       # Search papers
-zot --json read ABC123                   # View paper details (JSON)
-zot export ABC123                        # BibTeX export
-zot workspace query "RLHF" --workspace my-ws  # RAG search
+zot search "transformer attention"                      # Search papers
+zot --detail minimal search "transformer attention"     # Search papers (minimal output)
+zot --detail full search "transformer attention"        # Search papers (full output)
+zot --json read ABC123                                  # View paper details (JSON)
+zot export ABC123                                       # Export BibTeX
+zot workspace query "RLHF" --workspace my-ws            # Workspace RAG search
 ```
 
 ## Critical Rules


### PR DESCRIPTION
# Summary
This PR updates the zotero-cli SKILL.md to better reflect the CLI's argument model and prevent invalid command generation by AI agents.

# Changes
Correct the Quick Start examples to place the root-level --detail option before the command:
zot --detail minimal search ...
zot --detail full search ...

# Motivation
Several AI agents generated invalid commands such as:
```bash
zot search "query" --detail full
```
However, --detail is defined on the root zot command rather than the search subcommand. The correct form is:
```bash
zot --detail full search "query"
```
Making this explicit in the Skill helps agents generate valid commands and reduces reliance on inference about CLI option scope.