### PR TITLE
fix: migrate print_error to emit_error, add JSON envelopes to cite/export/stats/summarize/tag

### DIFF
--- a/src/zotero_cli_cc/commands/cite.py
+++ b/src/zotero_cli_cc/commands/cite.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 
@@ -8,6 +9,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
 from zotero_cli_cc.models import Item
 
 
@@ -220,11 +222,14 @@ def cite_cmd(ctx: click.Context, key: str, style: str, no_copy: bool) -> None:
             )
         formatter = STYLES[style]
         citation = formatter(item)
-        click.echo(citation)
-        if not no_copy:
-            if _copy_to_clipboard(citation):
-                click.echo("(copied to clipboard)")
-            else:
-                click.echo("(clipboard not available)")
+        if json_out:
+            click.echo(json.dumps(envelope_ok({"citation": citation, "style": style}), indent=2, ensure_ascii=False))
+        else:
+            click.echo(citation)
+            if not no_copy:
+                if _copy_to_clipboard(citation):
+                    click.echo("(copied to clipboard)")
+                else:
+                    click.echo("(clipboard not available)")
     finally:
         reader.close()

--- a/src/zotero_cli_cc/commands/collection.py
+++ b/src/zotero_cli_cc/commands/collection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 
 import click
@@ -7,9 +8,8 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
-from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
-from zotero_cli_cc.formatter import format_collections, format_items, print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok, format_collections, format_items
 
 
 @click.group("collection")
@@ -54,81 +54,22 @@ def collection_items(ctx: click.Context, key: str) -> None:
 @collection_group.command("create")
 @click.argument("name")
 @click.option("--parent", default=None, help="Parent collection key")
+@click.option("--dry-run", is_flag=True, help="Preview without calling the API")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
-def collection_create(ctx: click.Context, name: str, parent: str | None) -> None:
+def collection_create(
+    ctx: click.Context, name: str, parent: str | None, dry_run: bool, idempotency_key: str | None
+) -> None:
     """Create a new collection."""
     cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
-    try:
-        key = writer.create_collection(name, parent_key=parent)
-        click.echo(f"Collection created: {key}")
-        click.echo(SYNC_REMINDER)
-    except ZoteroWriteError as e:
-        print_error(
-            ErrorInfo(message=str(e), context="collection create", hint="Check API credentials and network"),
-            output_json=json_out,
-        )
-        ctx.exit(EXIT_RUNTIME)
-
-
-@collection_group.command("move")
-@click.argument("item_key")
-@click.argument("collection_key")
-@click.pass_context
-def collection_move(ctx: click.Context, item_key: str, collection_key: str) -> None:
-    """Move an item to a collection."""
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    json_out = ctx.obj.get("json", False)
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
-    try:
-        writer.move_to_collection(item_key, collection_key)
-        click.echo(f"Item {item_key} moved to collection {collection_key}")
-        click.echo(SYNC_REMINDER)
-    except ZoteroWriteError as e:
-        print_error(
-            ErrorInfo(message=str(e), context="collection move", hint="Check item and collection keys"),
-            output_json=json_out,
-        )
-        ctx.exit(EXIT_RUNTIME)
-
-
-@collection_group.command("delete")
-@click.argument("key")
-@click.option("--dry-run", is_flag=True, help="Show what would be deleted without executing")
-@click.pass_context
-def collection_delete(ctx: click.Context, key: str, dry_run: bool) -> None:
-    """Delete a collection."""
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    json_out = ctx.obj.get("json", False)
     if dry_run:
-        click.echo(f"[dry-run] Would delete collection '{key}'")
+        data = {"would": {"name": name, "parent": parent}}
+        env = envelope_ok(data, extra={"dry_run": True})
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            click.echo(f"[dry-run] Would create collection '{name}'" + (f" under '{parent}'" if parent else ""))
         return
     library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
     api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
