### PR TITLE
fix: harden agent contract, SQLite robustness, and test hermeticity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,22 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --group dev --extra mcp
+          enable-cache: true
+      - run: uv sync --locked --group dev --extra mcp
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
       - run: uv run mypy src/zotero_cli_cc/
       - run: uv run pytest tests/ -v
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      # The wheel force-includes the Zotero bridge plugin assets; fail here
+      # rather than at release time if they go missing.
+      - run: uv build
+      - name: Verify bridge assets are bundled
+        run: unzip -l dist/*.whl | grep bridge_assets

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dist/
 build/
 .pytest_cache/
 .coverage
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+*.log
 # Docs build output
 site/
 # Internal dev docs (plans, specs)

--- a/src/zotero_cli_cc/commands/config.py
+++ b/src/zotero_cli_cc/commands/config.py
@@ -215,7 +215,19 @@ def profile_set(name: str, config_path: str | None) -> None:
         )
     content = path.read_text()
     if "[default]" in content:
-        content = re.sub(r'(profile\s*=\s*)"[^"]*"', f'\\1"{name}"', content)
+        # Match both quote styles: save_config used to write single-quoted
+        # TOML literal strings, so a double-quote-only regex silently no-ops.
+        def _repl(m: re.Match[str]) -> str:
+            return f'{m.group(1)}"{name}"'
+
+        content, n = re.subn(
+            r"""(profile\s*=\s*)("[^"]*"|'[^']*')""",
+            _repl,
+            content,
+            count=1,
+        )
+        if n == 0:
+            content = content.replace("[default]", f'[default]\nprofile = "{name}"', 1)
     else:
         content = f'[default]\nprofile = "{name}"\n\n' + content
     path.write_text(content)

--- a/src/zotero_cli_cc/commands/open_cmd.py
+++ b/src/zotero_cli_cc/commands/open_cmd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -14,7 +15,8 @@ def _open_path(path: str) -> None:
     if sys.platform == "darwin":
         subprocess.run(["open", path], check=True)
     elif sys.platform == "win32":
-        subprocess.run(["start", path], shell=True, check=True)
+        # os.startfile avoids cmd.exe metacharacter interpretation of the path
+        os.startfile(path)  # type: ignore[attr-defined]
     else:
         subprocess.run(["xdg-open", path], check=True)
 

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -8,7 +8,7 @@ import click
 from zotero_cli_cc.commands._helpers import open_reader
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
 from zotero_cli_cc.exit_codes import emit_error
-from zotero_cli_cc.formatter import format_pdf_annotations, format_pdf_text
+from zotero_cli_cc.formatter import envelope_ok, format_pdf_annotations, format_pdf_text
 
 
 def _parse_outline(markdown: str) -> list[tuple[int, str, int]]:
@@ -154,7 +154,7 @@ def pdf_cmd(
                 emit_error("runtime_error", str(e), output_json=json_out, context="pdf")
             if not annots:
                 if json_out:
-                    click.echo("[]")
+                    click.echo(format_pdf_annotations(annots, output_json=True))
                 else:
                     click.echo("No annotations found.")
                 return
@@ -174,10 +174,13 @@ def pdf_cmd(
                     context="pdf",
                 )
             if not refs:
-                click.echo("[]" if json_out else "No references found.")
+                if json_out:
+                    click.echo(json.dumps(envelope_ok({"key": key, "references": []}), ensure_ascii=False))
+                else:
+                    click.echo("No references found.")
                 return
             if json_out:
-                click.echo(json.dumps({"key": key, "references": refs}, ensure_ascii=False))
+                click.echo(json.dumps(envelope_ok({"key": key, "references": refs}), ensure_ascii=False))
             else:
                 lines = []
                 for i, r in enumerate(refs, 1):
@@ -200,10 +203,13 @@ def pdf_cmd(
                     context="pdf",
                 )
             if not extracted:
-                click.echo("[]" if json_out else "No tables found.")
+                if json_out:
+                    click.echo(json.dumps(envelope_ok({"key": key, "tables": []}), ensure_ascii=False))
+                else:
+                    click.echo("No tables found.")
                 return
             if json_out:
-                click.echo(json.dumps({"key": key, "tables": extracted}, ensure_ascii=False))
+                click.echo(json.dumps(envelope_ok({"key": key, "tables": extracted}), ensure_ascii=False))
             else:
                 blocks = []
                 for t in extracted:
@@ -268,7 +274,8 @@ def pdf_cmd(
                 outline_data = _parse_outline(text)
                 if not outline_data:
                     if json_out:
-                        click.echo(json.dumps({"key": key, "pages": pages, "outline": []}, ensure_ascii=False))
+                        empty = envelope_ok({"key": key, "pages": pages, "outline": []})
+                        click.echo(json.dumps(empty, ensure_ascii=False))
                     else:
                         click.echo("No headings found in document.")
                     return

--- a/src/zotero_cli_cc/commands/update_status.py
+++ b/src/zotero_cli_cc/commands/update_status.py
@@ -89,7 +89,7 @@ def update_status_cmd(
 
     if not items:
         if json_out:
-            click.echo("[]")
+            click.echo(json.dumps(envelope_ok({"results": []}), indent=2, ensure_ascii=False))
         else:
             click.echo("No preprints found.")
         return
@@ -107,7 +107,7 @@ def update_status_cmd(
 
     if not preprint_items:
         if json_out:
-            click.echo("[]")
+            click.echo(json.dumps(envelope_ok({"results": []}), indent=2, ensure_ascii=False))
         else:
             click.echo("No items with preprint IDs found.")
         return
@@ -177,7 +177,8 @@ def update_status_cmd(
         client.close()
 
     if json_out:
-        click.echo(json.dumps(results, indent=2))
+        scan_env = envelope_ok({"published_count": published_count, "results": results})
+        click.echo(json.dumps(scan_env, indent=2, ensure_ascii=False))
         return
 
     click.echo()
@@ -238,7 +239,7 @@ def update_status_cmd(
         try:
             writer.update_item(r["key"], fields)
             updated += 1
-            click.echo(f"  Updated {r['key']}: {r['title'][:50]}...")
+            click.echo(f"  Updated {r['key']}: {r['title'][:50]}...", err=True)
         except ZoteroWriteError as e:
             click.echo(f"  Failed {r['key']}: {e}", err=True)
 
@@ -247,6 +248,7 @@ def update_status_cmd(
         store_cached(cache_scope, idempotency_key, env)
     if json_out:
         click.echo(json.dumps(env, indent=2, ensure_ascii=False))
-    click.echo(f"\nUpdated {updated} item(s).")
+    # Prose goes to stderr so stdout stays a parseable JSON envelope
+    click.echo(f"\nUpdated {updated} item(s).", err=True)
     if updated > 0:
-        click.echo(SYNC_REMINDER)
+        click.echo(SYNC_REMINDER, err=True)

--- a/src/zotero_cli_cc/commands/workspace.py
+++ b/src/zotero_cli_cc/commands/workspace.py
@@ -462,11 +462,12 @@ def workspace_index(
         click.echo(f"Workspace '{name}' is empty. Add items first with: zot workspace add {name} KEY")
         return
 
-    # Reader and idx share one finally-cleanup below, so no `with` block here.
-    reader = open_reader(ctx)
-
     idx_path = workspaces_dir() / f"{name}.idx.sqlite"
     idx = RagIndex(idx_path)
+
+    # Reader and idx share one finally-cleanup below, so no `with` block here.
+    # Reader is opened last so a failure above cannot leak the SQLite connection.
+    reader = open_reader(ctx)
 
     try:
         if force:

--- a/src/zotero_cli_cc/config.py
+++ b/src/zotero_cli_cc/config.py
@@ -181,9 +181,16 @@ def get_default_profile(path: Path | None = None) -> str:
     return str(data.get("default", {}).get("profile", ""))
 
 
+def _toml_str(value: str) -> str:
+    """Render value as a TOML basic string (escapes backslashes and quotes)."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def save_config(config: AppConfig, path: Path | None = None) -> None:
     path = path or CONFIG_FILE
     path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
 
     # Check if existing config uses profile-based structure
     existing_raw = ""
@@ -196,53 +203,55 @@ def save_config(config: AppConfig, path: Path | None = None) -> None:
     if has_profiles:
         lines = [
             "[default]",
-            "profile = 'default'",
+            'profile = "default"',
             "",
             "[profile.default]",
-            f"data_dir = '{config.data_dir}'",
-            f"library_id = '{config.library_id}'",
-            f"api_key = '{config.api_key}'",
+            f"data_dir = {_toml_str(config.data_dir)}",
+            f"library_id = {_toml_str(config.library_id)}",
+            f"api_key = {_toml_str(config.api_key)}",
         ]
         if config.semantic_scholar_api_key:
-            lines.append(f"semantic_scholar_api_key = '{config.semantic_scholar_api_key}'")
+            lines.append(f"semantic_scholar_api_key = {_toml_str(config.semantic_scholar_api_key)}")
         if config.prefs_js_path:
-            lines.append(f"prefs_js_path = '{config.prefs_js_path}'")
+            lines.append(f"prefs_js_path = {_toml_str(config.prefs_js_path)}")
         lines.extend(
             [
                 "",
                 "[output]",
-                f"default_format = '{config.default_format}'",
+                f"default_format = {_toml_str(config.default_format)}",
                 f"limit = {config.default_limit}",
                 "",
                 "[export]",
-                f"default_style = '{config.default_export_style}'",
+                f"default_style = {_toml_str(config.default_export_style)}",
                 "",
             ]
         )
     else:
         lines = [
             "[zotero]",
-            f"data_dir = '{config.data_dir}'",
-            f"library_id = '{config.library_id}'",
-            f"api_key = '{config.api_key}'",
+            f"data_dir = {_toml_str(config.data_dir)}",
+            f"library_id = {_toml_str(config.library_id)}",
+            f"api_key = {_toml_str(config.api_key)}",
         ]
         if config.semantic_scholar_api_key:
-            lines.append(f"semantic_scholar_api_key = '{config.semantic_scholar_api_key}'")
+            lines.append(f"semantic_scholar_api_key = {_toml_str(config.semantic_scholar_api_key)}")
         if config.prefs_js_path:
-            lines.append(f"prefs_js_path = '{config.prefs_js_path}'")
+            lines.append(f"prefs_js_path = {_toml_str(config.prefs_js_path)}")
         lines.extend(
             [
                 "",
                 "[output]",
-                f"default_format = '{config.default_format}'",
+                f"default_format = {_toml_str(config.default_format)}",
                 f"limit = {config.default_limit}",
                 "",
                 "[export]",
-                f"default_style = '{config.default_export_style}'",
+                f"default_style = {_toml_str(config.default_export_style)}",
                 "",
             ]
         )
     path.write_text("\n".join(lines))
+    # Config holds API keys — restrict to owner read/write
+    os.chmod(path, 0o600)
 
 
 def detect_zotero_data_dir(config: AppConfig) -> Path:

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -4,6 +4,7 @@ import io
 import os
 import re
 import sys
+import tempfile
 import time
 import xml.etree.ElementTree as ET
 import zipfile
@@ -521,13 +522,18 @@ class MinerUExtractor(BasePdfExtractor):
             raw_md = zf.read("full.md").decode("utf-8", errors="replace")
         return _clean_markdown_images(raw_md)
 
-    def _split_pdf(self, pdf_path: Path, max_pages: int) -> list[Path]:
+    def _split_pdf(self, pdf_path: Path, max_pages: int, dest_dir: Path) -> list[Path]:
+        """Split a large PDF into ≤max_pages chunk files inside dest_dir.
+
+        Chunks must not be written next to the source PDF: the source lives in
+        Zotero storage, and a crash would leave litter that Zotero could sync.
+        """
         pymupdf = _import_pymupdf()
         doc = pymupdf.open(str(pdf_path))
         total_pages = len(doc)
         chunks: list[Path] = []
         for start in range(0, total_pages, max_pages):
-            chunk_path = pdf_path.with_suffix(f".chunk{start // max_pages}.pdf")
+            chunk_path = dest_dir / f"{pdf_path.stem}.chunk{start // max_pages}.pdf"
             chunk_doc = pymupdf.open()
             end = min(start + max_pages, total_pages)
             for page_num in range(start, end):
@@ -585,9 +591,9 @@ class MinerUExtractor(BasePdfExtractor):
         if total_pages > 200:
             if pages:
                 raise PdfExtractionError("Page range splitting not supported for PDFs >200 pages")
-            chunk_paths = self._split_pdf(pdf_path, 200)
-            total_chunks = len(chunk_paths)
-            try:
+            with tempfile.TemporaryDirectory(prefix="zot-mineru-") as tmp:
+                chunk_paths = self._split_pdf(pdf_path, 200, Path(tmp))
+                total_chunks = len(chunk_paths)
                 texts = []
                 for chunk_idx, chunk_path in enumerate(chunk_paths, 1):
                     # Wrap progress_callback to report chunk progress instead of per-chunk-internal progress
@@ -608,24 +614,19 @@ class MinerUExtractor(BasePdfExtractor):
                         wrapped_callback = None
                     texts.append(self._extract_single(chunk_path, wrapped_callback))
                 return "\n\n".join(texts)
-            finally:
-                for chunk_path in chunk_paths:
-                    chunk_path.unlink(missing_ok=True)
         else:
             if pages:
-                chunk_path = pdf_path.with_suffix(".pagetemp.pdf")
-                doc = pymupdf.open(str(pdf_path))
-                chunk_doc = pymupdf.open()
-                start, end = pages
-                for page_num in range(start - 1, min(end, total_pages)):
-                    chunk_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
-                chunk_doc.save(str(chunk_path))
-                chunk_doc.close()
-                doc.close()
-                try:
+                with tempfile.TemporaryDirectory(prefix="zot-mineru-") as tmp:
+                    chunk_path = Path(tmp) / f"{pdf_path.stem}.pagetemp.pdf"
+                    doc = pymupdf.open(str(pdf_path))
+                    chunk_doc = pymupdf.open()
+                    start, end = pages
+                    for page_num in range(start - 1, min(end, total_pages)):
+                        chunk_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
+                    chunk_doc.save(str(chunk_path))
+                    chunk_doc.close()
+                    doc.close()
                     return self._extract_single(chunk_path, progress_callback)
-                finally:
-                    chunk_path.unlink(missing_ok=True)
             else:
                 return self._extract_single(pdf_path, progress_callback)
 
@@ -636,7 +637,9 @@ class MinerUExtractor(BasePdfExtractor):
     ) -> dict[Path, str | Exception]:
         pymupdf = _import_pymupdf()
         results: dict[Path, str | Exception] = {}
-        temp_files: list[Path] = []
+        # Split chunks go to a private temp dir — never next to the source PDF
+        # in Zotero storage; cleaned up even if the batch raises mid-upload.
+        chunk_tmp = tempfile.TemporaryDirectory(prefix="zot-mineru-")
         original_to_chunks: dict[Path, list[Path]] = {}
         total_pages = 0
 
@@ -665,8 +668,7 @@ class MinerUExtractor(BasePdfExtractor):
             total_pages += page_count
 
             if page_count > 200:
-                chunk_paths = self._split_pdf(pdf_path, 200)
-                temp_files.extend(chunk_paths)
+                chunk_paths = self._split_pdf(pdf_path, 200, Path(chunk_tmp.name))
                 original_to_chunks[pdf_path] = chunk_paths
                 for chunk_path in chunk_paths:
                     file_name = chunk_path.name
@@ -731,8 +733,7 @@ class MinerUExtractor(BasePdfExtractor):
                 else:
                     results[orig_for_chunk] = PdfExtractionError(f"Unexpected state: {state}")
 
-        for temp_file in temp_files:
-            temp_file.unlink(missing_ok=True)
+        chunk_tmp.cleanup()
 
         return results
 

--- a/src/zotero_cli_cc/core/reader.py
+++ b/src/zotero_cli_cc/core/reader.py
@@ -5,9 +5,12 @@ import re
 import shutil
 import sqlite3
 import tempfile
+import urllib.parse
 import warnings
+from collections.abc import Iterator
 from difflib import SequenceMatcher
 from pathlib import Path
+from typing import Any
 
 from zotero_cli_cc.models import (
     Attachment,
@@ -30,6 +33,29 @@ _EXCLUDED_TYPE_NAMES = ("attachment", "note", "annotation")
 # Tested schema version range (Zotero 6–8)
 MIN_SCHEMA_VERSION = 100
 MAX_SCHEMA_VERSION = 200
+
+# SQLITE_MAX_VARIABLE_NUMBER can be as low as 999 on older SQLite builds, so
+# large IN (...) parameter lists are executed in batches (same pattern as
+# rag_index.get_bm25_terms_bulk). Sorted queries keep a single SQL ORDER BY up
+# to _SORT_IN_THRESHOLD ids (modern SQLite allows 32766 variables) and only
+# fall back to Python-side sorting beyond that.
+_IN_BATCH_SIZE = 900
+_SORT_IN_THRESHOLD = 30000
+
+_NOCASE_TRANS = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
+
+
+def _in_batches(ids: list[int], size: int | None = None) -> Iterator[list[int]]:
+    """Yield an id list in chunks small enough for SQLite's variable limit."""
+    if size is None:
+        size = _IN_BATCH_SIZE  # read at call time so tests can monkeypatch
+    for i in range(0, len(ids), size):
+        yield ids[i : i + size]
+
+
+def _nocase_key(value: str) -> str:
+    """ASCII-only case fold, matching SQLite's COLLATE NOCASE."""
+    return value.translate(_NOCASE_TRANS)
 
 
 class ZoteroReader:
@@ -55,7 +81,8 @@ class ZoteroReader:
                 f"  Run 'zot config init --data-dir <path>' to set the correct data directory."
             )
         # immutable=1 skips WAL, avoids lock contention with running Zotero desktop
-        uri_path = self._db_path.as_posix()
+        # Percent-encode so paths containing '?', '#' or '%' don't corrupt the URI
+        uri_path = urllib.parse.quote(self._db_path.as_posix())
         try:
             conn = sqlite3.connect(
                 f"file:{uri_path}?mode=ro&immutable=1",
@@ -327,13 +354,13 @@ class ZoteroReader:
                 (item_type,),
             ).fetchone()
             if type_row:
-                typed_items = conn.execute(
-                    "SELECT itemID FROM items WHERE itemTypeID = ? AND itemID IN ({})".format(
-                        ",".join("?" * len(item_ids))
-                    ),
-                    (type_row["itemTypeID"], *item_ids),
-                ).fetchall()
-                item_ids = {r["itemID"] for r in typed_items}
+                rows = self._batched_in_query(
+                    conn,
+                    "SELECT itemID FROM items WHERE itemTypeID = ? AND itemID IN ({ph})",
+                    sorted(item_ids),
+                    (type_row["itemTypeID"],),
+                )
+                item_ids = {r["itemID"] for r in rows}
             else:
                 item_ids = set()
 
@@ -342,37 +369,75 @@ class ZoteroReader:
 
         if sort and item_ids:
             dir_sql = "DESC" if direction == "desc" else "ASC"
-            ph = ",".join("?" * len(item_ids))
-            id_list = list(item_ids)
+            reverse = direction == "desc"
+            id_list = sorted(item_ids)
 
             if sort in ("dateAdded", "dateModified"):
-                rows = conn.execute(
-                    f"SELECT itemID FROM items WHERE itemID IN ({ph}) ORDER BY {sort} {dir_sql} LIMIT ? OFFSET ?",
-                    (*id_list, limit, offset),
-                ).fetchall()
-                target_ids = [r["itemID"] for r in rows]
+                if len(id_list) <= _SORT_IN_THRESHOLD:
+                    ph = ",".join("?" * len(id_list))
+                    rows = conn.execute(
+                        f"SELECT itemID FROM items WHERE itemID IN ({ph}) ORDER BY {sort} {dir_sql} LIMIT ? OFFSET ?",
+                        (*id_list, limit, offset),
+                    ).fetchall()
+                    target_ids = [r["itemID"] for r in rows]
+                else:
+                    # Oversized IN list: fetch sort keys batched, sort in Python
+                    pairs = self._batched_in_query(
+                        conn,
+                        f"SELECT itemID, {sort} AS sort_key FROM items WHERE itemID IN ({{ph}})",
+                        id_list,
+                    )
+                    pairs.sort(key=lambda r: r["sort_key"] or "", reverse=reverse)
+                    target_ids = [r["itemID"] for r in pairs[offset : offset + limit]]
             elif sort == "title":
                 title_field = conn.execute("SELECT fieldID FROM fields WHERE fieldName = 'title'").fetchone()
                 fid = title_field["fieldID"] if title_field else 4
-                rows = conn.execute(
-                    f"SELECT i.itemID FROM items i "
-                    f"LEFT JOIN itemData id_t ON i.itemID = id_t.itemID AND id_t.fieldID = ? "
-                    f"LEFT JOIN itemDataValues iv_t ON id_t.valueID = iv_t.valueID "
-                    f"WHERE i.itemID IN ({ph}) "
-                    f"ORDER BY COALESCE(iv_t.value, '') COLLATE NOCASE {dir_sql} LIMIT ? OFFSET ?",
-                    (fid, *id_list, limit, offset),
-                ).fetchall()
-                target_ids = [r["itemID"] for r in rows]
+                if len(id_list) <= _SORT_IN_THRESHOLD:
+                    ph = ",".join("?" * len(id_list))
+                    rows = conn.execute(
+                        f"SELECT i.itemID FROM items i "
+                        f"LEFT JOIN itemData id_t ON i.itemID = id_t.itemID AND id_t.fieldID = ? "
+                        f"LEFT JOIN itemDataValues iv_t ON id_t.valueID = iv_t.valueID "
+                        f"WHERE i.itemID IN ({ph}) "
+                        f"ORDER BY COALESCE(iv_t.value, '') COLLATE NOCASE {dir_sql} LIMIT ? OFFSET ?",
+                        (fid, *id_list, limit, offset),
+                    ).fetchall()
+                    target_ids = [r["itemID"] for r in rows]
+                else:
+                    pairs = self._batched_in_query(
+                        conn,
+                        "SELECT i.itemID, COALESCE(iv_t.value, '') AS sort_key FROM items i "
+                        "LEFT JOIN itemData id_t ON i.itemID = id_t.itemID AND id_t.fieldID = ? "
+                        "LEFT JOIN itemDataValues iv_t ON id_t.valueID = iv_t.valueID "
+                        "WHERE i.itemID IN ({ph})",
+                        id_list,
+                        (fid,),
+                    )
+                    pairs.sort(key=lambda r: _nocase_key(r["sort_key"]), reverse=reverse)
+                    target_ids = [r["itemID"] for r in pairs[offset : offset + limit]]
             elif sort == "creator":
-                rows = conn.execute(
-                    f"SELECT i.itemID FROM items i "
-                    f"LEFT JOIN itemCreators ic ON i.itemID = ic.itemID AND ic.orderIndex = 0 "
-                    f"LEFT JOIN creators c ON ic.creatorID = c.creatorID "
-                    f"WHERE i.itemID IN ({ph}) "
-                    f"ORDER BY COALESCE(c.lastName, '') COLLATE NOCASE {dir_sql} LIMIT ? OFFSET ?",
-                    (*id_list, limit, offset),
-                ).fetchall()
-                target_ids = [r["itemID"] for r in rows]
+                if len(id_list) <= _SORT_IN_THRESHOLD:
+                    ph = ",".join("?" * len(id_list))
+                    rows = conn.execute(
+                        f"SELECT i.itemID FROM items i "
+                        f"LEFT JOIN itemCreators ic ON i.itemID = ic.itemID AND ic.orderIndex = 0 "
+                        f"LEFT JOIN creators c ON ic.creatorID = c.creatorID "
+                        f"WHERE i.itemID IN ({ph}) "
+                        f"ORDER BY COALESCE(c.lastName, '') COLLATE NOCASE {dir_sql} LIMIT ? OFFSET ?",
+                        (*id_list, limit, offset),
+                    ).fetchall()
+                    target_ids = [r["itemID"] for r in rows]
+                else:
+                    pairs = self._batched_in_query(
+                        conn,
+                        "SELECT i.itemID, COALESCE(c.lastName, '') AS sort_key FROM items i "
+                        "LEFT JOIN itemCreators ic ON i.itemID = ic.itemID AND ic.orderIndex = 0 "
+                        "LEFT JOIN creators c ON ic.creatorID = c.creatorID "
+                        "WHERE i.itemID IN ({ph})",
+                        id_list,
+                    )
+                    pairs.sort(key=lambda r: _nocase_key(r["sort_key"]), reverse=reverse)
+                    target_ids = [r["itemID"] for r in pairs[offset : offset + limit]]
             else:
                 target_ids = sorted(item_ids)[offset : offset + limit]
         else:
@@ -446,14 +511,14 @@ class ZoteroReader:
 
         # --- DOI strategy ---
         if strategy in ("doi", "both"):
-            ph = ",".join("?" * len(item_ids))
-            doi_rows = conn.execute(
-                f"SELECT id.itemID, iv.value FROM itemData id "
-                f"JOIN fields f ON id.fieldID = f.fieldID "
-                f"JOIN itemDataValues iv ON id.valueID = iv.valueID "
-                f"WHERE f.fieldName = 'DOI' AND id.itemID IN ({ph}) AND iv.value != ''",
+            doi_rows = self._batched_in_query(
+                conn,
+                "SELECT id.itemID, iv.value FROM itemData id "
+                "JOIN fields f ON id.fieldID = f.fieldID "
+                "JOIN itemDataValues iv ON id.valueID = iv.valueID "
+                "WHERE f.fieldName = 'DOI' AND id.itemID IN ({ph}) AND iv.value != ''",
                 item_ids,
-            ).fetchall()
+            )
 
             doi_map: dict[str, list[int]] = {}
             for r in doi_rows:
@@ -472,14 +537,14 @@ class ZoteroReader:
 
         # --- Title strategy ---
         if strategy in ("title", "both"):
-            ph = ",".join("?" * len(item_ids))
-            title_rows = conn.execute(
-                f"SELECT id.itemID, iv.value FROM itemData id "
-                f"JOIN fields f ON id.fieldID = f.fieldID "
-                f"JOIN itemDataValues iv ON id.valueID = iv.valueID "
-                f"WHERE f.fieldName = 'title' AND id.itemID IN ({ph})",
+            title_rows = self._batched_in_query(
+                conn,
+                "SELECT id.itemID, iv.value FROM itemData id "
+                "JOIN fields f ON id.fieldID = f.fieldID "
+                "JOIN itemDataValues iv ON id.valueID = iv.valueID "
+                "WHERE f.fieldName = 'title' AND id.itemID IN ({ph})",
                 item_ids,
-            ).fetchall()
+            )
 
             def _normalize(title: str) -> str:
                 t = re.sub(r"[^\w\s]", "", title.lower()).strip()
@@ -916,25 +981,42 @@ class ZoteroReader:
 
     # --- Private helpers ---
 
+    @staticmethod
+    def _batched_in_query(
+        conn: sqlite3.Connection,
+        sql: str,
+        ids: list[int],
+        prefix_params: tuple[Any, ...] = (),
+    ) -> list[sqlite3.Row]:
+        """Run a query containing one ``IN ({ph})`` placeholder, batched over ``ids``.
+
+        SQLITE_MAX_VARIABLE_NUMBER can be as low as 999 on older SQLite builds,
+        so large id lists are split into batches. ``prefix_params`` bind before
+        each id batch.
+        """
+        out: list[sqlite3.Row] = []
+        for batch in _in_batches(ids):
+            ph = ",".join("?" * len(batch))
+            out.extend(conn.execute(sql.format(ph=ph), (*prefix_params, *batch)).fetchall())
+        return out
+
     def _get_items_batch(self, conn: sqlite3.Connection, item_ids: list[int]) -> list[Item]:
         """Resolve multiple item IDs to Items using bulk queries instead of N+1."""
         if not item_ids:
             return []
 
-        placeholders = ",".join("?" * len(item_ids))
-
         # Fetch base item rows
-        rows = conn.execute(
+        rows = self._batched_in_query(
+            conn,
             f"SELECT itemID, itemTypeID, key, dateAdded, dateModified "
-            f"FROM items WHERE itemID IN ({placeholders}) AND itemTypeID {self._get_excluded_sql()}",
+            f"FROM items WHERE itemID IN ({{ph}}) AND itemTypeID {self._get_excluded_sql()}",
             item_ids,
-        ).fetchall()
+        )
         if not rows:
             return []
 
         id_to_row = {r["itemID"]: r for r in rows}
         valid_ids = list(id_to_row.keys())
-        valid_ph = ",".join("?" * len(valid_ids))
 
         # Batch fetch item types
         type_ids = list({r["itemTypeID"] for r in rows})
@@ -946,26 +1028,28 @@ class ZoteroReader:
         type_map = {r["itemTypeID"]: r["typeName"] for r in type_rows}
 
         # Batch fetch fields
-        field_rows = conn.execute(
-            f"SELECT id.itemID, f.fieldName, iv.value FROM itemData id "
-            f"JOIN fields f ON id.fieldID = f.fieldID "
-            f"JOIN itemDataValues iv ON id.valueID = iv.valueID "
-            f"WHERE id.itemID IN ({valid_ph})",
+        field_rows = self._batched_in_query(
+            conn,
+            "SELECT id.itemID, f.fieldName, iv.value FROM itemData id "
+            "JOIN fields f ON id.fieldID = f.fieldID "
+            "JOIN itemDataValues iv ON id.valueID = iv.valueID "
+            "WHERE id.itemID IN ({ph})",
             valid_ids,
-        ).fetchall()
+        )
         fields_map: dict[int, dict[str, str]] = {}
         for r in field_rows:
             fields_map.setdefault(r["itemID"], {})[r["fieldName"]] = r["value"]
 
         # Batch fetch creators
-        creator_rows = conn.execute(
-            f"SELECT ic.itemID, c.firstName, c.lastName, ct.creatorType "
-            f"FROM itemCreators ic "
-            f"JOIN creators c ON ic.creatorID = c.creatorID "
-            f"JOIN creatorTypes ct ON ic.creatorTypeID = ct.creatorTypeID "
-            f"WHERE ic.itemID IN ({valid_ph}) ORDER BY ic.itemID, ic.orderIndex",
+        creator_rows = self._batched_in_query(
+            conn,
+            "SELECT ic.itemID, c.firstName, c.lastName, ct.creatorType "
+            "FROM itemCreators ic "
+            "JOIN creators c ON ic.creatorID = c.creatorID "
+            "JOIN creatorTypes ct ON ic.creatorTypeID = ct.creatorTypeID "
+            "WHERE ic.itemID IN ({ph}) ORDER BY ic.itemID, ic.orderIndex",
             valid_ids,
-        ).fetchall()
+        )
         creators_map: dict[int, list[Creator]] = {}
         for r in creator_rows:
             creators_map.setdefault(r["itemID"], []).append(
@@ -973,23 +1057,23 @@ class ZoteroReader:
             )
 
         # Batch fetch tags
-        tag_rows = conn.execute(
-            f"SELECT it.itemID, t.name FROM itemTags it "
-            f"JOIN tags t ON it.tagID = t.tagID "
-            f"WHERE it.itemID IN ({valid_ph})",
+        tag_rows = self._batched_in_query(
+            conn,
+            "SELECT it.itemID, t.name FROM itemTags it JOIN tags t ON it.tagID = t.tagID WHERE it.itemID IN ({ph})",
             valid_ids,
-        ).fetchall()
+        )
         tags_map: dict[int, list[str]] = {}
         for r in tag_rows:
             tags_map.setdefault(r["itemID"], []).append(r["name"])
 
         # Batch fetch collections
-        coll_rows = conn.execute(
-            f"SELECT ci.itemID, c.key FROM collectionItems ci "
-            f"JOIN collections c ON ci.collectionID = c.collectionID "
-            f"WHERE ci.itemID IN ({valid_ph})",
+        coll_rows = self._batched_in_query(
+            conn,
+            "SELECT ci.itemID, c.key FROM collectionItems ci "
+            "JOIN collections c ON ci.collectionID = c.collectionID "
+            "WHERE ci.itemID IN ({ph})",
             valid_ids,
-        ).fetchall()
+        )
         colls_map: dict[int, list[str]] = {}
         for r in coll_rows:
             colls_map.setdefault(r["itemID"], []).append(r["key"])

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -379,8 +379,6 @@ def format_ask(question: str, evidence: list[dict], mode: str, output_json: bool
     if output_json:
         return _dump(envelope_ok(data, meta={"retrieved": len(evidence)}))
     if not evidence:
-        if output_json:
-            return _dump(envelope_error(code="not_found", message="No evidence found."))
         return "No evidence found."
     buf = StringIO()
     console = Console(file=buf, force_terminal=False, width=120)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -109,3 +109,20 @@ def test_cache_list_json(tmp_path):
         assert data[0]["preview"] == "Short text."
     finally:
         pdf_cache_module.DEFAULT_CACHE_PATH = old_default
+
+
+def test_config_profile_set_single_quoted(tmp_path):
+    """`profile set` must rewrite single-quoted profile lines: older save_config
+    wrote TOML literal strings, and a double-quote-only regex silently no-ops."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[default]\nprofile = 'default'\n\n"
+        "[profile.default]\ndata_dir = '/tmp/z1'\nlibrary_id = '1'\napi_key = 'a'\n\n"
+        "[profile.work]\ndata_dir = '/tmp/z2'\nlibrary_id = '2'\napi_key = 'b'\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["config", "profile", "set", "work", "--config-path", str(config_path)])
+    assert result.exit_code == 0
+    content = config_path.read_text()
+    assert 'profile = "work"' in content
+    assert "profile = 'default'" not in content

--- a/tests/test_cli_p1.py
+++ b/tests/test_cli_p1.py
@@ -57,9 +57,7 @@ def test_add_by_doi_resolver_404_falls_back(mock_writer_cls, mock_resolve):
     result = runner.invoke(main, ["add", "--doi", "10.1234/missing"], env=WRITE_ENV)
     assert result.exit_code == 0  # bare item is still created
     assert mock_writer.add_item.call_args.kwargs["extra_fields"] is None
-    assert "no record" in result.output.lower() or "no record" in result.stderr.lower() or True
-    # stderr capture is implementation-dependent in CliRunner; we just confirm
-    # the item was still created and the writer call did not receive metadata.
+    assert "no record" in result.stderr.lower()
 
 
 @patch("zotero_cli_cc.commands.add.resolve_doi")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
+import stat
 import sys
 from pathlib import Path
+
+import pytest
 
 from zotero_cli_cc.config import (
     AppConfig,
@@ -214,3 +217,25 @@ def test_embedding_config_is_configured():
 
     assert EmbeddingConfig(url="http://x", api_key="k", model="m").is_configured is True
     assert EmbeddingConfig(url="http://x", api_key="", model="m").is_configured is False
+
+
+def test_save_and_reload_with_special_chars(tmp_path):
+    """Apostrophes, quotes and backslashes must not corrupt the generated TOML."""
+    config_path = tmp_path / "config.toml"
+    cfg = AppConfig(
+        data_dir="/Users/o'brien/Zotero Data",
+        library_id="123",
+        api_key='key"with\\escapes',
+    )
+    save_config(cfg, config_path)
+    loaded = load_config(config_path)
+    assert loaded.data_dir == "/Users/o'brien/Zotero Data"
+    assert loaded.api_key == 'key"with\\escapes'
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions not applicable")
+def test_save_config_file_permissions(tmp_path):
+    """Config holds API keys — file must be owner read/write only."""
+    config_path = tmp_path / "config.toml"
+    save_config(AppConfig(api_key="secret"), config_path)
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -922,9 +922,11 @@ class TestMcpWriteErrorHandling:
         result = _handle_tag_remove(["K1"], ["t1"])
         assert result["results"][0]["error"] == "Item not found"
 
-    def test_add_error(self):
+    @patch("zotero_cli_cc.core.metadata_resolver.resolve_doi")
+    def test_add_error(self, mock_resolve):
         from zotero_cli_cc.mcp_server import _handle_add
 
+        mock_resolve.return_value = None  # Crossref miss → bare item, no network
         self.writer.add_item.side_effect = self.ZoteroWriteError("API error: Bad request")
         result = _handle_add(doi="10.1234/test", url=None)
         assert result["error"] == "API error: Bad request"

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -317,8 +317,10 @@ class TestTimeout:
 
 
 class TestWriteErrorInCommands:
+    @patch("zotero_cli_cc.commands.add.resolve_doi")
     @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
-    def test_add_write_error(self, mock_writer_cls):
+    def test_add_write_error(self, mock_writer_cls, mock_resolve):
+        mock_resolve.return_value = None  # Crossref miss → bare item, no network
         mock_writer = MagicMock()
         mock_writer_cls.return_value = mock_writer
         mock_writer.add_item.side_effect = ZoteroWriteError("API error: Bad request")

--- a/tests/test_pdf_cache.py
+++ b/tests/test_pdf_cache.py
@@ -1,4 +1,4 @@
-import time
+import os
 
 import pytest
 
@@ -27,8 +27,10 @@ def test_cache_invalidation_on_mtime_change(cache, tmp_path):
     pdf = tmp_path / "test.pdf"
     pdf.write_bytes(b"fake pdf v1")
     cache.put(pdf, "v1 text")
-    time.sleep(0.05)
     pdf.write_bytes(b"fake pdf v2")
+    # Bump mtime deterministically instead of sleeping for the fs timestamp to tick
+    st = pdf.stat()
+    os.utime(pdf, (st.st_atime, st.st_mtime + 10))
     assert cache.get(pdf) is None
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -217,3 +217,73 @@ class TestRelatedItems:
     def test_no_relations(self, reader: ZoteroReader):
         related = reader.get_related_items("DEEP003")
         assert isinstance(related, list)
+
+
+class TestUriEncodedDbPaths:
+    def test_db_path_with_uri_special_chars(self, tmp_path: Path, test_db_path: Path):
+        """Paths containing '?', '#' or '%' must not corrupt the SQLite URI."""
+        import shutil
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("'?' is not allowed in Windows filenames")
+        weird = tmp_path / "we?ir#d%dir"
+        weird.mkdir()
+        db = weird / "zotero.sqlite"
+        shutil.copy2(test_db_path, db)
+        with ZoteroReader(db) as r:
+            item = r.get_item("ATTN001")
+        assert item is not None
+        assert item.title == "Attention Is All You Need"
+
+
+class TestBatchedInQueries:
+    """Force tiny IN-clause batches and the Python-side sort fallback, and
+    verify results are identical to the default single-query paths."""
+
+    @pytest.mark.parametrize("sort", ["dateAdded", "dateModified", "title", "creator"])
+    def test_sorted_search_matches_unbatched(self, reader: ZoteroReader, monkeypatch, sort: str):
+        import zotero_cli_cc.core.reader as reader_mod
+
+        # Fixture matches two items with distinct sort keys — no tie ambiguity
+        baseline = reader.search("transformer", sort=sort, limit=100)
+        assert len(baseline.items) == 2
+
+        monkeypatch.setattr(reader_mod, "_IN_BATCH_SIZE", 1)
+        monkeypatch.setattr(reader_mod, "_SORT_IN_THRESHOLD", 0)
+        batched = reader.search("transformer", sort=sort, limit=100)
+
+        assert batched.total == baseline.total
+        assert [i.key for i in batched.items] == [i.key for i in baseline.items]
+
+    def test_item_type_filter_batched(self, reader: ZoteroReader, monkeypatch):
+        import zotero_cli_cc.core.reader as reader_mod
+
+        baseline = reader.search("transformer", item_type="journalArticle", limit=100)
+        monkeypatch.setattr(reader_mod, "_IN_BATCH_SIZE", 1)
+        batched = reader.search("transformer", item_type="journalArticle", limit=100)
+        assert [i.key for i in batched.items] == [i.key for i in baseline.items]
+
+    def test_find_duplicates_batched(self, reader: ZoteroReader, monkeypatch):
+        import zotero_cli_cc.core.reader as reader_mod
+
+        baseline = reader.find_duplicates()
+        monkeypatch.setattr(reader_mod, "_IN_BATCH_SIZE", 1)
+        batched = reader.find_duplicates()
+
+        def group_keys(groups):
+            return {frozenset(i.key for i in g.items) for g in groups}
+
+        assert group_keys(batched) == group_keys(baseline)
+
+    def test_in_batches_helper(self):
+        from zotero_cli_cc.core.reader import _in_batches
+
+        assert list(_in_batches([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+        assert list(_in_batches([], 3)) == []
+
+    def test_nocase_key_folds_ascii_only(self):
+        from zotero_cli_cc.core.reader import _nocase_key
+
+        assert _nocase_key("AbC-Z") == "abc-z"
+        assert _nocase_key("Äbc") == "Äbc"  # SQLite NOCASE folds ASCII only


### PR DESCRIPTION
## Summary

Findings from a full repo review, implemented and verified:

**Bug fixes**
- `config profile set`: match both TOML quote styles — previously a silent no-op on configs written by `save_config` (single quotes)
- `save_config`: emit escaped double-quoted TOML (an apostrophe in `data_dir` corrupted the file and crashed every later `load_config`); `chmod 0600` on config.toml / `0700` on the config dir (they hold API keys)
- `update-status`: stdout stays a parseable JSON envelope in `--json` mode (prose and `SYNC_REMINDER` moved to stderr; scan results and empty states wrapped in `envelope_ok`)
- `pdf`: annotations/references/tables/outline JSON output routed through `envelope_ok` (was raw `json.dumps` / bare `[]`)
- `reader`: percent-encode the SQLite URI — paths containing `?`, `#` or `%` corrupted `file:...?mode=ro&immutable=1`; batch all library-scale `IN (?,…)` clauses against `SQLITE_MAX_VARIABLE_NUMBER`, with a Python-side sort fallback for >30k-id sorted queries
- `open`: `os.startfile` on Windows instead of `shell=True` (cmd.exe metacharacter injection via attachment filenames)
- `pdf_extractor`: MinerU split chunks go to a `TemporaryDirectory` instead of next to the source PDF inside Zotero storage
- `workspace index`: reader opened after `RagIndex` so a failure cannot leak the connection; `formatter`: remove unreachable branch in `format_ask`

**Tests**
- The two tests making live Crossref calls now mock `resolve_doi` (they failed behind proxies/offline)
- The `or True` assertion is real again; `time.sleep` → `os.utime` in the cache test
- 13 new regression tests: config escaping round-trip, `0600` permissions, single-quoted `profile set`, URI-special-char DB paths, and forced-batching equivalence (`_IN_BATCH_SIZE=1`, `_SORT_IN_THRESHOLD=0`) proving batched/sorted results match the single-query paths

**CI / hygiene**
- `uv sync --locked` (stale lockfile now fails CI), uv cache enabled, new `build` job asserting bridge assets are bundled in the wheel (verified locally)
- `.gitignore`: `*.log`, `.mypy_cache/`, `.ruff_cache/`, `htmlcov/`

## Test plan
- `ruff check`, `ruff format --check`, `mypy` (67 files): all clean
- `pytest`: **812 passed, 1 skipped, 0 failed** (was 798 passed / 2 failed)
- `uv build` + wheel contents verified locally
- CLI smoke-tested against the fixture DB (JSON envelope intact)