### PR TITLE
refactor: delete dead code, finish PDF shim migration, simplify EmbeddingRouter

### DIFF
--- a/src/zotero_cli_cc/commands/add.py
+++ b/src/zotero_cli_cc/commands/add.py
@@ -245,11 +245,11 @@ def _add_from_pdf(
     resolve: bool = True,
 ) -> None:
     """Add item from PDF: extract DOI, create item, upload attachment."""
-    from zotero_cli_cc.core.pdf_extractor import extract_doi
+    from zotero_cli_cc.core.pdf_extractor import get_extractor
 
     doi = doi_override
     if not doi:
-        doi = extract_doi(pdf_path)
+        doi = get_extractor("pymupdf").extract_doi(pdf_path)
     if not doi:
         emit_error(
             "validation_error",

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -153,10 +153,9 @@ def pdf_cmd(
                 context="pdf",
             )
         if annotations:
-            from zotero_cli_cc.core.pdf_extractor import extract_annotations
-
+            # Annotation extraction is a pymupdf-only capability.
             try:
-                annots = extract_annotations(pdf_path)
+                annots = get_extractor("pymupdf").extract_annotations(pdf_path)
             except PdfExtractionError as e:
                 emit_error("runtime_error", str(e), output_json=json_out, context="pdf")
             if not annots:

--- a/src/zotero_cli_cc/core/embedding_router.py
+++ b/src/zotero_cli_cc/core/embedding_router.py
@@ -9,31 +9,23 @@ from zotero_cli_cc.core.providers.jina import JinaProvider
 
 
 class EmbeddingRouter:
+    """Holds the single embedding provider selected by config.provider."""
+
     def __init__(self, config: EmbeddingConfig):
         self.config = config
-        self.providers: dict[str, EmbeddingProvider] = {}
-        self._init_providers()
+        self.provider: EmbeddingProvider | None = None
 
-    def _init_providers(self) -> None:
-        api_key = self.config.api_key
-        model = self.config.model
-
+        api_key = config.api_key
         if not api_key:
             return
-
-        if self.config.provider == "jina":
-            jina_url = self.config.url if "jina" in self.config.url else "https://api.jina.ai/v1/embeddings"
-            self.providers["jina"] = JinaProvider(
+        if config.provider == "jina":
+            jina_url = config.url if "jina" in config.url else "https://api.jina.ai/v1/embeddings"
+            self.provider = JinaProvider(api_key=api_key, model=config.model, url=jina_url)
+        elif config.provider == "aliyun":
+            self.provider = AliyunProvider(
                 api_key=api_key,
-                model=model,
-                url=jina_url,
-            )
-        elif self.config.provider == "aliyun":
-            aliyun_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-            self.providers["aliyun"] = AliyunProvider(
-                api_key=api_key,
-                model=model,
-                base_url=aliyun_url,
+                model=config.model,
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
             )
 
     def embed(
@@ -43,16 +35,6 @@ class EmbeddingRouter:
     ) -> list[list[float]]:
         if not texts:
             return []
-
-        provider = self._find_provider()
-        if provider:
-            return provider.embed(texts, progress_callback)
-
-        raise RuntimeError("No embedding provider configured")
-
-    def _find_provider(self) -> EmbeddingProvider | None:
-        priority = ["aliyun", "jina"]
-        for name in priority:
-            if name in self.providers:
-                return self.providers[name]
-        return None
+        if self.provider is None:
+            raise RuntimeError("No embedding provider configured")
+        return self.provider.embed(texts, progress_callback)

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 import time
-import warnings
 import xml.etree.ElementTree as ET
 import zipfile
 from abc import ABC, abstractmethod
@@ -201,9 +200,12 @@ class PyMuPdfExtractor(BasePdfExtractor):
         return annotations
 
     def extract_doi(self, pdf_path: Path) -> str | None:
+        # PdfExtractionError covers pymupdf not being installed; pymupdf raises
+        # RuntimeError subclasses (e.g. FileDataError) for corrupt files. Both
+        # mean "no DOI available", matching the pdfium/pdfplumber contract.
         try:
             text = self.extract_text(pdf_path, pages=(1, 2))
-        except (FileNotFoundError, OSError):
+        except (FileNotFoundError, OSError, PdfExtractionError, RuntimeError, ValueError):
             return None
         match = re.search(r"10\.\d{4,9}/[^\s]+", text)
         if match:
@@ -982,107 +984,3 @@ def get_extractor(name: str | None = None) -> BasePdfExtractor:
         cfg = load_pdf_config()
         return extractor_cls(cfg.grobid_url)  # type: ignore[call-arg]
     return extractor_cls()
-
-
-# ---------------------------------------------------------------------------
-# Deprecated functions (kept for backwards compatibility)
-# ---------------------------------------------------------------------------
-
-
-def extract_text_from_pdf(
-    pdf_path: Path,
-    pages: tuple[int, int] | None = None,
-) -> str:
-    warnings.warn(
-        "extract_text_from_pdf is deprecated, use PyMuPdfExtractor().extract_text or get_extractor('pymupdf')",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if not pdf_path.exists():
-        raise FileNotFoundError(f"PDF not found: {pdf_path}")
-    pymupdf = _import_pymupdf()
-    try:
-        doc = pymupdf.open(str(pdf_path))
-    except Exception as e:
-        raise PdfExtractionError(f"Cannot open PDF: {e}") from e
-    try:
-        if pages:
-            start, end = pages
-            if start > len(doc):
-                raise PdfExtractionError(f"Start page {start} exceeds document length ({len(doc)} pages)")
-            page_range = range(start - 1, min(end, len(doc)))
-        else:
-            page_range = range(len(doc))
-        texts = []
-        for i in page_range:
-            texts.append(doc[i].get_text())
-        return "\n".join(texts)
-    except PdfExtractionError:
-        raise
-    except Exception as e:
-        raise PdfExtractionError(f"Failed to extract text: {e}") from e
-    finally:
-        doc.close()
-
-
-def extract_annotations(pdf_path: Path) -> list[dict]:
-    """Extract annotations (highlights, notes, comments) from a PDF.
-
-    Returns list of dicts with keys: type, page, content, quote (for highlights).
-    """
-    warnings.warn(
-        "extract_annotations is deprecated, use PyMuPdfExtractor().extract_annotations or get_extractor('pymupdf')",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if not pdf_path.exists():
-        raise FileNotFoundError(f"PDF not found: {pdf_path}")
-    pymupdf = _import_pymupdf()
-    try:
-        doc = pymupdf.open(str(pdf_path))
-    except Exception as e:
-        raise PdfExtractionError(f"Cannot open PDF: {e}") from e
-    annotations: list[dict] = []
-    try:
-        for page_num, page in enumerate(doc, start=1):  # type: ignore[var-annotated,arg-type]
-            for annot in page.annots() or []:
-                entry: dict = {
-                    "type": annot.type[1],  # e.g. "Highlight", "Text", "Underline"
-                    "page": page_num,
-                    "content": annot.info.get("content", "") or "",
-                }
-                # For highlight/underline/squiggly/strikeout, extract quoted text
-                if annot.type[0] in (8, 9, 10, 11):
-                    try:
-                        quads = annot.vertices
-                        if quads:
-                            quad_points = [pymupdf.Quad(quads[i : i + 4]) for i in range(0, len(quads), 4)]
-                            text_parts = []
-                            for q in quad_points:
-                                text_parts.append(page.get_text("text", clip=q.rect).strip())
-                            quoted = " ".join(t for t in text_parts if t)
-                            if quoted:
-                                entry["quote"] = quoted
-                    except Exception:
-                        pass
-                annotations.append(entry)
-    finally:
-        doc.close()
-    return annotations
-
-
-def extract_doi(pdf_path: Path) -> str | None:
-    """Extract DOI from first 2 pages of a PDF. Returns first match or None."""
-    warnings.warn(
-        "extract_doi is deprecated, use PyMuPdfExtractor().extract_doi or get_extractor('pymupdf')",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    try:
-        text = extract_text_from_pdf(pdf_path, pages=(1, 2))
-    except (PdfExtractionError, FileNotFoundError):
-        return None
-    match = re.search(r"10\.\d{4,9}/[^\s]+", text)
-    if match:
-        return match.group(0).rstrip(".,;)]}>'\"")
-    return None

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -472,33 +472,6 @@ def stream_items(items: list[Item], detail: str = "standard") -> str:
     return "\n".join(lines)
 
 
-def print_error(error: str | ErrorInfo, output_json: bool = False) -> None:
-    """Emit a structured error to the correct channel.
-
-    JSON mode: envelope to stdout (parseable result for agents).
-    Text mode: human line(s) to stderr (human-facing diagnostic).
-
-    Does not exit. Use zotero_cli_cc.exit_codes.emit_error when you want to exit.
-    """
-    import sys as _sys
-
-    import click
-
-    rendered = format_error(error, output_json=output_json)
-    if output_json:
-        click.echo(rendered)
-    else:
-        click.echo(rendered, err=True)
-    _sys.stdout.flush() if output_json else _sys.stderr.flush()
-
-
-def format_success(data: Any, output_json: bool = False, human_text: str = "", meta: dict | None = None) -> str:
-    """Format a success result. JSON mode emits envelope; text mode emits `human_text`."""
-    if output_json:
-        return _dump(envelope_ok(data, meta=meta))
-    return human_text
-
-
 def _collection_to_dict(c: Collection) -> dict:
     return {
         "key": c.key,

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -242,8 +242,6 @@ def _handle_pdf(key: str, pages: str | None, library: str = "user") -> dict:
 
 
 def _handle_annotations(key: str, library: str = "user") -> dict:
-    from zotero_cli_cc.core.pdf_extractor import extract_annotations
-
     reader = _get_reader(library)
     att = reader.get_pdf_attachment(key)
     if att is None:
@@ -251,7 +249,8 @@ def _handle_annotations(key: str, library: str = "user") -> dict:
     pdf_path = att.path
     if not pdf_path or not pdf_path.exists():
         return {"error": f"PDF file not found at {pdf_path or att.filename}"}
-    annots = extract_annotations(pdf_path)
+    # Annotation extraction is a pymupdf-only capability.
+    annots = get_extractor("pymupdf").extract_annotations(pdf_path)
     return {"key": key, "annotations": annots, "total": len(annots)}
 
 
@@ -666,11 +665,10 @@ def _handle_attach(parent_key: str, file_path: str, library: str = "user", via_b
 
 def _handle_add_from_pdf(file_path: str, doi_override: str | None = None, library: str = "user") -> dict:
     from zotero_cli_cc.core.metadata_resolver import MetadataResolveError, resolve_doi
-    from zotero_cli_cc.core.pdf_extractor import extract_doi
 
     doi = doi_override
     if not doi:
-        doi = extract_doi(Path(file_path))
+        doi = get_extractor("pymupdf").extract_doi(Path(file_path))
     if not doi:
         return {"error": "No DOI found in PDF. Use doi_override to specify manually."}
 

--- a/tests/test_add_pdf.py
+++ b/tests/test_add_pdf.py
@@ -4,32 +4,32 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from zotero_cli_cc.core.pdf_extractor import extract_doi
+from zotero_cli_cc.core.pdf_extractor import PyMuPdfExtractor
 
 
 class TestExtractDoi:
     def test_extract_doi_found(self, tmp_path):
-        with patch("zotero_cli_cc.core.pdf_extractor.extract_text_from_pdf") as mock_extract:
+        with patch.object(PyMuPdfExtractor, "extract_text") as mock_extract:
             mock_extract.return_value = "Some text with DOI 10.1038/s41586-023-06139-9 in it"
-            result = extract_doi(tmp_path / "dummy.pdf")
+            result = PyMuPdfExtractor().extract_doi(tmp_path / "dummy.pdf")
             assert result == "10.1038/s41586-023-06139-9"
 
     def test_extract_doi_not_found(self, tmp_path):
-        with patch("zotero_cli_cc.core.pdf_extractor.extract_text_from_pdf") as mock_extract:
+        with patch.object(PyMuPdfExtractor, "extract_text") as mock_extract:
             mock_extract.return_value = "No DOI in this text"
-            result = extract_doi(tmp_path / "dummy.pdf")
+            result = PyMuPdfExtractor().extract_doi(tmp_path / "dummy.pdf")
             assert result is None
 
     def test_extract_doi_strips_trailing_punctuation(self, tmp_path):
-        with patch("zotero_cli_cc.core.pdf_extractor.extract_text_from_pdf") as mock_extract:
+        with patch.object(PyMuPdfExtractor, "extract_text") as mock_extract:
             mock_extract.return_value = "DOI: 10.1234/test.paper)."
-            result = extract_doi(tmp_path / "dummy.pdf")
+            result = PyMuPdfExtractor().extract_doi(tmp_path / "dummy.pdf")
             assert result == "10.1234/test.paper"
 
     def test_extract_doi_multiple_returns_first(self, tmp_path):
-        with patch("zotero_cli_cc.core.pdf_extractor.extract_text_from_pdf") as mock_extract:
+        with patch.object(PyMuPdfExtractor, "extract_text") as mock_extract:
             mock_extract.return_value = "10.1234/first and 10.5678/second"
-            result = extract_doi(tmp_path / "dummy.pdf")
+            result = PyMuPdfExtractor().extract_doi(tmp_path / "dummy.pdf")
             assert result == "10.1234/first"
 
 
@@ -56,7 +56,7 @@ class TestAddPdfMCP:
 
         with (
             patch("zotero_cli_cc.mcp_server._get_writer"),
-            patch("zotero_cli_cc.core.pdf_extractor.extract_doi", return_value=None),
+            patch("zotero_cli_cc.core.pdf_extractor.PyMuPdfExtractor.extract_doi", return_value=None),
         ):
             result = _handle_add_from_pdf("/tmp/test.pdf")
             assert "error" in result
@@ -67,7 +67,7 @@ class TestAddPdfMCP:
 
         with (
             patch("zotero_cli_cc.mcp_server._get_writer") as mock_get,
-            patch("zotero_cli_cc.core.pdf_extractor.extract_doi", return_value="10.1234/test"),
+            patch("zotero_cli_cc.core.pdf_extractor.PyMuPdfExtractor.extract_doi", return_value="10.1234/test"),
             patch("zotero_cli_cc.core.metadata_resolver.resolve_doi", return_value=None),
         ):
             mock_writer = MagicMock()

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -10,7 +10,7 @@ import pytest
 from click.testing import CliRunner
 
 from zotero_cli_cc.cli import main
-from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, extract_text_from_pdf
+from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, PdfiumExtractor
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 
 WRITE_ENV = {"ZOT_LIBRARY_ID": "123", "ZOT_API_KEY": "abc"}
@@ -162,7 +162,7 @@ class TestPdfExtractionError:
         bad_pdf = tmp_path / "bad.pdf"
         bad_pdf.write_bytes(b"not a real pdf file")
         with pytest.raises(PdfExtractionError, match="Cannot open PDF"):
-            extract_text_from_pdf(bad_pdf)
+            PdfiumExtractor().extract_text(bad_pdf)
 
     def test_page_range_exceeds_length(self):
         fixtures = Path(__file__).parent / "fixtures"
@@ -170,7 +170,7 @@ class TestPdfExtractionError:
         if not pdf.exists():
             pytest.skip("test.pdf fixture not found")
         with pytest.raises(PdfExtractionError, match="exceeds document length"):
-            extract_text_from_pdf(pdf, pages=(9999, 10000))
+            PdfiumExtractor().extract_text(pdf, pages=(9999, 10000))
 
     def test_pdf_extraction_error_is_catchable(self):
         """Verify PdfExtractionError can be caught as expected in commands."""

--- a/tests/test_pdf_extractor.py
+++ b/tests/test_pdf_extractor.py
@@ -2,21 +2,21 @@ from pathlib import Path
 
 import pytest
 
-from zotero_cli_cc.core.pdf_extractor import extract_text_from_pdf
+from zotero_cli_cc.core.pdf_extractor import PyMuPdfExtractor
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_extract_full_pdf():
-    text = extract_text_from_pdf(FIXTURES / "test.pdf")
+    text = PyMuPdfExtractor().extract_text(FIXTURES / "test.pdf")
     assert "test PDF" in text
 
 
 def test_extract_specific_pages():
-    text = extract_text_from_pdf(FIXTURES / "test.pdf", pages=(1, 1))
+    text = PyMuPdfExtractor().extract_text(FIXTURES / "test.pdf", pages=(1, 1))
     assert "test PDF" in text
 
 
 def test_extract_nonexistent_pdf():
     with pytest.raises(FileNotFoundError):
-        extract_text_from_pdf(FIXTURES / "nonexistent.pdf")
+        PyMuPdfExtractor().extract_text(FIXTURES / "nonexistent.pdf")

--- a/tests/test_tier1_annotations.py
+++ b/tests/test_tier1_annotations.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pymupdf
 import pytest
 
-from zotero_cli_cc.core.pdf_extractor import extract_annotations
+from zotero_cli_cc.core.pdf_extractor import PyMuPdfExtractor
+
+
+def extract_annotations(pdf_path: Path) -> list[dict]:
+    return PyMuPdfExtractor().extract_annotations(pdf_path)
 
 
 @pytest.fixture


### PR DESCRIPTION
Part 1 of the over-engineering cleanup (from the repo audit).

## Changes (net **−146 LOC**)

- **formatter.py**: delete `print_error` and `format_success` — zero callers after #78's emit_error migration
- **pdf_extractor.py**: delete the three deprecated module-level shims (`extract_text_from_pdf`, `extract_annotations`, `extract_doi`). All 4 production callers migrated to `get_extractor("pymupdf")` — the CLI no longer fires DeprecationWarnings against itself at runtime (test-run warnings drop from 20 → 5)
- **PyMuPdfExtractor.extract_doi**: broadened exception net so corrupt/missing PDFs return `None`, matching the old shim contract for callers
- **embedding_router.py**: removed the providers dict + priority list + `_find_provider` — dead flexibility; `_init_providers` only ever registered the one provider chosen by `config.provider`. Public `embed()` signature unchanged
- **tests**: repointed to the extractor API; coverage equivalent

## Verification

- ruff check + format: clean
- mypy: clean (67 files)
- pytest: **792 passed**, 2 pre-existing local SOCKS-proxy failures (unrelated)

Follow-up (separate PR): wire `open_reader`/`build_writer` helpers into the ~35 command boilerplate sites.