### PR TITLE
feat: custom embedding base URL + OpenAI-compatible endpoint mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ This split is load-bearing for the project's value proposition. Preserve it when
 - `writer.py` — pyzotero-backed writes (add, update, delete, note, tag mutations, attachment upload).
 - `pdf_extractor.py` + `pdf_cache.py` — pluggable extraction backends (`pdfium` default — permissive BSD/Apache; `pymupdf` opt-in via the `[pymupdf]` extra for annotations/highlights + better markdown; `mineru` opt-in with auto-fallback to `pdfium`) with on-disk cache keyed per-extractor; feeds `zot pdf`, `summarize`, and the workspace RAG indexer. pymupdf is lazy-imported so the base install ships no AGPL code.
 - `workspace.py` — local-only TOML-backed workspaces at `~/.config/zot/workspaces/<name>.toml` (no API key, no Zotero sync). Workspaces are lightweight cross-cutting groupings, distinct from Zotero collections.
-- `rag.py` + `rag_index.py` — BM25 index over workspace metadata + PDF text, with optional embedding-based hybrid retrieval. The embedding layer is provider-routed (`core/embedding_router.py`) — choose via `[embedding] provider` (jina/aliyun) plus `ZOT_EMBEDDING_URL` / `ZOT_EMBEDDING_KEY`.
+- `rag.py` + `rag_index.py` — BM25 index over workspace metadata + PDF text, with optional embedding-based hybrid retrieval. The embedding layer is provider-routed (`core/embedding_router.py`) — choose via `[embedding] provider` (jina/aliyun/openai — the last covers any OpenAI-compatible `/v1/embeddings` endpoint) plus `ZOT_EMBEDDING_URL` / `ZOT_EMBEDDING_KEY`.
 - `idempotency.py` — supports `--idempotency-key` on mutating commands so agent retries are safe.
 - `semantic_scholar.py` — drives `zot update-status` (preprint → published detection).
 - `version_check.py` — PyPI version nudge.

--- a/docs/en/getting-started/setup.md
+++ b/docs/en/getting-started/setup.md
@@ -79,6 +79,7 @@ default_style = "bibtex"
 | `ZOT_EMBEDDING_URL` | Embedding API endpoint (default: Jina AI) |
 | `ZOT_EMBEDDING_KEY` | Embedding API key (enables semantic workspace search) |
 | `ZOT_EMBEDDING_MODEL` | Embedding model name (default: `jina-embeddings-v3`) |
+| `ZOT_EMBEDDING_PROVIDER` | Embedding provider: `jina` (default), `aliyun`, or `openai` (any OpenAI-compatible `/v1/embeddings` endpoint — set `ZOT_EMBEDDING_URL` to its base URL) |
 
 ## Multiple Profiles
 

--- a/docs/en/guide/workspace.md
+++ b/docs/en/guide/workspace.md
@@ -75,6 +75,15 @@ zot workspace index llm-safety --force      # Rebuild with embeddings
 zot workspace query "reward hacking" --workspace llm-safety --mode hybrid
 ```
 
+Any OpenAI-compatible `/v1/embeddings` endpoint also works (Aliyun Bailian workspace URLs, LiteLLM, Ollama, vLLM, ...):
+
+```bash
+export ZOT_EMBEDDING_PROVIDER="openai"
+export ZOT_EMBEDDING_URL="https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+export ZOT_EMBEDDING_KEY="your-key"
+export ZOT_EMBEDDING_MODEL="text-embedding-v3"
+```
+
 ## Manage
 
 ```bash

--- a/docs/zh/getting-started/setup.md
+++ b/docs/zh/getting-started/setup.md
@@ -79,6 +79,7 @@ default_style = "bibtex"
 | `ZOT_EMBEDDING_URL` | Embedding API 端点（默认：Jina AI） |
 | `ZOT_EMBEDDING_KEY` | Embedding API 密钥（启用语义工作区搜索） |
 | `ZOT_EMBEDDING_MODEL` | Embedding 模型名称（默认：`jina-embeddings-v3`） |
+| `ZOT_EMBEDDING_PROVIDER` | Embedding 提供商：`jina`（默认）、`aliyun` 或 `openai`（任意 OpenAI 兼容 `/v1/embeddings` 端点，将 `ZOT_EMBEDDING_URL` 设为其 base URL） |
 
 ## 多配置文件
 

--- a/docs/zh/guide/workspace.md
+++ b/docs/zh/guide/workspace.md
@@ -75,6 +75,15 @@ zot workspace index llm-safety --force      # 重建索引（含 embeddings）
 zot workspace query "reward hacking" --workspace llm-safety --mode hybrid
 ```
 
+也支持任意 OpenAI 兼容的 `/v1/embeddings` 端点（阿里云百炼工作空间专属地址、LiteLLM、Ollama、vLLM 等）：
+
+```bash
+export ZOT_EMBEDDING_PROVIDER="openai"
+export ZOT_EMBEDDING_URL="https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+export ZOT_EMBEDDING_KEY="your-key"
+export ZOT_EMBEDDING_MODEL="text-embedding-v3"
+```
+
 ## 管理
 
 ```bash