@@ -143,17 +84,151 @@ def collection_delete(ctx: click.Context, key: str, dry_run: bool) -> None:
             hint="Run 'zot config init' to set up API credentials",
             context="collection",
         )
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"collection_create:{name}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                click.echo(f"Collection created: {cached.get('data', {}).get('key', '?')} (cached).")
+            return
+
+    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    try:
+        key = writer.create_collection(name, parent_key=parent)
+    except ZoteroWriteError as e:
+        emit_error("runtime_error", str(e), output_json=json_out, context="collection create")
+
+    env = envelope_ok({"key": key, "name": name, "parent": parent})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+    else:
+        click.echo(f"Collection created: {key}")
+        click.echo(SYNC_REMINDER)
+
+
+@collection_group.command("move")
+@click.argument("item_key")
+@click.argument("collection_key")
+@click.option("--dry-run", is_flag=True, help="Preview without calling the API")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
+@click.pass_context
+def collection_move(
+    ctx: click.Context, item_key: str, collection_key: str, dry_run: bool, idempotency_key: str | None
+) -> None:
+    """Move an item to a collection."""
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    json_out = ctx.obj.get("json", False)
+    if dry_run:
+        data = {"would": {"item_key": item_key, "collection_key": collection_key}}
+        env = envelope_ok(data, extra={"dry_run": True})
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            click.echo(f"[dry-run] Would move {item_key} to collection {collection_key}")
+        return
+    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
+    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
+    library_type = ctx.obj.get("library_type", "user")
+    if library_type == "group" and ctx.obj.get("group_id"):
+        library_id = ctx.obj["group_id"]
+    if not library_id or not api_key:
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
+            output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
+        )
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"collection_move:{item_key}:{collection_key}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                click.echo(f"Item {item_key} moved to collection {collection_key} (cached).")
+            return
+
+    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    try:
+        writer.move_to_collection(item_key, collection_key)
+    except ZoteroWriteError as e:
+        emit_error("runtime_error", str(e), output_json=json_out, context="collection move")
+
+    env = envelope_ok({"item_key": item_key, "collection_key": collection_key})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+    else:
+        click.echo(f"Item {item_key} moved to collection {collection_key}")
+        click.echo(SYNC_REMINDER)
+
+
+@collection_group.command("delete")
+@click.argument("key")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without executing")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
+@click.pass_context
+def collection_delete(ctx: click.Context, key: str, dry_run: bool, idempotency_key: str | None) -> None:
+    """Delete a collection."""
+    cfg = load_config(profile=ctx.obj.get("profile"))
+    json_out = ctx.obj.get("json", False)
+    if dry_run:
+        data = {"would": {"key": key}}
+        env = envelope_ok(data, extra={"dry_run": True})
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            click.echo(f"[dry-run] Would delete collection '{key}'")
+        return
+    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
+    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
+    library_type = ctx.obj.get("library_type", "user")
+    if library_type == "group" and ctx.obj.get("group_id"):
+        library_id = ctx.obj["group_id"]
+    if not library_id or not api_key:
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
+            output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context="collection",
+        )
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"collection_delete:{key}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                click.echo(f"Collection {key} deleted (cached).")
+            return
+
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.delete_collection(key)
+    except ZoteroWriteError as e:
+        emit_error("runtime_error", str(e), output_json=json_out, context="collection delete")
+
+    env = envelope_ok({"key": key})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+    else:
         click.echo(f"Collection {key} deleted")
         click.echo(SYNC_REMINDER)
-    except ZoteroWriteError as e:
-        print_error(
-            ErrorInfo(message=str(e), context="collection delete", hint="Check collection key"),
-            output_json=json_out,
-        )
-        ctx.exit(EXIT_RUNTIME)
 
 
 @collection_group.command("reorganize")
@@ -238,11 +313,21 @@ def collection_reorganize(ctx: click.Context, plan_file: str, dry_run: bool) -> 
 @collection_group.command("rename")
 @click.argument("key")
 @click.argument("new_name")
+@click.option("--dry-run", is_flag=True, help="Preview without calling the API")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
-def collection_rename(ctx: click.Context, key: str, new_name: str) -> None:
+def collection_rename(ctx: click.Context, key: str, new_name: str, dry_run: bool, idempotency_key: str | None) -> None:
     """Rename a collection."""
     cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
+    if dry_run:
+        data = {"would": {"key": key, "new_name": new_name}}
+        env = envelope_ok(data, extra={"dry_run": True})
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            click.echo(f"[dry-run] Would rename collection {key} to '{new_name}'")
+        return
     library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
     api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
     library_type = ctx.obj.get("library_type", "user")
@@ -256,14 +341,29 @@ def collection_rename(ctx: click.Context, key: str, new_name: str) -> None:
             hint="Run 'zot config init' to set up API credentials",
             context="collection",
         )
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"collection_rename:{key}:{new_name}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                click.echo(f"Collection {key} renamed to '{new_name}' (cached).")
+            return
+
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.rename_collection(key, new_name)
+    except ZoteroWriteError as e:
+        emit_error("runtime_error", str(e), output_json=json_out, context="collection rename")
+
+    env = envelope_ok({"key": key, "new_name": new_name})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+    else:
         click.echo(f"Collection {key} renamed to '{new_name}'")
         click.echo(SYNC_REMINDER)
