### PR TITLE
feat(attachment): path 命令支持 --all 列出全部 PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logs/
 my-docs/
 .sisyphus/
 .claude/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-12
+
+### Added
+
+- **`zot attachment path KEY --all`** (`-a`) — list every PDF attachment of an
+  item, one local path per line, instead of just the first. Built for items that
+  now routinely ship an appendix or supplementary PDF alongside the main article.
+  In JSON mode it returns `{item_key, count, attachments: [...]}` with each entry
+  carrying `attachment_key`, `path`, `filename`, `exists`, and `mime_type`.
+  Attachments with no local file are skipped; `not_found` is returned only when
+  the item has no PDF at all, or no PDF has been synced to local storage.
+  Default (no flag) behaviour is unchanged — still prints the first PDF's path.
+- New reader API `ZoteroReader.get_pdf_attachments(key)` returning all PDFs;
+  `get_pdf_attachment` (first PDF) is now a thin wrapper over it.
+
+### Changed
+
+- Schema version bumped to `1.9.0` (additive: new `--all` option on
+  `attachment path`).
+
 ## [0.8.0] - 2026-06-03
 
 ### Added

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -6,13 +6,17 @@
 - **AI agents** (Claude Code, Codex) — stable JSON envelopes, schema introspection, typed errors.
 - **Orchestrators** — deterministic exit codes, delegated auth, structured progress.
 
-Everything on this page is machine-verifiable via `zot schema`.
+`zot schema` is the machine-discoverable source for the command surface:
+command names, nested subcommands, parameters, help text, and
+`safety_tier`. The runtime semantics documented below describe the
+execution-time contract agents should rely on for envelope-backed commands;
+remaining legacy/non-envelope cases are being normalized onto the same model.
 
 ## Channels
 
 | Channel | Primary audience | Contents |
 |---------|-----------------|----------|
-| `stdout` | machines / agents | one JSON envelope per invocation (or NDJSON under `--stream`) |
+| `stdout` | machines / agents | standard JSON envelopes for envelope-backed commands; some documented commands use NDJSON/stream output, and a small number of legacy outputs are still being normalized |
 | `stderr` | humans | prose diagnostics, progress events, `SYNC_REMINDER` |
 | exit code | orchestrators | distinct code per failure class |
 
@@ -26,6 +30,8 @@ ZOT_FORMAT=table zot search foo   # force table even when piped
 ```
 
 ## Envelope
+
+For envelope-backed commands, JSON mode uses the standard shapes below.
 
 ### Success
 
@@ -42,7 +48,7 @@ ZOT_FORMAT=table zot search foo   # force table even when piped
 }
 ```
 
-Mutating commands additionally set `data.sync_required: true` and may carry a `next` slot with follow-up commands:
+Mutating command envelopes may include `data.sync_required`; when present, it is `true` if the command actually changed Zotero state and requires sync. They may also carry a `next` slot with follow-up commands:
 
 ```json
 {
@@ -99,7 +105,7 @@ Agents should read `error.retryable` before retrying.
 }
 ```
 
-Re-running with the same `--idempotency-key` retries only the failed items (see below).
+When a batch reports partial success, inspect `data.failed[]` and explicitly retry the failed entries; do not assume the original batch will automatically replay only those items.
 
 ## Exit codes
 
@@ -177,17 +183,23 @@ The input file may be either a full envelope or a bare `data` tree.
 
 ## Safety tiers
 
-Commands are grouped by risk in `zot --help`:
+Top-level `zot --help` groups commands into risk buckets:
 
