### PR TITLE
docs: fix license drift in README_CN, pdfium default in CLAUDE.md, agent-interface accuracy, changelog 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ my-docs/
 .sisyphus/
 .claude/
 .DS_Store
+# Local-only assets and notes (not part of the published repo)
+asserts/banner_cn.png
+asserts/banner_en.png
+goal-pdf-extraction-tiers.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-06-12
+## [0.9.0] - 2026-07-14
 
 ### Added
 
@@ -21,11 +21,34 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Default (no flag) behaviour is unchanged — still prints the first PDF's path.
 - New reader API `ZoteroReader.get_pdf_attachments(key)` returning all PDFs;
   `get_pdf_attachment` (first PDF) is now a thin wrapper over it.
+- **Tokenized multi-word search** — `zot search` splits multi-word queries into
+  independent word matches: each word may hit title, creator, tag, or full text
+  separately, and results are the intersection across words (#76).
+- **Group-library support for `zot attach --via-bridge`** — the bridge maps the
+  Web-API group id to the desktop's internal `libraryID`; requires bridge plugin
+  **v0.4.0** (the CLI checks the plugin version and fails with `bridge_missing`
+  rather than importing into the personal library) (#72).
+- **`zot attach` auto-detects the bridge** — imports through the running Zotero
+  desktop when reachable, otherwise falls back to the Web API; the cloud path
+  now reports an honest `data.result` (`created` vs `exists`) (#71).
+- **`--idempotency-key` on `zot enrich` and `zot rename`** so agent retries are
+  safe on those commands too (#79).
 
 ### Changed
 
 - Schema version bumped to `1.9.0` (additive: new `--all` option on
   `attachment path`).
+
+### Fixed
+
+- Migrated remaining `print_error` call sites to `emit_error` so failures exit
+  non-zero with typed codes; `cite`, `export`, `stats`, `summarize`, and `tag`
+  now emit proper JSON envelopes (#78).
+- MCP server no longer re-creates the writer connection per call (caching);
+  workspace-index errors are now logged instead of swallowed; `mineru` fallback
+  reports the underlying error; `save_config` preserves other profiles; removed
+  an N+1 query in `get_collection_items`; workspace search is tokenized;
+  duplicate detection scores all pairs (#77).
 
 ## [0.8.0] - 2026-06-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Config lives at `~/.config/zot/config.toml` with multi-profile support (`[profil
 
 - Type hints are required (`disallow_untyped_defs = true`). mypy runs on `src/zotero_cli_cc/` only — tests are exempt.
 - Ruff: `target-version = py310`, `line-length = 120`, E501 ignored. `zotero_cli_cc` is configured as first-party for isort.
-- License is **dual: AGPL-3.0-or-later + a commercial license** (see `LICENSE`, `LICENSE-COMMERCIAL`). Preserve both the `license` field and the AGPL classifier when touching packaging metadata. Contributions come in under the DCO/relicense terms in `CONTRIBUTING.md`. Note: PyMuPDF (default PDF extractor) is itself AGPL-or-Artifex-commercial — a closed-source commercial build must satisfy that dependency separately.
+- License is **dual: AGPL-3.0-or-later + a commercial license** (see `LICENSE`, `LICENSE-COMMERCIAL`). Preserve both the `license` field and the AGPL classifier when touching packaging metadata. Contributions come in under the DCO/relicense terms in `CONTRIBUTING.md`. Note: PyMuPDF is an opt-in extra (`[pymupdf]`), not the default — the default `pdfium` backend is permissively licensed, so the base install ships no AGPL PDF code; a commercial build only needs to consider PyMuPDF's AGPL-or-Artifex-commercial licensing if the `[pymupdf]` extra is included.
 - Never run `git commit` or `git push` without explicit user instruction — the repo has CI, docs, and PyPI publish wired to `main`.
 
 ## Docs & skill

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Writes** — safe via Zotero Web API, Zotero stays in sync
 - **PDF + RAG** — extract full text with caching; built-in BM25 (+ optional embedding) search over per-topic workspaces
 - **Agent-native** — stable JSON envelope, typed exit codes, `zot schema`, `--dry-run`, `--idempotency-key`, NDJSON streaming
-- **MCP server** — exposes 45 tools to Claude Desktop / LM Studio / Cursor via `zot mcp serve`
+- **MCP server** — exposes 48 tools to Claude Desktop / LM Studio / Cursor via `zot mcp serve`
 
 ## Architecture
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,7 +8,7 @@
   <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/v/zotero-cli-cc?color=blue" alt="PyPI version"></a>
   <a href="https://github.com/Agents365-ai/zotero-cli-cc/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli-cc/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-cc" alt="Python versions"></a>
-  <a href="https://creativecommons.org/licenses/by-nc/4.0/"><img src="https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey" alt="License"></a>
+  <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue" alt="License"></a>
   <a href="https://agents365-ai.github.io/zotero-cli-cc/zh/"><img src="https://img.shields.io/badge/文档-GitHub%20Pages-blue" alt="文档"></a>
 </p>
 
@@ -20,7 +20,7 @@
 - **写操作** — 通过 Zotero Web API 安全写入，Zotero 完全感知变更
 - **PDF + RAG** — 提取 PDF 全文并自动缓存；内置 BM25（可选向量）按主题工作空间检索
 - **Agent-native** — 稳定 JSON envelope、类型化退出码、`zot schema`、`--dry-run`、`--idempotency-key`、NDJSON 流
-- **MCP 服务器** — 通过 `zot mcp serve` 向 Claude Desktop / LM Studio / Cursor 暴露 45 个工具
+- **MCP 服务器** — 通过 `zot mcp serve` 向 Claude Desktop / LM Studio / Cursor 暴露 48 个工具
 
 ## 架构
 
@@ -132,4 +132,10 @@ cp -r skill/zotero-cli-cc ~/.claude/skills/
 
 ## 许可证
 
-[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) — 非商业使用免费。
+zotero-cli-cc 采用**双许可证**：
+
+- **开源：** [GNU AGPL-3.0-or-later](https://www.gnu.org/licenses/agpl-3.0)（见 [LICENSE](LICENSE)）。
+- **商业：** 如需在闭源或商业产品中使用而不受 AGPL 的 copyleft 义务约束，
+  可获取单独的商业许可证（见 [LICENSE-COMMERCIAL](LICENSE-COMMERCIAL)）。
+
+贡献代码需遵循项目的 [Developer Certificate of Origin](CONTRIBUTING.md)。

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -9,14 +9,14 @@
 `zot schema` is the machine-discoverable source for the command surface:
 command names, nested subcommands, parameters, help text, and
 `safety_tier`. The runtime semantics documented below describe the
-execution-time contract agents should rely on for envelope-backed commands;
-remaining legacy/non-envelope cases are being normalized onto the same model.
+execution-time contract agents should rely on; envelope coverage is now
+standard across the documented commands.
 
 ## Channels
 
 | Channel | Primary audience | Contents |
 |---------|-----------------|----------|
-| `stdout` | machines / agents | standard JSON envelopes for envelope-backed commands; some documented commands use NDJSON/stream output, and a small number of legacy outputs are still being normalized |
+| `stdout` | machines / agents | standard JSON envelopes; some documented commands use NDJSON/stream output |
 | `stderr` | humans | prose diagnostics, progress events, `SYNC_REMINDER` |
 | exit code | orchestrators | distinct code per failure class |
 
@@ -31,7 +31,7 @@ ZOT_FORMAT=table zot search foo   # force table even when piped
 
 ## Envelope
 
-For envelope-backed commands, JSON mode uses the standard shapes below.
+In JSON mode, commands use the standard shapes below.
 
 ### Success
 
@@ -40,7 +40,7 @@ For envelope-backed commands, JSON mode uses the standard shapes below.
   "ok": true,
   "data": { "key": "ABC123", "title": "..." },
   "meta": {
-    "schema_version": "1.2.0",
+    "schema_version": "1.9.0",
     "cli_version": "0.3.0",
     "request_id": "a1b2c3d4e5f6",
     "latency_ms": 412
@@ -70,7 +70,7 @@ Mutating command envelopes may include `data.sync_required`; when present, it is
     "retryable": false,
     "hint": "Run 'zot search' to find valid item keys"
   },
-  "meta": { "request_id": "...", "schema_version": "1.2.0" }
+  "meta": { "request_id": "...", "schema_version": "1.9.0" }
 }
 ```
 
@@ -454,7 +454,7 @@ summarize the run. Missing credentials abort with `auth_missing` (2).
 
 ## `--idempotency-key`
 
-Mutating commands (`add`, `update`, `note --add`, `attach`, `delete`, `orphans clean`) accept `--idempotency-key <string>`:
+Mutating commands (`add`, `update`, `note --add`, `attach`, `delete`, `orphans clean`, `enrich`, `rename`, `tag`, `trash restore`, `collection create/delete/move/rename`, `update-status`) accept `--idempotency-key <string>`:
 
 ```bash
 zot add --doi "10.1/x" --idempotency-key "ingest-2026-04-15-001"
@@ -477,6 +477,8 @@ zot pdf KEY                        # full text
 zot pdf KEY --pages 1-5           # page range
 zot pdf KEY --outline             # numbered heading outline
 zot pdf KEY --section 3           # content under 3rd heading
+zot pdf KEY --references          # parsed reference list (requires a running GROBID service)
+zot pdf KEY --tables              # extract tables (requires the optional pdfplumber extractor)
 zot pdf KEY --extractor pymupdf   # force specific extractor
 ```
 
@@ -491,7 +493,7 @@ JSON output envelopes the extracted content:
     "text": "...",
     "meta": { "extractor": "pymupdf", "cached": true }
   },
-  "meta": { "schema_version": "1.2.0", ... }
+  "meta": { "schema_version": "1.9.0", ... }
 }
 ```
 
@@ -593,7 +595,7 @@ Query JSON output:
       { "rank": 2, "score": 0.8123, "item_key": "DEF456", "source": "metadata", "content": "..." }
     ]
   },
-  "meta": { "schema_version": "1.2.0", ... }
+  "meta": { "schema_version": "1.9.0", ... }
 }
 ```
 

--- a/skill/zotero-cli-cc/references/commands.md
+++ b/skill/zotero-cli-cc/references/commands.md
@@ -200,6 +200,8 @@ zot --json pdf ITEMKEY                      # Full text extraction
 zot --json pdf --outline ITEMKEY            # Numbered section headings
 zot --json pdf --section N ITEMKEY          # Extract content under the N-th heading
 zot pdf ITEMKEY --annotations               # PDF annotations
+zot --json pdf ITEMKEY --references         # parsed reference list (needs GROBID service)
+zot --json pdf ITEMKEY --tables             # extract tables (needs [pdfplumber] extra)
 zot --json summarize ITEMKEY
 zot summarize-all
 ```


### PR DESCRIPTION
## Summary

Text-only documentation drift fixes ahead of the 0.9.0 release.

- **README_CN.md (legal)**: replace stale CC BY-NC 4.0 badge and 许可证 section with the actual dual license (AGPL-3.0-or-later + Commercial), mirroring README.md.
- **CLAUDE.md**: correct the PDF-extractor licensing note — pdfium is the default (permissive); PyMuPDF is opt-in via the `[pymupdf]` extra, so the base install ships no AGPL PDF code.
- **docs/agent-interface.md**:
  - example envelopes updated `schema_version` 1.2.0 → 1.9.0 (illustrative `--diff` values left as-is)
  - idempotency list now reflects actual coverage (enrich, rename, tag, trash restore, collection create/delete/move/rename, update-status), verified against `commands/*.py`
  - PDF section documents `--references` (GROBID) and `--tables` (pdfplumber)
  - softened stale "legacy outputs being normalized" hedging — envelope coverage is standard post-#78
- **MCP tool count**: 45 → 48 in README.md and README_CN.md (`grep -c "@mcp.tool()"`).
- **skill commands.md**: added `pdf --references` / `pdf --tables` examples.
- **CHANGELOG.md**: folded the merged-but-unreleased PRs (#71, #72, #76, #77, #78, #79) into [0.9.0] and moved its date to 2026-07-14 (0.9.0 was never tagged); [Unreleased] stays empty.
- **.gitignore**: ignore local-only `asserts/banner_cn.png`, `asserts/banner_en.png`, `goal-pdf-extraction-tiers.md`.

## Test plan

- `uv run pytest tests/test_agent_interface.py -q` — 27 passed (help/schema drift contract).
- Verified no remaining `CC BY-NC`, `1.2.0` envelope examples, or "45 tools" strings in the touched docs.