### PR TITLE
fix: batch get_bm25_terms_bulk to respect SQLITE_MAX_VARIABLE_NUMBER

### DIFF
--- a/src/zotero_cli_cc/core/rag_index.py
+++ b/src/zotero_cli_cc/core/rag_index.py
@@ -80,14 +80,18 @@ class RagIndex:
     def get_bm25_terms_bulk(self, chunk_ids: list[int]) -> dict[int, dict[str, float]]:
         if not chunk_ids:
             return {}
-        placeholders = ",".join("?" * len(chunk_ids))
-        rows = self._conn.execute(
-            f"SELECT chunk_id, term, tf FROM bm25_terms WHERE chunk_id IN ({placeholders})",
-            chunk_ids,
-        ).fetchall()
         result: dict[int, dict[str, float]] = {cid: {} for cid in chunk_ids}
-        for r in rows:
-            result[r["chunk_id"]][r["term"]] = r["tf"]
+        # SQLITE_MAX_VARIABLE_NUMBER can be as low as 999, so batch the IN clause
+        batch_size = 900
+        for i in range(0, len(chunk_ids), batch_size):
+            batch = chunk_ids[i : i + batch_size]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                f"SELECT chunk_id, term, tf FROM bm25_terms WHERE chunk_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for r in rows:
+                result[r["chunk_id"]][r["term"]] = r["tf"]
         return result
 
     def get_indexed_keys(self) -> set[str]:

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -51,6 +51,19 @@ class TestRagIndex:
         finally:
             idx.close()
 
+    def test_get_bm25_terms_bulk_exceeds_sqlite_variable_limit(self, tmp_path):
+        # Regression for #83: >SQLITE_MAX_VARIABLE_NUMBER ids in one IN clause
+        idx = RagIndex(tmp_path / "test.idx.sqlite")
+        try:
+            chunk_id = idx.insert_chunk("ABC123", "metadata", "attention mechanism")
+            idx.insert_bm25_terms(chunk_id, {"attention": 1.0})
+            chunk_ids = [chunk_id] + list(range(100_000, 140_000))
+            result = idx.get_bm25_terms_bulk(chunk_ids)
+            assert result[chunk_id] == {"attention": 1.0}
+            assert len(result) == len(chunk_ids)
+        finally:
+            idx.close()
+
     def test_set_and_get_meta(self, tmp_path):
         idx = RagIndex(tmp_path / "test.idx.sqlite")
         try:


### PR DESCRIPTION
## Summary
- `zot workspace query` crashed with `sqlite3.OperationalError: too many SQL variables` on large indices because `get_bm25_terms_bulk()` bound every chunk id into a single `IN (...)` clause. SQLite caps bound variables at `SQLITE_MAX_VARIABLE_NUMBER` (999 on older builds, 32766 max).
- Query in batches of 900 ids and merge the results.

## Test plan
- New regression test `test_get_bm25_terms_bulk_exceeds_sqlite_variable_limit` passes 40k+ ids (above the 32766 compile-time cap, so it fails deterministically on the old code).
- `ruff check`, `mypy`, `pytest tests/test_rag.py` all pass.

Fixes #83