### PR TITLE
refactor: consolidate reader/writer construction into open_reader/build_writer helpers

### DIFF
--- a/src/zotero_cli_cc/commands/_helpers.py
+++ b/src/zotero_cli_cc/commands/_helpers.py
@@ -1,0 +1,45 @@
+"""Shared plumbing helpers for command modules."""
+
+from __future__ import annotations
+
+import os
+
+import click
+
+from zotero_cli_cc.config import AppConfig, get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.core.writer import ZoteroWriter
+from zotero_cli_cc.exit_codes import emit_error
+
+
+def open_reader(ctx: click.Context, cfg: AppConfig | None = None) -> ZoteroReader:
+    """Build a ZoteroReader from the Click context (config, data dir, library).
+
+    Pass ``cfg`` when the caller already loaded the config (avoids a second load).
+    """
+    if cfg is None:
+        cfg = load_config(profile=ctx.obj.get("profile"))
+    db_path = get_data_dir(cfg) / "zotero.sqlite"
+    return ZoteroReader(
+        db_path,
+        library_id=resolve_library_id(db_path, ctx.obj),
+        prefs_js_path=get_prefs_js_path(cfg),
+    )
+
+
+def build_writer(ctx: click.Context, cfg: AppConfig, json_out: bool, context: str) -> ZoteroWriter:
+    """Build a ZoteroWriter from config; exits via emit_error if credentials are missing."""
+    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
+    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
+    library_type = ctx.obj.get("library_type", "user")
+    if library_type == "group" and ctx.obj.get("group_id"):
+        library_id = ctx.obj["group_id"]
+    if not library_id or not api_key:
+        emit_error(
+            "auth_missing",
+            "Write credentials not configured",
+            output_json=json_out,
+            hint="Run 'zot config init' to set up API credentials",
+            context=context,
+        )
+    return ZoteroWriter(library_id=str(library_id), api_key=api_key, library_type=library_type)

--- a/src/zotero_cli_cc/commands/add.py
+++ b/src/zotero_cli_cc/commands/add.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import click
 
-from zotero_cli_cc.config import load_config
+from zotero_cli_cc.commands._helpers import build_writer
+from zotero_cli_cc.config import AppConfig, load_config
 from zotero_cli_cc.core.metadata_resolver import MetadataResolveError, resolve_doi
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import emit_progress, envelope_ok, envelope_partial
 
@@ -127,30 +127,12 @@ def add_cmd(
             click.echo(f"[dry-run] Would add: {would}")
         return
 
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="add",
-        )
-
     if pdf_file:
-        _add_from_pdf(
-            Path(pdf_file), doi, library_id, api_key, json_out, library_type=library_type, resolve=not no_resolve
-        )
+        _add_from_pdf(Path(pdf_file), doi, ctx, cfg, json_out, resolve=not no_resolve)
         return
 
     if from_file:
-        _add_from_file(
-            Path(from_file), library_id, api_key, json_out, library_type=library_type, resolve=not no_resolve
-        )
+        _add_from_file(Path(from_file), ctx, cfg, json_out, resolve=not no_resolve)
         return
 
     if not doi and not url:
@@ -161,6 +143,8 @@ def add_cmd(
             hint="Example: zot add --doi '10.1038/...' or --from-file dois.txt",
             context="add",
         )
+
+    writer = build_writer(ctx, cfg, json_out, context="add")
 
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
@@ -204,7 +188,6 @@ def add_cmd(
                     err=True,
                 )
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         key = writer.add_item(doi=doi, url=url, extra_fields=extra_fields)
     except ZoteroWriteError as e:
