### PR TITLE
feat(search): tokenize multi-word queries into independent word matches (#73)

### DIFF
--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -215,8 +215,73 @@ class ZoteroReader:
         lib_sql, lib_params = self._library_filter()
 
         if query:
+            # Tokenize into words and match each word independently across
+            # all search dimensions, then intersect (AND).  This lets
+            # "Vaswani attention" match an item whose creator is Vaswani
+            # and whose title contains "attention" — the words live in
+            # different fields.  The original full-phrase LIKE is also kept
+            # as an OR contributor so exact phrase matches still rank.
+            words = query.split()
             like = f"%{query}%"
-            # Search titles and abstracts
+
+            # Per-word match sets for intersection
+            word_sets: list[set[int]] = []
+            for w in words:
+                pat = f"%{w}%"
+                w_ids: set[int] = set()
+
+                # Metadata (title / abstract)
+                rows = conn.execute(
+                    "SELECT DISTINCT i.itemID FROM items i "
+                    "JOIN itemData id ON i.itemID = id.itemID "
+                    "JOIN itemDataValues iv ON id.valueID = iv.valueID "
+                    f"WHERE iv.value LIKE ? AND i.itemTypeID {excl_sql} {lib_sql}",
+                    (pat, *excl_params, *lib_params),
+                ).fetchall()
+                w_ids.update(r["itemID"] for r in rows)
+
+                # Creators
+                rows = conn.execute(
+                    "SELECT DISTINCT ic.itemID FROM itemCreators ic "
+                    "JOIN creators c ON ic.creatorID = c.creatorID "
+                    "JOIN items i ON ic.itemID = i.itemID "
+                    "WHERE (c.firstName LIKE ? OR c.lastName LIKE ?) "
+                    f"AND i.itemTypeID {excl_sql} {lib_sql}",
+                    (pat, pat, *excl_params, *lib_params),
+                ).fetchall()
+                w_ids.update(r["itemID"] for r in rows)
+
+                # Tags
+                rows = conn.execute(
+                    "SELECT DISTINCT it.itemID FROM itemTags it "
+                    "JOIN tags t ON it.tagID = t.tagID "
+                    "JOIN items i ON it.itemID = i.itemID "
+                    f"WHERE t.name LIKE ? AND i.itemTypeID {excl_sql} {lib_sql}",
+                    (pat, *excl_params, *lib_params),
+                ).fetchall()
+                w_ids.update(r["itemID"] for r in rows)
+
+                # Fulltext
+                rows = conn.execute(
+                    "SELECT DISTINCT ia.parentItemID FROM fulltextItemWords fw "
+                    "JOIN fulltextWords w ON fw.wordID = w.wordID "
+                    "JOIN itemAttachments ia ON fw.itemID = ia.itemID "
+                    "JOIN items i ON ia.parentItemID = i.itemID "
+                    f"WHERE w.word LIKE ? AND ia.parentItemID IS NOT NULL AND i.itemTypeID {excl_sql} {lib_sql}",
+                    (pat, *excl_params, *lib_params),
+                ).fetchall()
+                w_ids.update(r["parentItemID"] for r in rows)
+
+                word_sets.append(w_ids)
+
+            # Intersect: an item must match every word somewhere
+            if word_sets:
+                item_ids = word_sets[0].copy()
+                for ws in word_sets[1:]:
+                    item_ids &= ws
+
+            # Also OR in the full-phrase match — exact phrase hits should
+            # always appear even if the tokenised intersection missed them.
             rows = conn.execute(
                 "SELECT DISTINCT i.itemID FROM items i "
                 "JOIN itemData id ON i.itemID = id.itemID "
@@ -225,38 +290,6 @@ class ZoteroReader:
                 (like, *excl_params, *lib_params),
             ).fetchall()
             item_ids.update(r["itemID"] for r in rows)
-
-            # Search creators
-            rows = conn.execute(
-                "SELECT DISTINCT ic.itemID FROM itemCreators ic "
-                "JOIN creators c ON ic.creatorID = c.creatorID "
-                "JOIN items i ON ic.itemID = i.itemID "
-                "WHERE (c.firstName LIKE ? OR c.lastName LIKE ?) "
-                f"AND i.itemTypeID {excl_sql} {lib_sql}",
-                (like, like, *excl_params, *lib_params),
-            ).fetchall()
-            item_ids.update(r["itemID"] for r in rows)
-
-            # Search tags
-            rows = conn.execute(
-                "SELECT DISTINCT it.itemID FROM itemTags it "
-                "JOIN tags t ON it.tagID = t.tagID "
-                "JOIN items i ON it.itemID = i.itemID "
-                f"WHERE t.name LIKE ? AND i.itemTypeID {excl_sql} {lib_sql}",
-                (like, *excl_params, *lib_params),
-            ).fetchall()
-            item_ids.update(r["itemID"] for r in rows)
-
-            # Search fulltext (with library filter)
-            rows = conn.execute(
-                "SELECT DISTINCT ia.parentItemID FROM fulltextItemWords fw "
-                "JOIN fulltextWords w ON fw.wordID = w.wordID "
-                "JOIN itemAttachments ia ON fw.itemID = ia.itemID "
-                "JOIN items i ON ia.parentItemID = i.itemID "
-                f"WHERE w.word LIKE ? AND ia.parentItemID IS NOT NULL AND i.itemTypeID {excl_sql} {lib_sql}",
-                (like, *excl_params, *lib_params),
-            ).fetchall()
-            item_ids.update(r["parentItemID"] for r in rows)
         else:
             rows = conn.execute(
                 f"SELECT itemID FROM items i WHERE itemTypeID {excl_sql} {lib_sql}",

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -72,6 +72,22 @@ class TestSearch:
         result = reader.search("", limit=1)
         assert len(result.items) == 1
 
+    def test_search_multi_word_cross_field(self, reader: ZoteroReader):
+        """Multi-word queries match across fields (title, creator, tags)."""
+        result = reader.search("Vaswani attention")
+        assert result.total > 0
+        assert any(i.key == "ATTN001" for i in result.items)
+
+    def test_search_multi_word_partial_miss(self, reader: ZoteroReader):
+        """When one word doesn't match anything, the item is excluded."""
+        result = reader.search("attention nonexistentword999")
+        assert result.total == 0
+
+    def test_search_single_word_still_works(self, reader: ZoteroReader):
+        """Single-word queries unchanged."""
+        result = reader.search("transformer")
+        assert result.total >= 2
+
 
 class TestNotes:
     def test_get_notes(self, reader: ZoteroReader):


### PR DESCRIPTION
## Problem

`zot search` used `LIKE '%full phrase%'` — multi-word queries required all words as a contiguous substring in the same field. "Vaswani attention" returned zero results because no single field contains both words together.

## Fix

Tokenize multi-word queries into individual words. Each word is matched independently across all four search dimensions (title/abstract, creators, tags, fulltext), and the results are intersected (AND semantics). The original full-phrase LIKE is kept as an OR contributor so exact phrase matches still rank.

**Before:** `LIKE '%Vaswani attention%'` → nothing matches
**After:** `LIKE '%Vaswani%'` (matches creator) AND `LIKE '%attention%'` (matches title) → finds ATTN001

Single-word queries are unchanged.

## Tests

- Multi-word cross-field match: "Vaswani attention" → ATTN001 ✓
- Partial miss: "attention nonexistentword999" → empty ✓
- Single-word unchanged: "transformer" → ≥2 results ✓
- Full suite: 783 passed, 2 pre-existing SOCKS proxy failures

Closes #73.