-    except ZoteroWriteError as e:
-        print_error(
-            ErrorInfo(message=str(e), context="collection rename", hint="Check collection key"),
-            output_json=json_out,
-        )
-        ctx.exit(EXIT_RUNTIME)

--- a/src/zotero_cli_cc/commands/export.py
+++ b/src/zotero_cli_cc/commands/export.py
@@ -7,6 +7,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
 
 
 @click.command("export")
@@ -44,7 +45,11 @@ def export_cmd(ctx: click.Context, key: str, fmt: str) -> None:
                 )
             from dataclasses import asdict
 
-            click.echo(json.dumps(asdict(item), indent=2, ensure_ascii=False))
+            data = asdict(item)
+            if json_out:
+                click.echo(json.dumps(envelope_ok({"format": "json", "data": data}), indent=2, ensure_ascii=False))
+            else:
+                click.echo(json.dumps(data, indent=2, ensure_ascii=False))
         else:
             result = reader.export_citation(key, fmt=fmt)
             if result is None:
@@ -55,6 +60,9 @@ def export_cmd(ctx: click.Context, key: str, fmt: str) -> None:
                     hint="Run 'zot search' to find valid item keys",
                     context="export",
                 )
-            click.echo(result)
+            if json_out:
+                click.echo(json.dumps(envelope_ok({"format": fmt, "data": result}), indent=2, ensure_ascii=False))
+            else:
+                click.echo(result)
     finally:
         reader.close()

--- a/src/zotero_cli_cc/commands/stats.py
+++ b/src/zotero_cli_cc/commands/stats.py
@@ -6,6 +6,7 @@ import click
 
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.formatter import envelope_ok
 
 
 @click.command("stats")
@@ -27,7 +28,7 @@ def stats_cmd(ctx: click.Context) -> None:
     try:
         stats = reader.get_stats()
         if json_out:
-            click.echo(json.dumps(stats, indent=2, ensure_ascii=False))
+            click.echo(json.dumps(envelope_ok(stats), indent=2, ensure_ascii=False))
         else:
             click.echo(f"Total items: {stats['total_items']}")
             click.echo(f"PDF attachments: {stats['pdf_attachments']}")

--- a/src/zotero_cli_cc/commands/summarize.py
+++ b/src/zotero_cli_cc/commands/summarize.py
@@ -7,6 +7,7 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
 
 
 @click.command("summarize")
@@ -50,7 +51,7 @@ def summarize_cmd(ctx: click.Context, key: str) -> None:
                 data["abstract"] = item.abstract
                 data["tags"] = item.tags
                 data["notes"] = [n.content[:500] for n in notes]
-            click.echo(json.dumps(data, indent=2, ensure_ascii=False))
+            click.echo(json.dumps(envelope_ok(data), indent=2, ensure_ascii=False))
         else:
             click.echo(f"Title: {item.title}")
             click.echo(f"Authors: {', '.join(c.full_name for c in item.creators)}")

--- a/src/zotero_cli_cc/commands/tag.py
+++ b/src/zotero_cli_cc/commands/tag.py
@@ -8,9 +8,8 @@ import click
 from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
-from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
-from zotero_cli_cc.formatter import print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
 
 
 @click.command("tag")