-- **Read** — `search`, `list`, `read`, `export`, `recent`, `stats`, `cite`, `pdf`, `collection list`, `tag list`, ...
-- **Write (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `enrich`, `bridge` (mutates local config, not the library)
-- **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`, `orphans` (its `clean` subcommand deletes attachment records)
+- **Read** — `search`, `list`, `read`, `export`, `recent`, `stats`, `cite`, `pdf`, `attachment`, `collection`, `tag`, `trash`, ...
+- **Write commands (MUTATES LIBRARY)** — `add`, `update`, `note`, `attach`, `find-pdf`, `rename`, `enrich`, `bridge` (`bridge` is a local bridge/setup operation, not a Zotero library record mutation)
+- **Destructive (MUTATES LIBRARY)** — `delete`, `update-status`, `orphans`
 
-Each write or destructive command's `--help` carries a `MUTATES LIBRARY` marker. The same classification is available via `zot schema <cmd>.safety_tier`.
+`data.safety_tier` from `zot schema <cmd>` exposes that same top-level
+classification. Treat it as a coarse gating signal, not a complete runtime
+authorization model: some top-level read groups contain nested mutators (for
+example `trash restore`), while destructive top-level groups may also contain
+inspection-only subcommands alongside the mutating ones (for example
+`orphans list` versus `orphans clean`). Agents should evaluate the full command
+path and documented subcommand semantics, not `safety_tier` alone.
 
 ## `--dry-run`
 
-Every mutating command accepts `--dry-run`:
+Many agent-facing mutating commands support `--dry-run`:
 
 ```bash
 zot add --doi "10.1/x" --dry-run
@@ -202,7 +214,13 @@ zot add --doi "10.1/x" --dry-run
 }
 ```
 
-Dry-run does not require credentials and never touches the network.
+For commands that support it, preview envelopes set `dry_run: true`. Treat
+preview behavior as command-specific: most `--dry-run` flows avoid the write
+itself, `zot find-pdf --dry-run` still pings the local Zotero bridge to verify
+reachability, and `zot update-status` uses preview-by-default / `--apply`
+semantics instead of a `--dry-run` flag. Do not assume every mutating command
+accepts `--dry-run`, or that preview mode is always network-free or
+credential-free, unless that command's help says so.
 
 ## DOI metadata resolution
 
@@ -226,6 +244,39 @@ compact summary of what was resolved (or, on miss, a `resolve_warning`):
 - Crossref `404` → `data.resolved = null` and `data.resolve_warning = "no_match"`; the item is still created.
 - Network/5xx error → `data.resolved = null` and `data.resolve_warning = "<message>"`; the item is still created (agents can safely retry to populate metadata via `zot update`).
 - Set `ZOT_CROSSREF_MAILTO=<email>` to join Crossref's "polite pool" (higher rate-limit ceiling, no key required).
+
+## Local PDF attachment path (`zot attachment path`)
+
+Agents that need to render PDF pages, inspect figures, or pass the file to a
+separate parser should use `zot attachment path` instead of `zot open`.
+`zot open` is for humans and launches the system PDF viewer; `attachment path`
+only resolves the local file path and performs no GUI action or text extraction.
+
+```bash
+zot attachment path ABCD1234
+zot --json attachment path ABCD1234
+```
+
+Envelope:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "item_key": "ABCD1234",
+    "attachment_key": "ATT0001",
+    "path": "/Users/me/Zotero/storage/ATT0001/paper.pdf",
+    "filename": "paper.pdf",
+    "exists": true,
+    "mime_type": "application/pdf"
+  }
+}
+```
+
+The command returns the same first PDF attachment selected by `zot pdf` and
+`zot open`. A missing item, missing PDF attachment, unresolved path, or missing
+local file is reported as `not_found` with exit code 4. Successful output always
+means `path` exists locally.
 
 ## Find Full Text (`zot find-pdf`)
 
@@ -403,7 +454,7 @@ summarize the run. Missing credentials abort with `auth_missing` (2).
 
 ## `--idempotency-key`
 