--- a/src/zotero_cli_cc/core/embedding_router.py
+++ b/src/zotero_cli_cc/core/embedding_router.py
@@ -7,6 +7,9 @@ from zotero_cli_cc.core.embedding_provider import EmbeddingProvider
 from zotero_cli_cc.core.providers.aliyun import AliyunProvider
 from zotero_cli_cc.core.providers.jina import JinaProvider
 
+_JINA_DEFAULT_URL = "https://api.jina.ai/v1/embeddings"
+_ALIYUN_DEFAULT_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
 
 class EmbeddingRouter:
     """Holds the single embedding provider selected by config.provider."""
@@ -19,14 +22,18 @@ class EmbeddingRouter:
         if not api_key:
             return
         if config.provider == "jina":
-            jina_url = config.url if "jina" in config.url else "https://api.jina.ai/v1/embeddings"
+            jina_url = config.url if "jina" in config.url else _JINA_DEFAULT_URL
             self.provider = JinaProvider(api_key=api_key, model=config.model, url=jina_url)
-        elif config.provider == "aliyun":
-            self.provider = AliyunProvider(
-                api_key=api_key,
-                model=config.model,
-                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            )
+        elif config.provider in ("aliyun", "openai"):
+            # AliyunProvider speaks the standard OpenAI-compatible /embeddings
+            # protocol, so it also serves any custom endpoint (Bailian
+            # workspace URLs, LiteLLM, Ollama, vLLM, ...).
+            if config.provider == "aliyun" and config.url == _JINA_DEFAULT_URL:
+                base_url = _ALIYUN_DEFAULT_URL
+            else:
+                # Accept both a base URL and a full .../embeddings endpoint
+                base_url = config.url.rstrip("/").removesuffix("/embeddings")
+            self.provider = AliyunProvider(api_key=api_key, model=config.model, base_url=base_url)
 
     def embed(
         self,

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from zotero_cli_cc.config import EmbeddingConfig
+from zotero_cli_cc.core.embedding_router import EmbeddingRouter
+from zotero_cli_cc.core.providers.aliyun import AliyunProvider
 from zotero_cli_cc.core.rag import (
     bm25_score_chunks,
     build_metadata_chunk,
@@ -220,6 +222,40 @@ class TestEmbedding:
         assert result is None
         captured = capsys.readouterr()
         assert captured.err == ""
+
+
+class TestEmbeddingRouter:
+    def test_aliyun_default_url(self):
+        cfg = EmbeddingConfig(api_key="key", provider="aliyun")
+        router = EmbeddingRouter(cfg)
+        assert isinstance(router.provider, AliyunProvider)
+        assert router.provider.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+    def test_aliyun_custom_base_url(self):
+        cfg = EmbeddingConfig(
+            url="https://ws-123.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            api_key="key",
+            provider="aliyun",
+        )
+        router = EmbeddingRouter(cfg)
+        assert router.provider.base_url == "https://ws-123.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+
+    def test_openai_compatible_provider(self):
+        cfg = EmbeddingConfig(url="http://localhost:11434/v1", api_key="key", model="nomic-embed", provider="openai")
+        router = EmbeddingRouter(cfg)
+        assert isinstance(router.provider, AliyunProvider)
+        assert router.provider.base_url == "http://localhost:11434/v1"
+        assert router.provider.model == "nomic-embed"
+
+    def test_openai_full_embeddings_url_stripped(self):
+        cfg = EmbeddingConfig(url="http://localhost:4000/v1/embeddings", api_key="key", provider="openai")
+        router = EmbeddingRouter(cfg)
+        assert router.provider.base_url == "http://localhost:4000/v1"
+
+    def test_no_api_key_no_provider(self):
+        cfg = EmbeddingConfig(api_key="", provider="openai")
+        router = EmbeddingRouter(cfg)
+        assert router.provider is None
 
 
 class TestRRF:


### PR DESCRIPTION
## Summary
Fixes #84.

- `provider = "aliyun"` now honors `ZOT_EMBEDDING_URL` / `[embedding] url` as its base URL, so per-workspace Bailian endpoints (`https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`) work. Falls back to the dashscope default when no custom URL is set, so existing configs are unchanged.
- New `provider = "openai"` mode routes any OpenAI-compatible `/v1/embeddings` endpoint (Bailian, LiteLLM, Ollama, vLLM, ...) with configurable `base_url`, `api_key`, and `model`. It reuses the existing `AliyunProvider`, which already speaks the standard OpenAI embeddings protocol — no new HTTP client.
- Both a base URL and a full `.../embeddings` URL are accepted (the suffix is stripped).
- Docs: `ZOT_EMBEDDING_PROVIDER` added to the env-var tables and an OpenAI-compatible example added to the workspace guide (en + zh).

## Test plan
- New `TestEmbeddingRouter` covers: aliyun default URL, aliyun custom base URL, openai provider selection + model, `/embeddings` suffix stripping, and missing-key behavior.
- `ruff check`, `ruff format --check`, `mypy`, and the rag/config test suites all pass.