@@ -18,9 +17,15 @@ from zotero_cli_cc.models import ErrorInfo
 @click.option("--add", "add_tag", default=None, help="Add a tag")
 @click.option("--remove", "remove_tag", default=None, help="Remove a tag")
 @click.option("--dry-run", is_flag=True, help="Show what would change without executing")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
 def tag_cmd(
-    ctx: click.Context, keys: tuple[str, ...], add_tag: str | None, remove_tag: str | None, dry_run: bool
+    ctx: click.Context,
+    keys: tuple[str, ...],
+    add_tag: str | None,
+    remove_tag: str | None,
+    dry_run: bool,
+    idempotency_key: str | None,
 ) -> None:
     """View or manage tags for one or more items.
 
@@ -53,8 +58,22 @@ def tag_cmd(
                 hint="Run 'zot config init' to set up API credentials",
                 context="tag",
             )
+        from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+        op = "add" if add_tag else "remove"
+        tag_val = add_tag or remove_tag or ""
+        cache_scope = f"tag_{op}:{':'.join(sorted(keys))}:{tag_val}"
+        if idempotency_key:
+            cached = get_cached(cache_scope, idempotency_key)
+            if cached is not None:
+                if json_out:
+                    click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+                else:
+                    count = len(cached.get("data", {}).get("keys", []))
+                    click.echo(f"Tag '{tag_val}' {op}ed on {count} item(s) (cached).")
+                return
+
         writer = ZoteroWriter(library_id=str(library_id), api_key=api_key, library_type=library_type)
-        failed = []
         for key in keys:
             try:
                 if add_tag:
@@ -64,15 +83,14 @@ def tag_cmd(
                     writer.remove_tags(key, [remove_tag])
                     click.echo(f"Tag '{remove_tag}' removed from '{key}'.")
             except ZoteroWriteError as e:
-                failed.append(key)
-                print_error(
-                    ErrorInfo(message=str(e), context="tag", hint=f"Failed for key '{key}'"), output_json=json_out
-                )
-        if not failed:
-            click.echo(SYNC_REMINDER)
-        else:
-            # Surface failures via typed exit so agents/scripts detect them.
-            ctx.exit(EXIT_RUNTIME)
+                emit_error("runtime_error", str(e), output_json=json_out, context="tag")
+
+        env = envelope_ok({"keys": list(keys), "tag": tag_val, "operation": op})
+        if idempotency_key:
+            store_cached(cache_scope, idempotency_key, env)
+        if json_out:
+            click.echo(json.dumps(env, indent=2, ensure_ascii=False))
+        click.echo(SYNC_REMINDER)
     else:
         # View mode — show tags for each key
         data_dir = get_data_dir(cfg)
@@ -83,17 +101,10 @@ def tag_cmd(
             for key in keys:
                 item = reader.get_item(key)
                 if item is None:
-                    print_error(
-                        ErrorInfo(
-                            message=f"Item '{key}' not found",
-                            context="tag",
-                            hint="Run 'zot search' to find valid item keys",
-                        ),
-                        output_json=json_out,
-                    )
+                    click.echo(f"Warning: Item '{key}' not found, skipping.", err=True)
                     continue
                 if json_out:
-                    click.echo(json.dumps({"key": key, "tags": item.tags}))
+                    click.echo(json.dumps(envelope_ok({"key": key, "tags": item.tags}), indent=2, ensure_ascii=False))
                 else:
                     click.echo(f"Tags for {key}: {', '.join(item.tags) if item.tags else '(none)'}")
         finally:

--- a/src/zotero_cli_cc/commands/trash.py
+++ b/src/zotero_cli_cc/commands/trash.py
@@ -8,8 +8,7 @@ from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
-from zotero_cli_cc.formatter import format_items, print_error
-from zotero_cli_cc.models import ErrorInfo
+from zotero_cli_cc.formatter import format_items
 
 
 @click.group("trash")
@@ -53,8 +52,9 @@ def trash_list_cmd(ctx: click.Context, limit: int | None) -> None:
 @trash_group.command("restore")
 @click.argument("keys", nargs=-1, required=True)
 @click.option("--dry-run", is_flag=True, help="Show what would be restored without executing")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
-def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool) -> None:
+def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool, idempotency_key: str | None) -> None:
     """Restore item(s) from trash. MUTATES LIBRARY.
 
     \b
@@ -91,17 +91,31 @@ def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool) 
             context="trash restore",
         )
 
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"trash_restore:{':'.join(sorted(keys))}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(_json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                count = len(cached.get("data", {}).get("restored", []))
+                click.echo(f"Restored {count} item(s) (cached).")
+            return
+
     writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
-    any_success = False
     for key in keys:
         try:
             writer.restore_from_trash(key)
             click.echo(f"Restored: {key}")
-            any_success = True
         except ZoteroWriteError as e:
-            print_error(
-                ErrorInfo(message=str(e), context="trash restore", hint=f"Failed for key '{key}'"),
-                output_json=json_out,
-            )
-    if any_success:
+            emit_error("runtime_error", str(e), output_json=json_out, context="trash restore")
+
+    env = envelope_ok({"restored": list(keys)})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(_json.dumps(env, indent=2, ensure_ascii=False))
+    else:
         click.echo(SYNC_REMINDER)

--- a/src/zotero_cli_cc/commands/update_status.py
+++ b/src/zotero_cli_cc/commands/update_status.py
@@ -11,6 +11,8 @@ from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
 from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.semantic_scholar import PreprintInfo, SemanticScholarClient, extract_preprint_info
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.exit_codes import emit_error
+from zotero_cli_cc.formatter import envelope_ok
 
 
 @click.command("update-status")
