### PR TITLE
feat: add --idempotency-key and --dry-run to collection/enrich/rename/tag/trash/update-status

### DIFF
--- a/src/zotero_cli_cc/commands/enrich.py
+++ b/src/zotero_cli_cc/commands/enrich.py
@@ -33,6 +33,7 @@ _ABORT_CODES = {"auth_missing", "auth_invalid", "network_error"}
     help="TOML table of journal name -> {metric: value}; applied by the item's journal",
 )
 @click.option("--dry-run", is_flag=True, help="Preview the Extra changes without writing")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
 def enrich_cmd(
     ctx: click.Context,
@@ -40,6 +41,7 @@ def enrich_cmd(
     set_pairs: tuple[str, ...],
     map_path: Path | None,
     dry_run: bool,
+    idempotency_key: str | None,
 ) -> None:
     """Write journal metrics into an item's Extra field. MUTATES LIBRARY.
 
@@ -70,6 +72,19 @@ def enrich_cmd(
             output_json=json_out,
             context="enrich",
         )
+
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"enrich:{':'.join(sorted(item_keys))}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                updated_count = cached.get("data", {}).get("updated_count", 0)
+                click.echo(f"Enrich results (cached): {updated_count} item(s) updated.")
+            return
 
     cfg = load_config(profile=ctx.obj.get("profile"))
     db_path = get_data_dir(cfg) / "zotero.sqlite"
@@ -104,7 +119,9 @@ def enrich_cmd(
                 emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, context="enrich")
             results.append({"key": key, "status": "error", "error": str(e), "code": e.code})
 
-    _emit(json_out, results, updated=updated, dry_run=dry_run)
+    env = _emit(json_out, results, updated=updated, dry_run=dry_run)
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
 
 
 def _build_writer(ctx: click.Context, cfg: AppConfig, json_out: bool) -> ZoteroWriter:
@@ -124,12 +141,12 @@ def _build_writer(ctx: click.Context, cfg: AppConfig, json_out: bool) -> ZoteroW
     return ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
 
 
-def _emit(json_out: bool, results: list[dict], *, updated: int, dry_run: bool) -> None:
+def _emit(json_out: bool, results: list[dict], *, updated: int, dry_run: bool) -> dict:
     data = {"results": results, "updated_count": updated, "sync_required": updated > 0}
     env = envelope_ok(data, extra={"dry_run": True} if dry_run else None)
     if json_out:
         click.echo(json.dumps(env, indent=2, ensure_ascii=False))
-        return
+        return env
     for item in results:
         click.echo(f"{item['key']}:")
         if item.get("error"):
@@ -144,3 +161,4 @@ def _emit(json_out: bool, results: list[dict], *, updated: int, dry_run: bool) -
         click.echo("[dry-run] no items changed", err=True)
     elif updated:
         click.echo(SYNC_REMINDER, err=True)
+    return env

--- a/src/zotero_cli_cc/commands/rename.py
+++ b/src/zotero_cli_cc/commands/rename.py
@@ -36,6 +36,7 @@ _ABORT_CODES = {"not_reachable", "bridge_missing"}
 @click.option("--library-id", type=int, default=None, help="Override the Zotero library ID (default: user library)")
 @click.option("--force", is_flag=True, help="Overwrite if a file with the new name already exists")
 @click.option("--dry-run", is_flag=True, help="Preview the renames without changing any files")
+@click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
 def rename_cmd(
     ctx: click.Context,
@@ -47,6 +48,7 @@ def rename_cmd(
     library_id: int | None,
     force: bool,
     dry_run: bool,
+    idempotency_key: str | None,
 ) -> None:
     """Rename PDF attachment files from item metadata. MUTATES LIBRARY.
 
@@ -74,19 +76,31 @@ def rename_cmd(
                 output_json=json_out,
                 context="rename",
             )
+        from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+        cache_scope = f"rename_explicit:{attachment_key}:{explicit_name}"
         row: dict[str, object] = {"attachment_key": attachment_key, "new_name": explicit_name, "role": "explicit"}
         if dry_run:
             row["status"] = "dry-run"
-        else:
-            try:
-                res = rename_attachment(attachment_key, explicit_name, library_id=library_id, force=force)  # type: ignore[arg-type]
-            except LocalBridgeError as e:
-                emit_error(
-                    e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="rename"
-                )
-            row["old_name"] = res.get("old_name")
-            row["status"] = "renamed"
-        _emit(ctx, json_out, [{"key": None, "renames": [row]}], renamed=0 if dry_run else 1, dry_run=dry_run)
+            _emit(ctx, json_out, [{"key": None, "renames": [row]}], renamed=0, dry_run=dry_run)
+            return
+        if idempotency_key:
+            cached = get_cached(cache_scope, idempotency_key)
+            if cached is not None:
+                if json_out:
+                    click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+                else:
+                    click.echo(f"Attachment {attachment_key} -> {explicit_name} (cached).")
+                return
+        try:
+            res = rename_attachment(attachment_key, explicit_name, library_id=library_id, force=force)  # type: ignore[arg-type]
+        except LocalBridgeError as e:
+            emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="rename")
+        row["old_name"] = res.get("old_name")
+        row["status"] = "renamed"
+        env = _emit(ctx, json_out, [{"key": None, "renames": [row]}], renamed=1, dry_run=dry_run)
+        if idempotency_key:
+            store_cached(cache_scope, idempotency_key, env)
         return
 
     if not item_keys:
