### PR TITLE
chore: release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-15
+
+### Added
+
+- **OpenAI-compatible embedding endpoints** — new `provider = "openai"`
+  (`ZOT_EMBEDDING_PROVIDER=openai`) routes any OpenAI-compatible
+  `/v1/embeddings` endpoint (Aliyun Bailian workspace URLs, LiteLLM, Ollama,
+  vLLM, ...) with configurable base URL, API key, and model. The `aliyun`
+  provider now also honors `ZOT_EMBEDDING_URL` / `[embedding] url` as a custom
+  base URL — needed since Bailian moved to per-workspace endpoints — and falls
+  back to the dashscope default when unset. Both base URLs and full
+  `.../embeddings` URLs are accepted (#84, #86).
+
+### Fixed
+
+- **`zot workspace query` crashed on large indices** with
+  `sqlite3.OperationalError: too many SQL variables` — BM25 term lookup bound
+  every chunk id into a single `IN (...)` clause, exceeding SQLite's
+  `SQLITE_MAX_VARIABLE_NUMBER`. Now queried in batches of 900 ids (#83, #85).
+
 ## [0.9.0] - 2026-07-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-cc"
-version = "0.9.0"
+version = "0.10.0"
 description = "Zotero CLI for Claude Code — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-cc"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Release 0.10.0 — everything merged since v0.9.0:

- **feat**: OpenAI-compatible embedding endpoints — `provider = "openai"` + custom base URL for `aliyun` (#84, #86)
- **fix**: `zot workspace query` crash (`too many SQL variables`) on large indices (#83, #85)

Bumps `pyproject.toml` + `uv.lock` to 0.10.0 and adds the CHANGELOG entry. No CLI surface / envelope changes, so `schema_version` is untouched.

After merge: tag `v0.10.0` on main to trigger the PyPI publish workflow.