-Mutating commands (`add`, `update`, `note --add`, `attach`, `delete`) accept `--idempotency-key <string>`:
+Mutating commands (`add`, `update`, `note --add`, `attach`, `delete`, `orphans clean`) accept `--idempotency-key <string>`:
 
 ```bash
 zot add --doi "10.1/x" --idempotency-key "ingest-2026-04-15-001"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.8.0"
+version = "0.9.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/skill/zotero-cli-cc/SKILL.md
+++ b/skill/zotero-cli-cc/SKILL.md
@@ -43,6 +43,7 @@ zot workspace query "RLHF" --workspace my-ws            # Workspace RAG search
 | PDF full text | `zot --json pdf KEY` |
 | PDF outline | `zot --json pdf --outline KEY` |
 | PDF section | `zot --json pdf --section N KEY` |
+| Local PDF path | `zot attachment path KEY` (first PDF; `--all` for appendix/supplementary too) |
 | Fetch/attach missing PDF | `zot find-pdf KEY` (needs Zotero desktop + bridge) |
 | Rename attachment files | `zot rename KEY --dry-run` (needs bridge; preview first) |
 | Add journal metrics (IF/分区) | `zot enrich KEY --set "JCR=Q1"` or `--from-map journals.toml` |

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -210,10 +210,25 @@ zot summarize-all
 
 Use `zot attachment path KEY` when an agent needs the local PDF file path for
 rendering pages, inspecting figures, or handing the file to another parser.
-Unlike `zot open KEY`, this command does not launch a GUI viewer. In JSON mode
-it returns `item_key`, `attachment_key`, `path`, `filename`, `exists`, and
-`mime_type`. Missing items, missing PDFs, and missing local files return
-`not_found`.
+Unlike `zot open KEY`, this command does not launch a GUI viewer.
+
+```bash
+zot attachment path KEY              # first PDF only (one bare path)
+zot attachment path KEY --all        # every PDF, one path per line
+zot --json attachment path KEY -a    # every PDF as a JSON array
+```
+
+By default it returns the **first** PDF: in JSON mode `item_key`,
+`attachment_key`, `path`, `filename`, `exists`, and `mime_type`. Missing items,
+missing PDFs, and missing local files return `not_found`.
+
+Pass `--all` (`-a`) when an item carries more than one PDF — common now that
+papers ship an **appendix or supplementary file** beside the main article. It
+lists every PDF whose file exists locally (one path per line for humans). JSON
+mode returns `{item_key, count, attachments: [...]}`, each entry with
+`attachment_key`, `path`, `filename`, `exists`, `mime_type`. Attachments not yet
+synced to local storage are skipped; `not_found` comes back only when the item
+has no PDF at all, or none has a local file.
 
 ## Utilities
 

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -41,7 +41,6 @@ zot add --doi "10.1038/s41586-023-06139-9"
 zot add --url "https://arxiv.org/abs/2301.00001"
 zot add --from-file dois.txt              # Batch import (one DOI/URL per line)
 zot add --pdf paper.pdf                   # Add from local PDF (auto-extract DOI)
-zot --no-interaction delete ITEMKEY
 zot update ITEMKEY --title "New Title"
 zot update ITEMKEY --field volume=42 --field pages=1-10
 zot attach ITEMKEY --file supplement.pdf                 # auto: bridge if desktop up (local), else cloud
@@ -75,17 +74,32 @@ them down rather than deleting. `clean --include-recoverable` also deletes those
 ### Safety Flags
 
 ```bash
-# Preview without writing — no API call
+# Preview first — exact behavior is command-specific
 zot add --doi "10.1038/..." --dry-run
-zot delete ITEMKEY --dry-run
 zot update ITEMKEY --field volume=42 --dry-run
 
 # Idempotency — safe retry after network failure
 zot add --doi "10.1038/..." --idempotency-key abc-123
 zot update ITEMKEY --title "X" --idempotency-key abc-124
 zot attach ITEMKEY --file x.pdf --idempotency-key abc-125
-zot delete ITEMKEY --yes --idempotency-key abc-126
 ```
+
+Most write commands preview their planned mutation with `--dry-run`. Some
+bridge-backed or batch commands use command-specific preview semantics instead
+(for example `zot find-pdf --dry-run` checks bridge reachability, while
+`zot update-status` previews by default and uses `--apply` to write).
+
+## Trash Lifecycle
+
+```bash
+zot delete ITEMKEY --dry-run             # preview moving the item to trash
+zot delete ITEMKEY --yes                 # execute without interactive confirmation
+zot delete ITEMKEY --yes --idempotency-key abc-126
+zot trash restore ITEMKEY                # restore from trash
+```
+
+`zot delete` is the destructive step here; `zot trash restore` is the recovery
+path and does not permanently remove records.
 
 ## Find Full Text PDF (Zotero desktop bridge)
 
@@ -192,13 +206,22 @@ zot summarize-all
 
 **Token-saving strategy**: For large PDFs, use `--outline` to get section IDs first, then `--section` to extract only what you need.
 
+#### Getting a local PDF path for agents
+
+Use `zot attachment path KEY` when an agent needs the local PDF file path for
+rendering pages, inspecting figures, or handing the file to another parser.
+Unlike `zot open KEY`, this command does not launch a GUI viewer. In JSON mode
+it returns `item_key`, `attachment_key`, `path`, `filename`, `exists`, and
+`mime_type`. Missing items, missing PDFs, and missing local files return
+`not_found`.
+
 ## Utilities
 
 ```bash
 zot --json stats                     # Library statistics