@@ -96,6 +110,19 @@ def rename_cmd(
             output_json=json_out,
             context="rename",
         )
+
+    from zotero_cli_cc.core.idempotency import get_cached, store_cached
+
+    cache_scope = f"rename:{':'.join(sorted(item_keys))}"
+    if idempotency_key:
+        cached = get_cached(cache_scope, idempotency_key)
+        if cached is not None:
+            if json_out:
+                click.echo(json.dumps(cached, indent=2, ensure_ascii=False))
+            else:
+                n = cached.get("data", {}).get("renamed_count", 0)
+                click.echo(f"Renamed {n} attachment(s) (cached).")
+            return
 
     # Fail fast if the desktop / bridge is unreachable (skip for dry-run).
     if not dry_run:
@@ -158,15 +185,17 @@ def rename_cmd(
             renames.append(row)
         results.append({"key": key, "renames": renames})
 
-    _emit(ctx, json_out, results, renamed=renamed, dry_run=dry_run)
+    env = _emit(ctx, json_out, results, renamed=renamed, dry_run=dry_run)
+    if idempotency_key:
+        store_cached(cache_scope, idempotency_key, env)
 
 
-def _emit(ctx: click.Context, json_out: bool, results: list[dict], *, renamed: int, dry_run: bool) -> None:
+def _emit(ctx: click.Context, json_out: bool, results: list[dict], *, renamed: int, dry_run: bool) -> dict:
     data = {"results": results, "renamed_count": renamed, "sync_required": renamed > 0}
     env = envelope_ok(data, extra={"dry_run": True} if dry_run else None)
     if json_out:
         click.echo(json.dumps(env, indent=2, ensure_ascii=False))
-        return
+        return env
     for item in results:
         if item.get("key"):
             click.echo(f"{item['key']}:")
@@ -180,3 +209,4 @@ def _emit(ctx: click.Context, json_out: bool, results: list[dict], *, renamed: i
         click.echo("[dry-run] no files changed", err=True)
     elif renamed:
         click.echo(SYNC_REMINDER, err=True)
+    return env


### PR DESCRIPTION
Add missing --idempotency-key and --dry-run support to remaining mutating commands, following the exact pattern from attach.py.

### Changes

**enrich.py** — added `--idempotency-key`: cache check before processing loop, store envelope after `_emit`. Modified `_emit` to return the envelope.

**rename.py** — added `--idempotency-key` to both explicit single-attachment mode and metadata-based batch mode with appropriate cache scopes. Modified `_emit` to return the envelope.

**collection.py, tag.py, trash.py, update_status.py** — already updated in `9b46bee` (previous commit).

### Scope
| Command | --idempotency-key | --dry-run |
|---|---|---|
| collection create | new | new |
| collection move | new | new |
| collection delete | new | already had |
| collection rename | new | new |
| enrich | new | already had |
| rename (explicit) | new | already had |
| rename (batch) | new | already had |
| tag | new | already had |
| trash restore | new | already had |
| update-status | new | N/A (uses --apply)