@@ -238,10 +221,9 @@ def add_cmd(
 def _add_from_pdf(
     pdf_path: Path,
     doi_override: str | None,
-    library_id: str,
-    api_key: str,
+    ctx: click.Context,
+    cfg: AppConfig,
     json_out: bool,
-    library_type: str = "user",
     resolve: bool = True,
 ) -> None:
     """Add item from PDF: extract DOI, create item, upload attachment."""
@@ -259,6 +241,7 @@ def _add_from_pdf(
             context="add",
         )
 
+    writer = build_writer(ctx, cfg, json_out, context="add")
     extra_fields: dict | None = None
     resolved_summary: dict | None = None
     resolve_warning: str | None = None
@@ -267,7 +250,6 @@ def _add_from_pdf(
         if extra_fields:
             resolved_summary = _resolved_summary(extra_fields)
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         key = writer.add_item(doi=doi, extra_fields=extra_fields)
     except ZoteroWriteError as e:
@@ -319,10 +301,9 @@ def _add_from_pdf(
 
 def _add_from_file(
     file_path: Path,
-    library_id: str,
-    api_key: str,
+    ctx: click.Context,
+    cfg: AppConfig,
     json_out: bool,
-    library_type: str = "user",
     resolve: bool = True,
 ) -> None:
     """Batch add items from a file with one DOI or URL per line."""
@@ -336,10 +317,10 @@ def _add_from_file(
             context="add",
         )
 
+    writer = build_writer(ctx, cfg, json_out, context="add")
     emit_progress("start", phase="batch_add", total=len(lines), source=str(file_path))
     if not json_out:
         click.echo(f"Adding {len(lines)} items from {file_path}...", err=True)
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     succeeded: list[dict] = []
     failed: list[dict] = []
     for i, entry in enumerate(lines, 1):

--- a/src/zotero_cli_cc/commands/attach.py
+++ b/src/zotero_cli_cc/commands/attach.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import click
 
+from zotero_cli_cc.commands._helpers import build_writer
 from zotero_cli_cc.config import load_config
 from zotero_cli_cc.core.local_bridge import (
     LocalBridgeError,
@@ -13,7 +13,7 @@ from zotero_cli_cc.core.local_bridge import (
     import_file,
     resolve_use_bridge,
 )
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 
@@ -106,19 +106,7 @@ def attach_cmd(
             click.echo(SYNC_REMINDER, err=True)
         return
 
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="attach",
-        )
+    writer = build_writer(ctx, cfg, json_out, context="attach")
 
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
@@ -132,7 +120,6 @@ def attach_cmd(
                 click.echo(f"Attachment uploaded: {cached.get('data', {}).get('attachment_key', '?')} (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         att_key, upload_result = writer.upload_attachment(key, fp)
     except ZoteroWriteError as e:

--- a/src/zotero_cli_cc/commands/attachment.py
+++ b/src/zotero_cli_cc/commands/attachment.py
@@ -4,8 +4,7 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 from zotero_cli_cc.models import Attachment
@@ -39,15 +38,8 @@ def attachment_path(ctx: click.Context, item_key: str, show_all: bool) -> None:
       zot attachment path ABC123 --all      # all PDFs, one per line
       zot --json attachment path ABC123 -a  # all PDFs as a JSON array
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
-    db_path = get_data_dir(cfg) / "zotero.sqlite"
-    reader = ZoteroReader(
-        db_path,
-        library_id=resolve_library_id(db_path, ctx.obj),
-        prefs_js_path=get_prefs_js_path(cfg),
-    )
-    try:
+    with open_reader(ctx) as reader:
         if reader.get_item(item_key) is None:
             emit_error(
                 "not_found",
@@ -72,8 +64,6 @@ def attachment_path(ctx: click.Context, item_key: str, show_all: bool) -> None:
             return
 
         _emit_first(item_key, pdfs[0], json_out)
-    finally:
-        reader.close()
 
 
 def _emit_first(item_key: str, attachment: Attachment, json_out: bool) -> None:

--- a/src/zotero_cli_cc/commands/cite.py
+++ b/src/zotero_cli_cc/commands/cite.py
@@ -6,8 +6,7 @@ import sys
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 from zotero_cli_cc.models import Item
@@ -204,13 +203,8 @@ def cite_cmd(ctx: click.Context, key: str, style: str, no_copy: bool) -> None:
       zot cite ABC123 --style vancouver  Vancouver style
       zot cite ABC123 --no-copy          Print without copying
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
     json_out = ctx.obj.get("json", False)
-    try:
+    with open_reader(ctx) as reader:
         item = reader.get_item(key)
         if item is None:
             emit_error(
@@ -231,5 +225,3 @@ def cite_cmd(ctx: click.Context, key: str, style: str, no_copy: bool) -> None:
                     click.echo("(copied to clipboard)")
                 else:
                     click.echo("(clipboard not available)")
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/collection.py
+++ b/src/zotero_cli_cc/commands/collection.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok, format_collections, format_items
 
@@ -22,16 +21,9 @@ def collection_group() -> None:
 @click.pass_context
 def collection_list(ctx: click.Context) -> None:
     """List all collections."""
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         collections = reader.get_collections()
         click.echo(format_collections(collections, output_json=ctx.obj.get("json", False)))
-    finally:
-        reader.close()
 
 
 @collection_group.command("items")
@@ -39,16 +31,9 @@ def collection_list(ctx: click.Context) -> None:
 @click.pass_context
 def collection_items(ctx: click.Context, key: str) -> None:
     """List items in a collection."""
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         items = reader.get_collection_items(key)
         click.echo(format_items(items, output_json=ctx.obj.get("json", False)))
-    finally:
-        reader.close()
 
 
 @collection_group.command("create")
@@ -71,19 +56,6 @@ def collection_create(
         else:
             click.echo(f"[dry-run] Would create collection '{name}'" + (f" under '{parent}'" if parent else ""))
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = f"collection_create:{name}"
@@ -96,7 +68,7 @@ def collection_create(
                 click.echo(f"Collection created: {cached.get('data', {}).get('key', '?')} (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="collection")
     try:
         key = writer.create_collection(name, parent_key=parent)
     except ZoteroWriteError as e:
@@ -132,19 +104,6 @@ def collection_move(
         else:
             click.echo(f"[dry-run] Would move {item_key} to collection {collection_key}")
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = f"collection_move:{item_key}:{collection_key}"
@@ -157,7 +116,7 @@ def collection_move(
                 click.echo(f"Item {item_key} moved to collection {collection_key} (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="collection")
     try:
         writer.move_to_collection(item_key, collection_key)
     except ZoteroWriteError as e:
@@ -190,19 +149,6 @@ def collection_delete(ctx: click.Context, key: str, dry_run: bool, idempotency_k
         else:
             click.echo(f"[dry-run] Would delete collection '{key}'")
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = f"collection_delete:{key}"
@@ -215,7 +161,7 @@ def collection_delete(ctx: click.Context, key: str, dry_run: bool, idempotency_k
                 click.echo(f"Collection {key} deleted (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="collection")
     try:
         writer.delete_collection(key)
     except ZoteroWriteError as e:
@@ -269,21 +215,7 @@ def collection_reorganize(ctx: click.Context, plan_file: str, dry_run: bool) -> 
         click.echo(f"\n[dry-run] Total: {len(collections)} collections to create")
         return
 
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection reorganize",
-        )
-
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="collection reorganize")
     created_collections: dict[str, str] = {}  # name -> key mapping for parent lookups
 
     for coll in collections:
@@ -328,19 +260,6 @@ def collection_rename(ctx: click.Context, key: str, new_name: str, dry_run: bool
         else:
             click.echo(f"[dry-run] Would rename collection {key} to '{new_name}'")
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="collection",
-        )
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = f"collection_rename:{key}:{new_name}"
@@ -353,7 +272,7 @@ def collection_rename(ctx: click.Context, key: str, new_name: str, dry_run: bool
                 click.echo(f"Collection {key} renamed to '{new_name}' (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="collection")
     try:
         writer.rename_collection(key, new_name)
     except ZoteroWriteError as e:

--- a/src/zotero_cli_cc/commands/delete.py
+++ b/src/zotero_cli_cc/commands/delete.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import click
 
+from zotero_cli_cc.commands._helpers import build_writer
 from zotero_cli_cc.config import load_config
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
 from zotero_cli_cc.formatter import envelope_ok, envelope_partial
 
@@ -38,19 +38,6 @@ def delete_cmd(
             for key in keys:
                 click.echo(f"[dry-run] Would delete item '{key}' (move to trash)")
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="delete",
-        )
     no_interaction = ctx.obj.get("no_interaction", False)
     import sys
 
@@ -70,6 +57,9 @@ def delete_cmd(
             else:
                 click.echo("Cancelled.", err=True)
             return
+
+    writer = build_writer(ctx, cfg, json_out, context="delete")
+
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = "delete:" + ",".join(sorted(keys))
@@ -82,7 +72,6 @@ def delete_cmd(
                 click.echo(f"Deleted {len(keys)} item(s) (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     succeeded: list[dict] = []
     failed: list[dict] = []
     for key in keys:

--- a/src/zotero_cli_cc/commands/duplicates.py
+++ b/src/zotero_cli_cc/commands/duplicates.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.exit_codes import EXIT_CONFLICT
 from zotero_cli_cc.formatter import format_duplicates
 
@@ -30,11 +30,7 @@ def duplicates_cmd(ctx: click.Context, strategy: str, threshold: float, limit: i
       zot --json duplicates
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx, cfg) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", cfg.default_limit)
         groups = reader.find_duplicates(strategy=strategy, threshold=threshold, limit=limit)
         if not groups:
@@ -44,8 +40,6 @@ def duplicates_cmd(ctx: click.Context, strategy: str, threshold: float, limit: i
                 click.echo("No duplicates found.")
             return
         click.echo(format_duplicates(groups, output_json=ctx.obj.get("json", False)))
-    finally:
-        reader.close()
     # Signal "duplicates detected" via typed exit code so agents/scripts can
     # branch on `if zot duplicates ...; then ...; else act_on_duplicates; fi`.
     ctx.exit(EXIT_CONFLICT)

--- a/src/zotero_cli_cc/commands/enrich.py
+++ b/src/zotero_cli_cc/commands/enrich.py
@@ -7,14 +7,13 @@ Source-neutral: values come from `--set` flags or a user-maintained
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import click
 
-from zotero_cli_cc.config import AppConfig, get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.core.enrich import EnrichError, load_journal_map, merge_extra, metrics_for, parse_set_pairs
-from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
@@ -87,58 +86,37 @@ def enrich_cmd(
             return
 
     cfg = load_config(profile=ctx.obj.get("profile"))
-    db_path = get_data_dir(cfg) / "zotero.sqlite"
-    reader = ZoteroReader(
-        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
-    )
-
     writer: ZoteroWriter | None = None
     results: list[dict] = []
     updated = 0
-    for key in item_keys:
-        item = reader.get_item(key)
-        if item is None:
-            results.append({"key": key, "error": "item not found", "code": "not_found"})
-            continue
-        metrics = metrics_for(item, journal_map, pairs)
-        if not metrics:
-            results.append({"key": key, "warning": "no metrics (journal not in map and no --set given)"})
-            continue
-        if dry_run:
-            preview = merge_extra(item.extra.get("extra", ""), metrics)
-            results.append({"key": key, "metrics": metrics, "status": "dry-run", "extra_preview": preview})
-            continue
-        if writer is None:
-            writer = _build_writer(ctx, cfg, json_out)
-        try:
-            writer.update_extra_metrics(key, metrics)
-            results.append({"key": key, "metrics": metrics, "status": "updated"})
-            updated += 1
-        except ZoteroWriteError as e:
-            if e.code in _ABORT_CODES:
-                emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, context="enrich")
-            results.append({"key": key, "status": "error", "error": str(e), "code": e.code})
+    with open_reader(ctx, cfg) as reader:
+        for key in item_keys:
+            item = reader.get_item(key)
+            if item is None:
+                results.append({"key": key, "error": "item not found", "code": "not_found"})
+                continue
+            metrics = metrics_for(item, journal_map, pairs)
+            if not metrics:
+                results.append({"key": key, "warning": "no metrics (journal not in map and no --set given)"})
+                continue
+            if dry_run:
+                preview = merge_extra(item.extra.get("extra", ""), metrics)
+                results.append({"key": key, "metrics": metrics, "status": "dry-run", "extra_preview": preview})
+                continue
+            if writer is None:
+                writer = build_writer(ctx, cfg, json_out, context="enrich")
+            try:
+                writer.update_extra_metrics(key, metrics)
+                results.append({"key": key, "metrics": metrics, "status": "updated"})
+                updated += 1
+            except ZoteroWriteError as e:
+                if e.code in _ABORT_CODES:
+                    emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, context="enrich")
+                results.append({"key": key, "status": "error", "error": str(e), "code": e.code})
 
     env = _emit(json_out, results, updated=updated, dry_run=dry_run)
     if idempotency_key:
         store_cached(cache_scope, idempotency_key, env)
-
-
-def _build_writer(ctx: click.Context, cfg: AppConfig, json_out: bool) -> ZoteroWriter:
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="enrich",
-        )
-    return ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
 
 
 def _emit(json_out: bool, results: list[dict], *, updated: int, dry_run: bool) -> dict:

--- a/src/zotero_cli_cc/commands/export.py
+++ b/src/zotero_cli_cc/commands/export.py
@@ -4,8 +4,7 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 
@@ -26,13 +25,8 @@ def export_cmd(ctx: click.Context, key: str, fmt: str) -> None:
       zot export ABC123 --format ris       RIS
       zot export ABC123 --format json      Raw JSON metadata
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
     json_out = ctx.obj.get("json", False)
-    try:
+    with open_reader(ctx) as reader:
         if fmt == "json":
             item = reader.get_item(key)
             if item is None:
@@ -64,5 +58,3 @@ def export_cmd(ctx: click.Context, key: str, fmt: str) -> None:
                 click.echo(json.dumps(envelope_ok({"format": fmt, "data": result}), indent=2, ensure_ascii=False))
             else:
                 click.echo(result)
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/list_cmd.py
+++ b/src/zotero_cli_cc/commands/list_cmd.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_items, stream_items
 
@@ -53,11 +53,7 @@ def list_cmd(
       zot list --collection "Machine Learning" --limit 10  # list within a collection
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx, cfg) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", cfg.default_limit)
         try:
             result = reader.search(
@@ -70,5 +66,3 @@ def list_cmd(
             click.echo(stream_items(result.items, detail=detail))
             return
         click.echo(format_items(result.items, output_json=ctx.obj.get("json", False), detail=detail))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/note.py
+++ b/src/zotero_cli_cc/commands/note.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok, format_notes
 
@@ -46,20 +45,6 @@ def note_cmd(
                 click.echo(f"[dry-run] Would add note to '{key}': {content[:80]}...")
             return
 
-        library_id: str | int | None = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-        api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-        library_type = ctx.obj.get("library_type", "user")
-        if library_type == "group" and ctx.obj.get("group_id"):
-            library_id = ctx.obj["group_id"]
-        if not library_id or not api_key:
-            emit_error(
-                "auth_missing",
-                "Write credentials not configured",
-                output_json=json_out,
-                hint="Run 'zot config init' to set up API credentials",
-                context="note",
-            )
-
         from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
         cache_scope = f"note:{key}"
@@ -72,7 +57,7 @@ def note_cmd(
                     click.echo(f"Note added: {cached.get('data', {}).get('note_key', '?')} (cached).")
                 return
 
-        writer = ZoteroWriter(library_id=str(library_id), api_key=api_key, library_type=library_type)
+        writer = build_writer(ctx, cfg, json_out, context="note")
         try:
             note_key = writer.add_note(key, content)
         except ZoteroWriteError as e:
@@ -97,11 +82,7 @@ def note_cmd(
             click.echo(f"Note added: {note_key}")
             click.echo(SYNC_REMINDER, err=True)
     else:
-        data_dir = get_data_dir(cfg)
-        db_path = data_dir / "zotero.sqlite"
-        library_id = resolve_library_id(db_path, ctx.obj)
-        reader = ZoteroReader(db_path, library_id=library_id)
-        try:
+        with open_reader(ctx, cfg) as reader:
             notes = reader.get_notes(key)
             if not notes:
                 emit_error(
@@ -112,5 +93,3 @@ def note_cmd(
                     context="note",
                 )
             click.echo(format_notes(notes, output_json=json_out))
-        finally:
-            reader.close()

--- a/src/zotero_cli_cc/commands/open_cmd.py
+++ b/src/zotero_cli_cc/commands/open_cmd.py
@@ -5,8 +5,7 @@ import sys
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 
 
@@ -32,13 +31,8 @@ def open_cmd(ctx: click.Context, key: str, open_url: bool) -> None:
       zot open ABC123          Open PDF in default viewer
       zot open ABC123 --url    Open DOI/URL in browser
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
     json_out = ctx.obj.get("json", False)
-    try:
+    with open_reader(ctx) as reader:
         item = reader.get_item(key)
         if item is None:
             emit_error(
@@ -84,5 +78,3 @@ def open_cmd(ctx: click.Context, key: str, open_url: bool) -> None:
             )
         click.echo(f"Opening {pdf_path}")
         _open_path(str(pdf_path))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/orphans.py
+++ b/src/zotero_cli_cc/commands/orphans.py
@@ -12,14 +12,13 @@ from __future__ import annotations
 
 import dataclasses
 import json
-import os
 import sys
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import EXIT_RUNTIME, emit_error
 from zotero_cli_cc.formatter import envelope_ok, envelope_partial
 from zotero_cli_cc.models import OrphanAttachment
@@ -31,12 +30,8 @@ def orphans_group() -> None:
 
 
 def _scan(ctx: click.Context) -> list[OrphanAttachment]:
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    db_path = get_data_dir(cfg) / "zotero.sqlite"
-    reader = ZoteroReader(
-        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
-    )
-    return reader.find_orphan_attachments()
+    with open_reader(ctx) as reader:
+        return reader.find_orphan_attachments()
 
 
 def _counts(orphans: list[OrphanAttachment]) -> dict[str, int]:
@@ -145,19 +140,7 @@ def orphans_clean(
         return
 
     cfg = load_config(profile=ctx.obj.get("profile"))
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="orphans clean",
-        )
+    writer = build_writer(ctx, cfg, json_out, context="orphans clean")
 
     no_interaction = ctx.obj.get("no_interaction", False)
     if not yes and not no_interaction:
@@ -188,7 +171,6 @@ def orphans_clean(
                 click.echo(f"Deleted {len(keys)} orphan(s) (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     succeeded: list[dict] = []
     failed: list[dict] = []
     for key in keys:

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -5,9 +5,8 @@ import re
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
-from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_pdf_annotations, format_pdf_text
 
@@ -105,7 +104,6 @@ def pdf_cmd(
       zot pdf ABC123 --tables       Extract tables (needs pdfplumber)
       zot --json pdf ABC123         JSON output with metadata
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
     page_range = None
     if extractor is None:
@@ -128,11 +126,7 @@ def pdf_cmd(
                 hint="Use format: '1-5' or '3' for a single page",
                 context="pdf",
             )
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
-    try:
+    with open_reader(ctx) as reader:
         att = reader.get_pdf_attachment(key)
         if att is None:
             emit_error(
@@ -282,5 +276,3 @@ def pdf_cmd(
                 click.echo(format_pdf_text(key, pages, outline=outline_json, output_json=json_out))
             return
         click.echo(format_pdf_text(key, pages, text=text, output_json=json_out))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/read.py
+++ b/src/zotero_cli_cc/commands/read.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_item_detail
 
@@ -20,13 +19,8 @@ def read_cmd(ctx: click.Context, key: str) -> None:
       zot --json read ABC123
       zot --detail full read ABC123
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
     json_out = ctx.obj.get("json", False)
-    try:
+    with open_reader(ctx) as reader:
         item = reader.get_item(key)
         if item is None:
             emit_error(
@@ -39,5 +33,3 @@ def read_cmd(ctx: click.Context, key: str) -> None:
         notes = reader.get_notes(key)
         detail = ctx.obj.get("detail", "standard")
         click.echo(format_item_detail(item, notes, output_json=json_out, detail=detail))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/recent.py
+++ b/src/zotero_cli_cc/commands/recent.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta, timezone
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.formatter import format_items, stream_items
 
 
@@ -26,11 +26,7 @@ def recent_cmd(ctx: click.Context, days: int, modified: bool, limit: int | None,
       zot --json recent --days 14   JSON output
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx, cfg) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", cfg.default_limit)
         sort_field = "dateModified" if modified else "dateAdded"
         since = datetime.now(timezone.utc) - timedelta(days=days)
@@ -49,5 +45,3 @@ def recent_cmd(ctx: click.Context, days: int, modified: bool, limit: int | None,
                 click.echo(f"No items {'modified' if modified else 'added'} in the last {days} day(s).", err=True)
             return
         click.echo(format_items(items, output_json=json_out, detail=detail))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/relate.py
+++ b/src/zotero_cli_cc/commands/relate.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.formatter import format_items
 
 
@@ -19,13 +18,8 @@ def relate_cmd(ctx: click.Context, key: str, limit: int | None) -> None:
       zot relate ABC123
       zot --json relate ABC123
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", 20)
         items = reader.get_related_items(key, limit=limit)
         if not items:
@@ -39,5 +33,3 @@ def relate_cmd(ctx: click.Context, key: str, limit: int | None) -> None:
             return
         detail = ctx.obj.get("detail", "standard")
         click.echo(format_items(items, output_json=json_out, detail=detail))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/rename.py
+++ b/src/zotero_cli_cc/commands/rename.py
@@ -6,9 +6,8 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, resolve_library_id
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.core.local_bridge import LocalBridgeError, ping, rename_attachment
-from zotero_cli_cc.core.reader import ZoteroReader
 from zotero_cli_cc.core.rename import RenameError, build_plan
 from zotero_cli_cc.core.writer import SYNC_REMINDER
 from zotero_cli_cc.exit_codes import emit_error
@@ -131,59 +130,54 @@ def rename_cmd(
         except LocalBridgeError as e:
             emit_error(e.code, str(e), output_json=json_out, retryable=e.retryable, hint=_BRIDGE_HINT, context="rename")
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    db_path = get_data_dir(cfg) / "zotero.sqlite"
-    reader = ZoteroReader(
-        db_path, library_id=resolve_library_id(db_path, ctx.obj), prefs_js_path=get_prefs_js_path(cfg)
-    )
-
     results: list[dict] = []
     renamed = 0
-    for key in item_keys:
-        item = reader.get_item(key)
-        if item is None:
-            results.append({"key": key, "error": "item not found", "code": "not_found"})
-            continue
-        try:
-            plan = build_plan(item, reader.get_attachments(key), template=template, include_supp=not main_only)
-        except RenameError as e:
-            results.append({"key": key, "error": str(e), "code": e.code})
-            continue
-        if not plan:
-            results.append({"key": key, "warning": "no PDF attachments found"})
-            continue
-        renames: list[dict] = []
-        for entry in plan:
-            row = {
-                "attachment_key": entry.attachment_key,
-                "old_name": entry.old_name,
-                "new_name": entry.new_name,
-                "role": entry.role,
-            }
-            if entry.skip:
-                row["status"] = "unchanged"
-            elif dry_run:
-                row["status"] = "dry-run"
-            else:
-                try:
-                    rename_attachment(entry.attachment_key, entry.new_name, library_id=library_id, force=force)
-                    row["status"] = "renamed"
-                    renamed += 1
-                except LocalBridgeError as e:
-                    if e.code in _ABORT_CODES:
-                        emit_error(
-                            e.code,
-                            str(e),
-                            output_json=json_out,
-                            retryable=e.retryable,
-                            hint=_BRIDGE_HINT,
-                            context="rename",
-                        )
-                    row["status"] = "error"
-                    row["error"] = str(e)
-                    row["code"] = e.code
-            renames.append(row)
-        results.append({"key": key, "renames": renames})
+    with open_reader(ctx) as reader:
+        for key in item_keys:
+            item = reader.get_item(key)
+            if item is None:
+                results.append({"key": key, "error": "item not found", "code": "not_found"})
+                continue
+            try:
+                plan = build_plan(item, reader.get_attachments(key), template=template, include_supp=not main_only)
+            except RenameError as e:
+                results.append({"key": key, "error": str(e), "code": e.code})
+                continue
+            if not plan:
+                results.append({"key": key, "warning": "no PDF attachments found"})
+                continue
+            renames: list[dict] = []
+            for entry in plan:
+                row = {
+                    "attachment_key": entry.attachment_key,
+                    "old_name": entry.old_name,
+                    "new_name": entry.new_name,
+                    "role": entry.role,
+                }
+                if entry.skip:
+                    row["status"] = "unchanged"
+                elif dry_run:
+                    row["status"] = "dry-run"
+                else:
+                    try:
+                        rename_attachment(entry.attachment_key, entry.new_name, library_id=library_id, force=force)
+                        row["status"] = "renamed"
+                        renamed += 1
+                    except LocalBridgeError as e:
+                        if e.code in _ABORT_CODES:
+                            emit_error(
+                                e.code,
+                                str(e),
+                                output_json=json_out,
+                                retryable=e.retryable,
+                                hint=_BRIDGE_HINT,
+                                context="rename",
+                            )
+                        row["status"] = "error"
+                        row["error"] = str(e)
+                        row["code"] = e.code
+                renames.append(row)
+            results.append({"key": key, "renames": renames})
 
     env = _emit(ctx, json_out, results, renamed=renamed, dry_run=dry_run)
     if idempotency_key:

--- a/src/zotero_cli_cc/commands/search.py
+++ b/src/zotero_cli_cc/commands/search.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_items, stream_items
 
@@ -55,11 +55,7 @@ def search_cmd(
       zot search "BERT" --collection "NLP"       # search within "NLP" collection
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx, cfg) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", cfg.default_limit)
         json_out = ctx.obj.get("json", False)
         try:
@@ -79,5 +75,3 @@ def search_cmd(
                 click.echo("No results found.", err=True)
             return
         click.echo(format_items(result.items, output_json=json_out, detail=detail))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/stats.py
+++ b/src/zotero_cli_cc/commands/stats.py
@@ -4,8 +4,7 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.formatter import envelope_ok
 
 
@@ -19,13 +18,8 @@ def stats_cmd(ctx: click.Context) -> None:
       zot stats
       zot --json stats
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
     json_out = ctx.obj.get("json", False)
-    try:
+    with open_reader(ctx) as reader:
         stats = reader.get_stats()
         if json_out:
             click.echo(json.dumps(envelope_ok(stats), indent=2, ensure_ascii=False))
@@ -45,5 +39,3 @@ def stats_cmd(ctx: click.Context) -> None:
             click.echo(f"Top tags ({len(stats['top_tags'])}):")
             for name, cnt in stats["top_tags"].items():
                 click.echo(f"  {name}: {cnt}")
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/summarize.py
+++ b/src/zotero_cli_cc/commands/summarize.py
@@ -4,8 +4,7 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 
@@ -22,13 +21,8 @@ def summarize_cmd(ctx: click.Context, key: str) -> None:
       zot --json summarize ABC123
       zot --detail minimal summarize ABC123
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
     json_out = ctx.obj.get("json", False)
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         item = reader.get_item(key)
         if item is None:
             emit_error(
@@ -86,5 +80,3 @@ def summarize_cmd(ctx: click.Context, key: str) -> None:
                     click.echo(f"\nNotes ({len(notes)}):")
                     for n in notes:
                         click.echo(f"  {n.content[:500]}")
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/summarize_all.py
+++ b/src/zotero_cli_cc/commands/summarize_all.py
@@ -6,8 +6,7 @@ import json
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.formatter import emit_progress, envelope_ok
 
 
@@ -24,13 +23,8 @@ def summarize_all_cmd(ctx: click.Context, offset: int, limit: int | None) -> Non
       zot summarize-all --limit 100       First 100 items
       zot summarize-all --offset 100      Skip first 100 (pagination)
     """
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
     limit = limit if limit is not None else ctx.obj.get("limit", 10000)
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         emit_progress("start", phase="summarize_all", offset=offset, limit=limit)
         result = reader.search("", limit=limit, offset=offset)
         total = len(result.items)
@@ -54,5 +48,3 @@ def summarize_all_cmd(ctx: click.Context, offset: int, limit: int | None) -> Non
             click.echo(json.dumps(envelope_ok(items, meta={"count": total}), indent=2, ensure_ascii=False))
         else:
             click.echo(json.dumps(items, indent=2, ensure_ascii=False))
-    finally:
-        reader.close()

--- a/src/zotero_cli_cc/commands/tag.py
+++ b/src/zotero_cli_cc/commands/tag.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 
@@ -45,19 +44,6 @@ def tag_cmd(
         return
 
     if add_tag or remove_tag:
-        library_id: str | int | None = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-        api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-        library_type = ctx.obj.get("library_type", "user")
-        if library_type == "group" and ctx.obj.get("group_id"):
-            library_id = ctx.obj["group_id"]
-        if not library_id or not api_key:
-            emit_error(
-                "auth_missing",
-                "Write credentials not configured",
-                output_json=json_out,
-                hint="Run 'zot config init' to set up API credentials",
-                context="tag",
-            )
         from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
         op = "add" if add_tag else "remove"
@@ -73,7 +59,7 @@ def tag_cmd(
                     click.echo(f"Tag '{tag_val}' {op}ed on {count} item(s) (cached).")
                 return
 
-        writer = ZoteroWriter(library_id=str(library_id), api_key=api_key, library_type=library_type)
+        writer = build_writer(ctx, cfg, json_out, context="tag")
         for key in keys:
             try:
                 if add_tag:
@@ -93,11 +79,7 @@ def tag_cmd(
         click.echo(SYNC_REMINDER)
     else:
         # View mode — show tags for each key
-        data_dir = get_data_dir(cfg)
-        db_path = data_dir / "zotero.sqlite"
-        library_id = resolve_library_id(db_path, ctx.obj)
-        reader = ZoteroReader(db_path, library_id=library_id)
-        try:
+        with open_reader(ctx, cfg) as reader:
             for key in keys:
                 item = reader.get_item(key)
                 if item is None:
@@ -107,5 +89,3 @@ def tag_cmd(
                     click.echo(json.dumps(envelope_ok({"key": key, "tags": item.tags}), indent=2, ensure_ascii=False))
                 else:
                     click.echo(f"Tags for {key}: {', '.join(item.tags) if item.tags else '(none)'}")
-        finally:
-            reader.close()

--- a/src/zotero_cli_cc/commands/trash.py
+++ b/src/zotero_cli_cc/commands/trash.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import os
-
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.commands._helpers import build_writer, open_reader
+from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import format_items
 
@@ -30,11 +28,7 @@ def trash_list_cmd(ctx: click.Context, limit: int | None) -> None:
       zot --json trash list
     """
     cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx, cfg) as reader:
         limit = limit if limit is not None else ctx.obj.get("limit", cfg.default_limit)
         items = reader.get_trash_items(limit=limit)
         if not items:
@@ -45,8 +39,6 @@ def trash_list_cmd(ctx: click.Context, limit: int | None) -> None:
             return
         detail = ctx.obj.get("detail", "standard")
         click.echo(format_items(items, output_json=ctx.obj.get("json", False), detail=detail))
-    finally:
-        reader.close()
 
 
 @trash_group.command("restore")
@@ -77,20 +69,6 @@ def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool, 
             for k in keys:
                 click.echo(f"[dry-run] Would restore '{k}'")
         return
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="trash restore",
-        )
-
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
 
     cache_scope = f"trash_restore:{':'.join(sorted(keys))}"
@@ -104,7 +82,7 @@ def trash_restore_cmd(ctx: click.Context, keys: tuple[str, ...], dry_run: bool, 
                 click.echo(f"Restored {count} item(s) (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
+    writer = build_writer(ctx, cfg, json_out, context="trash restore")
     for key in keys:
         try:
             writer.restore_from_trash(key)

--- a/src/zotero_cli_cc/commands/update.py
+++ b/src/zotero_cli_cc/commands/update.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import click
 
+from zotero_cli_cc.commands._helpers import build_writer
 from zotero_cli_cc.config import load_config
-from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
+from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok
 
@@ -75,19 +75,7 @@ def update_cmd(
             click.echo(f"[dry-run] Would update '{key}' with {len(fields)} field(s): {list(fields.keys())}")
         return
 
-    library_id = os.environ.get("ZOT_LIBRARY_ID", cfg.library_id)
-    api_key = os.environ.get("ZOT_API_KEY", cfg.api_key)
-    library_type = ctx.obj.get("library_type", "user")
-    if library_type == "group" and ctx.obj.get("group_id"):
-        library_id = ctx.obj["group_id"]
-    if not library_id or not api_key:
-        emit_error(
-            "auth_missing",
-            "Write credentials not configured",
-            output_json=json_out,
-            hint="Run 'zot config init' to set up API credentials",
-            context="update",
-        )
+    writer = build_writer(ctx, cfg, json_out, context="update")
 
     # Idempotency cache check
     from zotero_cli_cc.core.idempotency import get_cached, store_cached
@@ -99,7 +87,6 @@ def update_cmd(
             click.echo(json.dumps(cached, indent=2, ensure_ascii=False) if json_out else f"Updated '{key}' (cached).")
             return
 
-    writer = ZoteroWriter(library_id=library_id, api_key=api_key, library_type=library_type)
     try:
         writer.update_item(key, fields)
     except ZoteroWriteError as e:

--- a/src/zotero_cli_cc/commands/update_status.py
+++ b/src/zotero_cli_cc/commands/update_status.py
@@ -7,8 +7,8 @@ import os
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, load_config, resolve_library_id
-from zotero_cli_cc.core.reader import ZoteroReader
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_config
 from zotero_cli_cc.core.semantic_scholar import PreprintInfo, SemanticScholarClient, extract_preprint_info
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError, ZoteroWriter
 from zotero_cli_cc.exit_codes import emit_error
@@ -75,12 +75,7 @@ def update_status_cmd(
             click.echo(rate_msg, err=True)
 
     # Read items from local DB
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-
-    try:
+    with open_reader(ctx, cfg) as reader:
         if key:
             item = reader.get_item(key)
             if not item:
@@ -91,8 +86,6 @@ def update_status_cmd(
                 items = reader.get_arxiv_preprints(collection=collection, limit=limit)
             except ValueError as e:
                 emit_error("runtime_error", str(e), output_json=json_out, context="update_status")
-    finally:
-        reader.close()
 
     if not items:
         if json_out:

--- a/src/zotero_cli_cc/commands/workspace.py
+++ b/src/zotero_cli_cc/commands/workspace.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import click
 
-from zotero_cli_cc.config import get_data_dir, get_prefs_js_path, load_config, load_embedding_config, resolve_library_id
+from zotero_cli_cc.commands._helpers import open_reader
+from zotero_cli_cc.config import load_embedding_config
 from zotero_cli_cc.core.rag import (
     bm25_score_chunks,
     build_metadata_chunk,
@@ -116,12 +117,7 @@ def workspace_add(ctx: click.Context, name: str, keys: tuple[str, ...]) -> None:
             context="workspace add",
         )
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         ws = load_workspace(name)
         added = 0
         for key in keys:
@@ -135,8 +131,6 @@ def workspace_add(ctx: click.Context, name: str, keys: tuple[str, ...]) -> None:
                 click.echo(f"Skipped: '{key}' already in workspace")
         save_workspace(ws)
         click.echo(f"Added {added} item(s) to workspace '{name}'")
-    finally:
-        reader.close()
 
 
 @workspace_group.command("remove")
@@ -198,12 +192,7 @@ def workspace_show(ctx: click.Context, name: str) -> None:
         click.echo(f"Workspace '{name}' is empty. Use 'zot workspace add {name} KEY' to add items.")
         return
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         items = []
         missing = []
         for ws_item in ws.items[:limit]:
@@ -216,8 +205,6 @@ def workspace_show(ctx: click.Context, name: str) -> None:
             click.echo(format_items(items, output_json=json_out, detail=detail))
         for key in missing:
             click.echo(f"Warning: item '{key}' not found in Zotero library (may have been deleted)")
-    finally:
-        reader.close()
 
 
 @workspace_group.command("export")
@@ -247,12 +234,7 @@ def workspace_export(ctx: click.Context, name: str, fmt: str) -> None:
         click.echo(f"Workspace '{name}' is empty.")
         return
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         items = []
         for ws_item in ws.items:
             item = reader.get_item(ws_item.key)
@@ -292,8 +274,6 @@ def workspace_export(ctx: click.Context, name: str, fmt: str) -> None:
                     lines.append(f"**Abstract:** {item.abstract}")
                 lines.append("")
             click.echo("\n".join(lines))
-    finally:
-        reader.close()
 
 
 @workspace_group.command("import")
@@ -325,12 +305,7 @@ def workspace_import_cmd(
             context="workspace import",
         )
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         ws = load_workspace(name)
         items_to_import: list[Item] = []
 
@@ -379,8 +354,6 @@ def workspace_import_cmd(
             f"Imported {added} item(s) into workspace '{name}'"
             + (f" ({skipped} skipped, already present)" if skipped else "")
         )
-    finally:
-        reader.close()
 
 
 @workspace_group.command("search")
@@ -407,12 +380,7 @@ def workspace_search(ctx: click.Context, query: str, ws_name: str) -> None:
         click.echo(f"Workspace '{ws_name}' is empty.")
         return
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id)
-    try:
+    with open_reader(ctx) as reader:
         query_lower = query.lower()
         matches = []
         for ws_item in ws.items:
@@ -439,8 +407,6 @@ def workspace_search(ctx: click.Context, query: str, ws_name: str) -> None:
             return
 
         click.echo(format_items(matches[:limit], output_json=json_out, detail=detail))
-    finally:
-        reader.close()
 
 
 def _resolve_collection_key(reader: ZoteroReader, name_or_key: str) -> str | None:
@@ -496,11 +462,8 @@ def workspace_index(
         click.echo(f"Workspace '{name}' is empty. Add items first with: zot workspace add {name} KEY")
         return
 
-    cfg = load_config(profile=ctx.obj.get("profile"))
-    data_dir = get_data_dir(cfg)
-    db_path = data_dir / "zotero.sqlite"
-    library_id = resolve_library_id(db_path, ctx.obj)
-    reader = ZoteroReader(db_path, library_id=library_id, prefs_js_path=get_prefs_js_path(cfg))
+    # Reader and idx share one finally-cleanup below, so no `with` block here.
+    reader = open_reader(ctx)
 
     idx_path = workspaces_dir() / f"{name}.idx.sqlite"
     idx = RagIndex(idx_path)

--- a/tests/test_agent_p1.py
+++ b/tests/test_agent_p1.py
@@ -109,7 +109,7 @@ class TestIdempotency:
     def setup_method(self, method):
         idempotency.clear()
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_idempotency_returns_cached_envelope(self, mock_writer_cls):
         mock_writer_cls.return_value.update_item.return_value = None
         env = {"ZOT_LIBRARY_ID": "abc", "ZOT_API_KEY": "xyz"}
@@ -124,7 +124,7 @@ class TestIdempotency:
         assert env_second["meta"]["request_id"] == env_first["meta"]["request_id"]
         assert env_second["data"]["key"] == "ABC"
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_without_idempotency_key_always_calls_writer(self, mock_writer_cls):
         mock_writer_cls.return_value.update_item.return_value = None
         env = {"ZOT_LIBRARY_ID": "abc", "ZOT_API_KEY": "xyz"}
@@ -135,7 +135,7 @@ class TestIdempotency:
 
 
 class TestNextHints:
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_success_has_next_hint(self, mock_writer_cls):
         idempotency.clear()
         mock_writer_cls.return_value.update_item.return_value = None
@@ -172,7 +172,7 @@ class TestHelpTiers:
 
 
 class TestRetryableFlag:
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_network_error_flagged_retryable(self, mock_writer_cls):
         from zotero_cli_cc.core.writer import ZoteroWriteError
 
@@ -186,7 +186,7 @@ class TestRetryableFlag:
         assert env_out["error"]["code"] == "network_error"
         assert env_out["error"]["retryable"] is True
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_not_found_flagged_not_retryable(self, mock_writer_cls):
         from zotero_cli_cc.core.writer import ZoteroWriteError
 

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -262,7 +262,7 @@ class TestAttachWebResultCLI:
         monkeypatch.setenv("ZOT_API_KEY", "abc")
         writer = MagicMock()
         writer.upload_attachment.return_value = (key, result)
-        monkeypatch.setattr("zotero_cli_cc.commands.attach.ZoteroWriter", lambda **k: writer)
+        monkeypatch.setattr("zotero_cli_cc.commands._helpers.ZoteroWriter", lambda **k: writer)
 
     def test_cloud_result_created(self, tmp_path, monkeypatch):
         pdf = self._pdf(tmp_path)

--- a/tests/test_cli_note.py
+++ b/tests/test_cli_note.py
@@ -29,7 +29,7 @@ def test_note_read_json(test_db_path):
     assert len(data) >= 1
 
 
-@patch("zotero_cli_cc.commands.note.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_note_add(mock_writer_cls, test_db_path):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer

--- a/tests/test_cli_p1.py
+++ b/tests/test_cli_p1.py
@@ -8,7 +8,7 @@ WRITE_ENV = {"ZOT_LIBRARY_ID": "123", "ZOT_API_KEY": "abc"}
 
 
 @patch("zotero_cli_cc.commands.add.resolve_doi")
-@patch("zotero_cli_cc.commands.add.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_add_by_doi(mock_writer_cls, mock_resolve):
     mock_resolve.return_value = {
         "title": "Resolved Title",
@@ -32,7 +32,7 @@ def test_add_by_doi(mock_writer_cls, mock_resolve):
 
 
 @patch("zotero_cli_cc.commands.add.resolve_doi")
-@patch("zotero_cli_cc.commands.add.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_add_by_doi_no_resolve_skips_lookup(mock_writer_cls, mock_resolve):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -46,7 +46,7 @@ def test_add_by_doi_no_resolve_skips_lookup(mock_writer_cls, mock_resolve):
 
 
 @patch("zotero_cli_cc.commands.add.resolve_doi")
-@patch("zotero_cli_cc.commands.add.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_add_by_doi_resolver_404_falls_back(mock_writer_cls, mock_resolve):
     mock_resolve.return_value = None  # Crossref miss
     mock_writer = MagicMock()
@@ -63,7 +63,7 @@ def test_add_by_doi_resolver_404_falls_back(mock_writer_cls, mock_resolve):
 
 
 @patch("zotero_cli_cc.commands.add.resolve_doi")
-@patch("zotero_cli_cc.commands.add.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_add_by_doi_resolver_network_error_falls_back(mock_writer_cls, mock_resolve):
     from zotero_cli_cc.core.metadata_resolver import MetadataResolveError
 
@@ -78,7 +78,7 @@ def test_add_by_doi_resolver_network_error_falls_back(mock_writer_cls, mock_reso
     assert mock_writer.add_item.call_args.kwargs["extra_fields"] is None
 
 
-@patch("zotero_cli_cc.commands.delete.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_delete_with_confirm(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -89,7 +89,7 @@ def test_delete_with_confirm(mock_writer_cls):
     mock_writer.delete_item.assert_called_once_with("K1")
 
 
-@patch("zotero_cli_cc.commands.delete.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_delete_without_confirm(mock_writer_cls):
     # Without --yes on non-tty stdin (CliRunner uses StringIO), `delete` refuses
     # the operation and exits EXIT_VALIDATION (3) — guards against unattended
@@ -100,7 +100,7 @@ def test_delete_without_confirm(mock_writer_cls):
     mock_writer_cls.return_value.delete_item.assert_not_called()
 
 
-@patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_tag_add(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -111,7 +111,7 @@ def test_tag_add(mock_writer_cls):
     mock_writer.add_tags.assert_called_once_with("K1", ["newtag"])
 
 
-@patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_tag_remove(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -122,7 +122,7 @@ def test_tag_remove(mock_writer_cls):
     mock_writer.remove_tags.assert_called_once_with("K1", ["oldtag"])
 
 
-@patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_tag_dry_run(mock_writer_cls):
     runner = CliRunner()
     result = runner.invoke(main, ["tag", "K1", "--add", "t", "--dry-run"], env=WRITE_ENV)
@@ -153,7 +153,7 @@ def test_collection_list(test_db_path):
     assert "Machine Learning" in result.output
 
 
-@patch("zotero_cli_cc.commands.collection.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_collection_create(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -164,7 +164,7 @@ def test_collection_create(mock_writer_cls):
     assert result.exit_code == 0
 
 
-@patch("zotero_cli_cc.commands.collection.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_collection_move(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
@@ -175,7 +175,7 @@ def test_collection_move(mock_writer_cls):
     mock_writer.move_to_collection.assert_called_once_with("ITEM1", "COLKEY")
 
 
-@patch("zotero_cli_cc.commands.collection.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_collection_delete_dry_run(mock_writer_cls):
     runner = CliRunner()
     result = runner.invoke(main, ["collection", "delete", "COLKEY", "--dry-run"], env=WRITE_ENV)
@@ -184,7 +184,7 @@ def test_collection_delete_dry_run(mock_writer_cls):
     mock_writer_cls.assert_not_called()
 
 
-@patch("zotero_cli_cc.commands.collection.ZoteroWriter")
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
 def test_collection_rename(mock_writer_cls):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -172,7 +172,7 @@ class TestEnrichCLI:
                 calls[key] = metrics
                 return "merged"
 
-        monkeypatch.setattr("zotero_cli_cc.commands.enrich._build_writer", lambda *a, **k: FakeWriter())
+        monkeypatch.setattr("zotero_cli_cc.commands.enrich.build_writer", lambda *a, **k: FakeWriter())
         result = _invoke(["enrich", "ATTN001", "--set", "JCR=Q1"], test_db_path, json_out=True)
         assert result.exit_code == 0
         assert calls == {"ATTN001": {"JCR": "Q1"}}

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -186,7 +186,7 @@ class TestPdfExtractionError:
 
 
 class TestBatchDelete:
-    @patch("zotero_cli_cc.commands.delete.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_delete_multiple_keys(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -211,7 +211,7 @@ class TestBatchDelete:
         assert "K1" in result.output
         assert "K2" in result.output
 
-    @patch("zotero_cli_cc.commands.delete.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_delete_partial_failure(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -232,7 +232,7 @@ class TestBatchDelete:
 
 
 class TestBatchTag:
-    @patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_tag_add_multiple_keys(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -249,7 +249,7 @@ class TestBatchTag:
         assert "K2" in result.output
         assert "K3" in result.output
 
-    @patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_tag_remove_multiple_keys(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -317,7 +317,7 @@ class TestTimeout:
 
 
 class TestWriteErrorInCommands:
-    @patch("zotero_cli_cc.commands.add.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_add_write_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -328,7 +328,7 @@ class TestWriteErrorInCommands:
         assert result.exit_code != 0
         assert "Bad request" in result.output
 
-    @patch("zotero_cli_cc.commands.delete.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_delete_write_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -339,7 +339,7 @@ class TestWriteErrorInCommands:
         assert result.exit_code != 0
         assert "not found" in result.output
 
-    @patch("zotero_cli_cc.commands.tag.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_tag_add_write_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -350,7 +350,7 @@ class TestWriteErrorInCommands:
         assert result.exit_code != 0
         assert "not found" in result.output
 
-    @patch("zotero_cli_cc.commands.note.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_note_write_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -361,7 +361,7 @@ class TestWriteErrorInCommands:
         assert result.exit_code != 0
         assert "timeout" in result.output
 
-    @patch("zotero_cli_cc.commands.collection.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_collection_create_write_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer

--- a/tests/test_orphans.py
+++ b/tests/test_orphans.py
@@ -148,7 +148,7 @@ class TestOrphansCleanCLI:
             def delete_item(self, key):
                 deleted.append(key)
 
-        monkeypatch.setattr("zotero_cli_cc.commands.orphans.ZoteroWriter", FakeWriter)
+        monkeypatch.setattr("zotero_cli_cc.commands._helpers.ZoteroWriter", FakeWriter)
         env = {"ZOT_DATA_DIR": str(tmp_path), "ZOT_LIBRARY_ID": "123", "ZOT_API_KEY": "abc"}
         result = CliRunner().invoke(main, ["--json", "orphans", "clean", "--yes"], env=env)
         assert result.exit_code == 0

--- a/tests/test_tier1_update.py
+++ b/tests/test_tier1_update.py
@@ -28,7 +28,7 @@ def _invoke(args: list[str], json_output: bool = False):
 
 
 class TestUpdateCommand:
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_title(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -37,7 +37,7 @@ class TestUpdateCommand:
         mock_writer.update_item.assert_called_once_with("ATTN001", {"title": "New Title"})
         assert "Updated" in result.output
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_date(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -45,7 +45,7 @@ class TestUpdateCommand:
         assert result.exit_code == 0
         mock_writer.update_item.assert_called_once_with("ATTN001", {"date": "2025-01-01"})
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_multiple_fields(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -67,7 +67,7 @@ class TestUpdateCommand:
             {"title": "New Title", "date": "2025-01-01", "abstractNote": "New abstract"},
         )
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_field_option(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -92,7 +92,7 @@ class TestUpdateCommand:
         assert result.exit_code != 0
         assert "Invalid" in result.output or "key=value" in result.output
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_json_output(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
@@ -103,7 +103,7 @@ class TestUpdateCommand:
         assert "fields" in data
         assert data["sync_required"] is True
 
-    @patch("zotero_cli_cc.commands.update.ZoteroWriter")
+    @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
     def test_update_api_error(self, mock_writer_cls):
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer


### PR DESCRIPTION
## Summary

Adds `src/zotero_cli_cc/commands/_helpers.py` with two shared helpers and converts the repeated boilerplate across `commands/*.py`:

- `open_reader(ctx, cfg=None)` — loads config (or reuses a caller-provided one), resolves the data dir / library id, and returns a `ZoteroReader` (context-manager, always passes `prefs_js_path`; `ZoteroReader.__init__` only forwards it to `AttachmentResolver` as a path-resolution fallback, so passing it unconditionally is harmless).
- `build_writer(ctx, cfg, json_out, context)` — env/config credential resolution, group-library override, `auth_missing` emit_error (preserving each site's original `context=` string), then `ZoteroWriter` construction.

## Sites converted

**Reader (24 sites)**: search, list, read, recent, export, tag (view), note (view), relate, duplicates, stats, open, cite, pdf, summarize, summarize-all, attachment path, collection list/items, trash list, orphans `_scan`, update-status, enrich, rename, workspace add/show/export/import/search/index. The orphans/enrich/rename sites previously leaked the reader (no close); they now close via `with`. workspace index keeps a plain `open_reader(ctx)` + existing `finally` because the reader shares cleanup with the RAG index handle.

**Writer (15 sites)**: update, tag, delete, add (x3 via helpers), note, attach, enrich (its private `_build_writer` deleted in favor of the shared one), orphans clean, trash restore, collection create/move/delete/rename/reorganize.

**Skipped**: `update_status.py` writer block — its `emit_error` message differs from the canonical block ("Zotero write credentials not configured. Run 'zot config init'...", no `hint`), so it was left alone per the drift rule. `commands/config.py` `get_data_dir` use is `zot config show` output, not a reader site.

## Ordering notes (kept tests/contract green)

`build_writer` couples the credential check with client construction, so at three sites the call is placed after cheap local validation instead of at the old check position, keeping validation/confirmation errors ahead of client construction (asserted by `test_agent_interface` / `test_cli_p0`) while still failing `auth_missing` before any network call:

- `add`: input-presence validation now precedes the credential check (previously auth-first for the no-input case — untested edge).
- `add --from-file` / `--pdf`: helpers validate (empty file / missing DOI) then call `build_writer` themselves.
- `delete`: `build_writer` sits after the confirmation gate (previously auth-first for the no-creds non-interactive case — untested edge).

Tests that patched `zotero_cli_cc.commands.<mod>.ZoteroWriter` (37 sites) now patch `zotero_cli_cc.commands._helpers.ZoteroWriter` (and `enrich._build_writer` → `enrich.build_writer`).

## Verification

- `ruff check` / `ruff format` / `mypy` clean
- `pytest`: 792 passed, 1 skipped; only the 2 pre-existing local SOCKS-proxy failures (`test_mcp_server.py::TestMcpWriteErrorHandling::test_add_error`, `test_new_features.py::TestWriteErrorInCommands::test_add_write_error`)
- `zot schema` emits successfully (no CLI-surface change)

LOC delta: 36 files changed, +254 / −605 (net −351).