-zot open ITEMKEY                     # Open PDF in system viewer
+zot open ITEMKEY                     # Open PDF in system viewer (human-facing)
 zot open --url ITEMKEY               # Open URL/DOI in browser
-zot update-status --limit 20        # Check preprint publication status (needs S2_API_KEY)
+zot update-status --limit 20        # Check preprint publication status (works without S2_API_KEY; key raises rate limits)
 ```
 
 ## Group Library
@@ -208,4 +231,6 @@ zot --library group:12345 search "query"
 zot --library group:12345 list
 ```
 
-All commands support `--library group:<id>` to operate on group libraries.
+Most library-scoped commands support `--library group:<id>` to operate on group
+libraries. Some bridge-backed commands expose command-specific selectors
+instead, such as `zot find-pdf ITEMKEY --library-id 42`.

--- a/src/zotero_cli_cc/cli.py
+++ b/src/zotero_cli_cc/cli.py
@@ -10,6 +10,7 @@ from zotero_cli_cc import __version__
 from zotero_cli_cc.commands.add import add_cmd
 from zotero_cli_cc.commands.ask import ask_cmd
 from zotero_cli_cc.commands.attach import attach_cmd
+from zotero_cli_cc.commands.attachment import attachment_group
 from zotero_cli_cc.commands.bridge import bridge_group
 from zotero_cli_cc.commands.cite import cite_cmd
 from zotero_cli_cc.commands.collection import collection_group
@@ -68,6 +69,7 @@ _READ_COMMANDS = {
     "ask",
     "schema",
     "trash",
+    "attachment",
 }
 _WRITE_COMMANDS = {"add", "update", "note", "attach", "find-pdf", "bridge", "rename", "enrich"}
 _DESTRUCTIVE_COMMANDS = {"delete", "update-status", "orphans"}
@@ -309,6 +311,7 @@ main.add_command(update_status_cmd, "update-status")
 main.add_command(workspace_group, "workspace")
 main.add_command(ask_cmd, "ask")
 main.add_command(schema_cmd, "schema")
+main.add_command(attachment_group, "attachment")
 
 
 if __name__ == "__main__":