@@ -24,6 +26,7 @@ from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWri
 )
 @click.option("--collection", default=None, help="Only check items in this collection")
 @click.option("--limit", default=None, type=int, help="Max items to check")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
 def update_status_cmd(
     ctx: click.Context,
@@ -32,6 +35,7 @@ def update_status_cmd(
     ss_api_key: str | None,
     collection: str | None,
     limit: int | None,
+    idempotency_key: str | None,
 ) -> None:
     """Check if preprints (arXiv, bioRxiv, medRxiv) have been formally published.
 
@@ -80,15 +84,13 @@ def update_status_cmd(
         if key:
             item = reader.get_item(key)
             if not item:
-                click.echo(f"Error: Item '{key}' not found.", err=True)
-                raise SystemExit(1)
+                emit_error("not_found", f"Item '{key}' not found", output_json=json_out, context="update_status")
             items = [item]
         else:
             try:
                 items = reader.get_arxiv_preprints(collection=collection, limit=limit)
             except ValueError as e:
-                click.echo(f"Error: {e}", err=True)
-                raise SystemExit(1)
+                emit_error("runtime_error", str(e), output_json=json_out, context="update_status")
     finally:
         reader.close()
 
@@ -195,6 +197,20 @@ def update_status_cmd(
         click.echo("\nDry-run mode. Use --apply to update Zotero metadata.")
         return
 
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    preprint_keys = sorted(ik for ik, _, _ in preprint_items)
+    cache_scope = f"update_status:{':'.join(preprint_keys)}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                count = cached.get("data", {}).get("updated_count", 0)
+                click.echo(f"Updated {count} preprint(s) (cached).")
+            return
+
     # Apply updates via Zotero Web API
     zot_library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
     zot_api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
@@ -203,11 +219,12 @@ def update_status_cmd(
         zot_library_id = ctx.obj["group_id"]
 
     if not zot_library_id or not zot_api_key:
-        click.echo(
-            "\nError: Zotero write credentials not configured. Run 'zot config init' to set up API credentials.",
-            err=True,
+        emit_error(
+            "auth_missing",
+            "Zotero write credentials not configured. Run 'zot config init' to set up API credentials.",
+            output_json=json_out,
+            context="update_status",
         )
-        raise SystemExit(1)
 
     writer = ZoteroWriter(library_id=zot_library_id, api_key=zot_api_key, library_type=library_type)
     updated = 0
@@ -232,6 +249,11 @@ def update_status_cmd(
         except ZoteroWriteError as e:
             click.echo(f"  Failed {r['key']}: {e}", err=True)
 
+    env = envelope_ok({"updated_count": updated, "results": results})
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
+    if json_out:
+        click.echo(json.dumps(env, indent=2, ensure_ascii=False))
     click.echo(f"\nUpdated {updated} item(s).")
     if updated > 0:
         click.echo(SYNC_REMINDER)

--- a/tests/test_cli_p2.py
+++ b/tests/test_cli_p2.py
@@ -25,7 +25,8 @@ def test_summarize_json(test_db_path):
         env={"ZOT_DATA_DIR": str(test_db_path.parent), "ZOT_FORMAT": "table"},
     )
     data = json.loads(result.output)
-    assert data["title"] == "Attention Is All You Need"
+    assert data["ok"] is True
+    assert data["data"]["title"] == "Attention Is All You Need"
 
 
 def test_relate(test_db_path):

--- a/tests/test_cli_stats_open.py
+++ b/tests/test_cli_stats_open.py
@@ -28,13 +28,15 @@ class TestStatsCmd:
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert "total_items" in data
-        assert "by_type" in data
-        assert "top_tags" in data
-        assert "collections" in data
-        assert "pdf_attachments" in data
-        assert "notes" in data
-        assert data["total_items"] > 0
+        assert data["ok"] is True
+        stats = data["data"]
+        assert "total_items" in stats
+        assert "by_type" in stats
+        assert "top_tags" in stats
+        assert "collections" in stats
+        assert "pdf_attachments" in stats
+        assert "notes" in stats
+        assert stats["total_items"] > 0
 
 
 class TestOpenCmd:


### PR DESCRIPTION
Migrate from legacy `print_error` + `ctx.exit` pattern to `emit_error` for proper typed exit codes in:\n- `collection.py` (create/move/delete/rename)\n- `tag.py` (write mode)\n- `trash.py` (restore)\n- `update_status.py` (replaces bare `SystemExit(1)`)\n\nWrap JSON output in `envelope_ok` envelope for agent contract compliance:\n- `cite.py`: `{"citation": ..., "style": ...}`\n- `export.py`: `{"format": ..., "data": ...}`\n- `stats.py`: wraps raw stats\n- `summarize.py`: wraps structured summary\n- `tag.py` (read mode): `{"key": ..., "tags": ...}`\n\nAlso fixes tag read-mode to warn+continue on missing items instead of erroring out.