--- a/src/zotero_cli_cc/commands/attachment.py
+++ b/src/zotero_cli_cc/commands/attachment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
+
+
+@click.group("attachment")
+def attachment_group() -> None:
+    """Inspect attachment metadata."""
+    pass
+
+
+@attachment_group.command("path")
+@click.argument("item_key")
+@click.pass_context
+def attachment_path(ctx: click.Context, item_key: str) -> None:
+    """Show the local path of the first PDF attachment for a parent item.
+
+    \b
+    Examples:
+      zot attachment path ABC123
+      zot --json attachment path ABC123
+    """
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    json_out = ctx.obj.get("json", False)
+    db_path = get_data_dir(cfg) / "zotero.sqlite"
+    reader = ZoteroReader(
+        db_path,
+        library_id=resolve_library_id(db_path, ctx.obj),
+        prefs_js_path=get_prefs_js_path(cfg),
+    )
+    try:
+        if reader.get_item(item_key) is None:
+            emit_error(
+                "not_found",
+                f"Item '{item_key}' not found",
+                output_json=json_out,
+                hint="Run 'zot search' to find valid item keys",
+                context="attachment path",
+            )
+
+        attachment = reader.get_pdf_attachment(item_key)
+        if attachment is None:
+            emit_error(
+                "not_found",
+                f"No PDF attachment for '{item_key}'",
+                output_json=json_out,
+                hint="Check item details with: zot read KEY",
+                context="attachment path",
+            )
+
+        pdf_path = attachment.path
+        if not pdf_path or not pdf_path.exists():
+            emit_error(
+                "not_found",
+                f"PDF file not found at {pdf_path or attachment.filename}",
+                output_json=json_out,
+                hint="The file may have been moved or the attachment path could not be resolved. "
+                "Check Zotero storage directory",
+                context="attachment path",
+            )
+
+        if json_out:
+            click.echo(
+                json.dumps(
+                    envelope_ok(
+                        {
+                            "item_key": item_key,
+                            "attachment_key": attachment.key,
+                            "path": str(pdf_path),
+                            "filename": attachment.filename,
+                            "exists": True,
+                            "mime_type": attachment.content_type,
+                        }
+                    ),
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+            return
+
+        click.echo(str(pdf_path))
+    finally:
+        reader.close()

--- a/src/zotero_cli_cc/commands/attachment.py
+++ b/src/zotero_cli_cc/commands/attachment.py
@@ -8,6 +8,7 @@ from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, r
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
+from zotero_cli_cc.models import Attachment
 
 
 @click.group("attachment")
@@ -18,14 +19,25 @@ def attachment_group() -> None:
 
 @attachment_group.command("path")
 @click.argument("item_key")
+@click.option(
+    "--all",
+    "-a",
+    "show_all",
+    is_flag=True,
+    help="List every PDF attachment (e.g. article + appendix), one path per line.",
+)
 @click.pass_context
-def attachment_path(ctx: click.Context, item_key: str) -> None:
-    """Show the local path of the first PDF attachment for a parent item.
+def attachment_path(ctx: click.Context, item_key: str, show_all: bool) -> None:
+    """Show the local path of a parent item's PDF attachment(s).
+
+    By default prints the first PDF only (one bare path on stdout). Pass --all to
+    list every PDF — useful when an item carries an appendix or supplementary file.
 
     \b
     Examples:
-      zot attachment path ABC123
-      zot --json attachment path ABC123
+      zot attachment path ABC123            # first PDF
+      zot attachment path ABC123 --all      # all PDFs, one per line
+      zot --json attachment path ABC123 -a  # all PDFs as a JSON array
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
@@ -45,8 +57,8 @@ def attachment_path(ctx: click.Context, item_key: str) -> None:
                 context="attachment path",
             )
 
-        attachment = reader.get_pdf_attachment(item_key)
-        if attachment is None:
+        pdfs = reader.get_pdf_attachments(item_key)
+        if not pdfs:
             emit_error(
                 "not_found",
                 f"No PDF attachment for '{item_key}'",
@@ -55,36 +67,84 @@ def attachment_path(ctx: click.Context, item_key: str) -> None:
                 context="attachment path",
             )
 
-        pdf_path = attachment.path
-        if not pdf_path or not pdf_path.exists():
-            emit_error(
-                "not_found",
-                f"PDF file not found at {pdf_path or attachment.filename}",
-                output_json=json_out,
-                hint="The file may have been moved or the attachment path could not be resolved. "
-                "Check Zotero storage directory",
-                context="attachment path",
-            )
-
-        if json_out:
-            click.echo(
-                json.dumps(
-                    envelope_ok(
-                        {
-                            "item_key": item_key,
-                            "attachment_key": attachment.key,
-                            "path": str(pdf_path),
-                            "filename": attachment.filename,
-                            "exists": True,
-                            "mime_type": attachment.content_type,
-                        }
-                    ),
-                    indent=2,
-                    ensure_ascii=False,
-                )
-            )
+        if show_all:
+            _emit_all(item_key, pdfs, json_out)
             return
 
-        click.echo(str(pdf_path))
+        _emit_first(item_key, pdfs[0], json_out)
     finally:
         reader.close()
+
+
+def _emit_first(item_key: str, attachment: Attachment, json_out: bool) -> None:
+    pdf_path = attachment.path
+    if not pdf_path or not pdf_path.exists():
+        emit_error(
+            "not_found",
+            f"PDF file not found at {pdf_path or attachment.filename}",
+            output_json=json_out,
+            hint="The file may have been moved or the attachment path could not be resolved. "
+            "Check Zotero storage directory. Use --all to list every PDF on the item",
+            context="attachment path",
+        )
+
+    if json_out:
+        click.echo(
+            json.dumps(
+                envelope_ok(
+                    {
+                        "item_key": item_key,
+                        "attachment_key": attachment.key,
+                        "path": str(pdf_path),
+                        "filename": attachment.filename,
+                        "exists": True,
+                        "mime_type": attachment.content_type,
+                    }
+                ),
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    click.echo(str(pdf_path))
+
+
+def _emit_all(item_key: str, pdfs: list[Attachment], json_out: bool) -> None:
+    present = [att for att in pdfs if att.path and att.path.exists()]
+    if not present:
+        emit_error(
+            "not_found",
+            f"No local PDF file found for '{item_key}' ({len(pdfs)} attachment(s) recorded)",
+            output_json=json_out,
+            hint="The files may have been moved or not yet synced to local storage. Check the Zotero storage directory",
+            context="attachment path",
+        )
+
+    if json_out:
+        click.echo(
+            json.dumps(
+                envelope_ok(
+                    {
+                        "item_key": item_key,
+                        "count": len(present),
+                        "attachments": [
+                            {
+                                "attachment_key": att.key,
+                                "path": str(att.path),
+                                "filename": att.filename,
+                                "exists": True,
+                                "mime_type": att.content_type,
+                            }
+                            for att in present
+                        ],
+                    }
+                ),
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    for att in present:
+        click.echo(str(att.path))

--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -603,6 +603,24 @@ class ZoteroReader:
             )
         return attachments
 
+    def get_pdf_attachments(self, key: str, skip_tags: set[str] | None = None) -> list[Attachment]:
+        """Return every PDF attachment for a parent item, in attachment order.
+
+        Modern items frequently carry more than one PDF (e.g. the article plus a
+        supplementary appendix or a translated copy). This returns all of them so
+        callers can hand the full set to an agent; use `get_pdf_attachment` when
+        only the first is needed. `skip_tags` excludes attachments carrying a
+        marker tag like `skip-index`.
+        """
+        result: list[Attachment] = []
+        for att in self.get_attachments(key):
+            if att.content_type != "application/pdf":
+                continue
+            if skip_tags and skip_tags.intersection(att.tags):
+                continue
+            result.append(att)
+        return result
+
     def get_pdf_attachment(self, key: str, skip_tags: set[str] | None = None) -> Attachment | None:
         """Return the first PDF attachment, skipping any tagged with a tag in `skip_tags`.
 
@@ -610,13 +628,8 @@ class ZoteroReader:
         attachments such as machine-translated copies or slides that carry a
         marker tag like `skip-index`.
         """
-        for att in self.get_attachments(key):
-            if att.content_type != "application/pdf":
-                continue
-            if skip_tags and skip_tags.intersection(att.tags):
-                continue
-            return att
-        return None
+        attachments = self.get_pdf_attachments(key, skip_tags=skip_tags)
+        return attachments[0] if attachments else None
 
     def find_orphan_attachments(self) -> list[OrphanAttachment]:
         """Find storage-backed attachments whose file is missing from local storage.

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.8.0"
+SCHEMA_VERSION = "1.9.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)

--- a/tests/test_cli_attachment.py
+++ b/tests/test_cli_attachment.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from zotero_cli_cc.cli import main
+
+
+def _copy_fixture_db(tmp_path: Path, fixture_db: Path) -> Path:
+    db_path = tmp_path / "zotero.sqlite"
+    shutil.copy2(fixture_db, db_path)
+    return db_path
+
+
+def _create_pdf(data_dir: Path, attachment_key: str = "ATCH005", filename: str = "attention.pdf") -> Path:
+    pdf_path = data_dir / "storage" / attachment_key / filename
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    pdf_path.write_bytes(b"%PDF-1.4 test\n")
+    return pdf_path
+
+
+def _invoke(args: list[str], data_dir: Path):
+    runner = CliRunner()
+    return runner.invoke(main, args, env={"ZOT_DATA_DIR": str(data_dir), "ZOT_FORMAT": "table"})
+
+
+def test_attachment_path_human_outputs_bare_existing_path(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    pdf_path = _create_pdf(tmp_path)
+
+    result = _invoke(["attachment", "path", "ATTN001"], tmp_path)
+
+    assert result.exit_code == 0
+    assert result.output.strip() == str(pdf_path)
+
+
+def test_attachment_path_json_envelope(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    pdf_path = _create_pdf(tmp_path)
+
+    result = _invoke(["--json", "attachment", "path", "ATTN001"], tmp_path)
+
+    assert result.exit_code == 0
+    env = json.loads(result.output)
+    assert env["ok"] is True
+    assert env["data"]["item_key"] == "ATTN001"
+    assert env["data"]["attachment_key"] == "ATCH005"
+    assert env["data"]["path"] == str(pdf_path)
+    assert env["data"]["filename"] == "attention.pdf"
+    assert env["data"]["exists"] is True
+    assert env["data"]["mime_type"] == "application/pdf"
+
+
+def test_attachment_path_direct_attachment_key_is_not_supported(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+
+    result = _invoke(["--json", "attachment", "path", "ATCH005"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "Item 'ATCH005' not found" in env["error"]["message"]
+
+
+def test_attachment_path_no_pdf_is_not_found(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+
+    result = _invoke(["--json", "attachment", "path", "DEEP003"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "No PDF attachment" in env["error"]["message"]
+
+
+def test_attachment_path_missing_local_file_is_not_found(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+
+    result = _invoke(["--json", "attachment", "path", "ATTN001"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "PDF file not found" in env["error"]["message"]
+
+
+def test_attachment_path_missing_item_is_not_found(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+
+    result = _invoke(["--json", "attachment", "path", "NOITEM"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "Item 'NOITEM' not found" in env["error"]["message"]
+
+
+def test_attachment_path_uses_first_pdf_for_multi_pdf_item(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    translated_path = _create_pdf(tmp_path, "ATCH012", "translated_cn.pdf")
+    _create_pdf(tmp_path, "ATCH013", "original.pdf")
+
+    result = _invoke(["--json", "attachment", "path", "BILI011"], tmp_path)
+
+    assert result.exit_code == 0
+    env = json.loads(result.output)
+    assert env["ok"] is True
+    assert env["data"]["attachment_key"] == "ATCH012"
+    assert env["data"]["filename"] == "translated_cn.pdf"
+    assert env["data"]["path"] == str(translated_path)
+
+
+def test_schema_attachment_path_reflects_command():
+    result = CliRunner().invoke(main, ["schema", "attachment", "path"])
+
+    assert result.exit_code == 0
+    env = json.loads(result.output)
+    assert env["ok"] is True
+    assert env["data"]["name"] == "attachment path"
+    assert env["data"]["safety_tier"] == "read"
+    assert env["data"]["params"] == [
+        {"name": "item_key", "kind": "argument", "type": "string", "required": True}
+    ]

--- a/tests/test_cli_attachment.py
+++ b/tests/test_cli_attachment.py
@@ -117,6 +117,77 @@ def test_attachment_path_uses_first_pdf_for_multi_pdf_item(tmp_path: Path, test_
     assert env["data"]["path"] == str(translated_path)
 
 
+def test_attachment_path_all_human_lists_every_pdf(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    translated_path = _create_pdf(tmp_path, "ATCH012", "translated_cn.pdf")
+    original_path = _create_pdf(tmp_path, "ATCH013", "original.pdf")
+
+    result = _invoke(["attachment", "path", "BILI011", "--all"], tmp_path)
+
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == [str(translated_path), str(original_path)]
+
+
+def test_attachment_path_all_json_returns_array(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    translated_path = _create_pdf(tmp_path, "ATCH012", "translated_cn.pdf")
+    original_path = _create_pdf(tmp_path, "ATCH013", "original.pdf")
+
+    result = _invoke(["--json", "attachment", "path", "BILI011", "-a"], tmp_path)
+
+    assert result.exit_code == 0
+    env = json.loads(result.output)
+    assert env["ok"] is True
+    assert env["data"]["item_key"] == "BILI011"
+    assert env["data"]["count"] == 2
+    keys = [a["attachment_key"] for a in env["data"]["attachments"]]
+    paths = [a["path"] for a in env["data"]["attachments"]]
+    assert keys == ["ATCH012", "ATCH013"]
+    assert paths == [str(translated_path), str(original_path)]
+    assert all(a["exists"] is True for a in env["data"]["attachments"])
+    assert all(a["mime_type"] == "application/pdf" for a in env["data"]["attachments"])
+
+
+def test_attachment_path_all_skips_missing_local_files(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    # Only create the second PDF on disk; the first is recorded but missing locally.
+    original_path = _create_pdf(tmp_path, "ATCH013", "original.pdf")
+
+    result = _invoke(["--json", "attachment", "path", "BILI011", "--all"], tmp_path)
+
+    assert result.exit_code == 0
+    env = json.loads(result.output)
+    assert env["data"]["count"] == 1
+    assert env["data"]["attachments"][0]["attachment_key"] == "ATCH013"
+    assert env["data"]["attachments"][0]["path"] == str(original_path)
+
+
+def test_attachment_path_all_no_pdf_is_not_found(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+
+    result = _invoke(["--json", "attachment", "path", "DEEP003", "--all"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "No PDF attachment" in env["error"]["message"]
+
+
+def test_attachment_path_all_no_local_file_is_not_found(tmp_path: Path, test_db_path: Path):
+    _copy_fixture_db(tmp_path, test_db_path)
+    # BILI011 has two PDF attachments recorded but neither file exists on disk.
+
+    result = _invoke(["--json", "attachment", "path", "BILI011", "--all"], tmp_path)
+
+    assert result.exit_code == 4
+    env = json.loads(result.output)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "not_found"
+    assert "No local PDF file found" in env["error"]["message"]
+
+
 def test_schema_attachment_path_reflects_command():
     result = CliRunner().invoke(main, ["schema", "attachment", "path"])
 
@@ -126,5 +197,14 @@ def test_schema_attachment_path_reflects_command():
     assert env["data"]["name"] == "attachment path"
     assert env["data"]["safety_tier"] == "read"
     assert env["data"]["params"] == [
-        {"name": "item_key", "kind": "argument", "type": "string", "required": True}
+        {"name": "item_key", "kind": "argument", "type": "string", "required": True},
+        {
+            "name": "show_all",
+            "kind": "option",
+            "type": "boolean",
+            "required": False,
+            "flags": ["--all", "-a"],
+            "is_flag": True,
+            "help": "List every PDF attachment (e.g. article + appendix), one path per line.",
+        },
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## 背景

现在的文献条目普遍带有附录 / 补充材料 PDF，而 `zot attachment path KEY` 只返回第一个 PDF，agent 无法拿到完整的 PDF 集合。

## 改动

- `zot attachment path KEY` 新增 `--all` / `-a` 标志:
  - 人类模式：列出该条目下所有**本地存在**的 PDF，每行一条路径
  - JSON 模式：返回 `{item_key, count, attachments: [...]}`，每项含 `attachment_key` / `path` / `filename` / `exists` / `mime_type`
  - 未同步到本地的附件自动跳过；仅当条目无任何 PDF、或无任何本地 PDF 文件时返回 `not_found`
  - **默认行为不变**（仍只输出第一个 PDF 的裸路径），向后兼容现有管道
- reader 新增 `get_pdf_attachments()`，`get_pdf_attachment()` 改为其薄包装，消除重复逻辑
- 版本 `0.8.0 → 0.9.0`，schema 版本 `1.8.0 → 1.9.0`（加性变更：新增可选 flag）
- 同步更新 `CHANGELOG.md`、skill 文档（`SKILL.md` 速查表 + `references/commands.md`）

Original PR: #68 by @pxb988. Rebased onto main to resolve merge conflicts with #72 and #74.

## 测试

- [x] `uv run pytest tests/` —— 780 passed, 2 failed (pre-existing SOCKS proxy, unrelated), 1 skipped
- [x] `uv run ruff check` / `ruff format --check` / `mypy src/` 全通过