### PR TITLE
chore: rename PyPI distribution to zotero-cli-ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **PyPI distribution renamed** `zotero-cli-cc` → `zotero-cli-ai`. Install or
+  upgrade with `uv tool install zotero-cli-ai` (or `pipx`/`pip`). The `zot`
+  command, the `zotero_cli_cc` Python module, the Zotero bridge plugin ID, and
+  all config/cache paths are unchanged. `zotero-cli-cc` on PyPI receives no
+  further updates; `zotero-cli` is an unrelated older project.
+- Project branding unified as "zotero-cli — A Zotero CLI for Any AI Agent"
+  (was positioned as Claude Code-only).
+
 ## [0.10.0] - 2026-07-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-`zotero-cli-cc` (binary: `zot`) — a Zotero CLI built for Claude Code / agent use. It combines **direct local SQLite reads** with **Zotero Web API writes**, and exposes the same surface via an MCP server. The CLI follows an agent-native contract documented in `docs/agent-interface.md` (stable JSON envelope, typed exit codes, `zot schema` introspection, `--dry-run`, `--idempotency-key`, NDJSON streaming).
+`zotero-cli` (binary: `zot`; PyPI package: `zotero-cli-ai`) — a Zotero CLI for any AI agent. It combines **direct local SQLite reads** with **Zotero Web API writes**, and exposes the same surface via an MCP server. The CLI follows an agent-native contract documented in `docs/agent-interface.md` (stable JSON envelope, typed exit codes, `zot schema` introspection, `--dry-run`, `--idempotency-key`, NDJSON streaming).
 
 ## Common commands
 
@@ -65,7 +65,7 @@ This split is load-bearing for the project's value proposition. Preserve it when
 
 ### MCP server (`mcp_server.py`)
 
-Exposes the CLI functionality as MCP tools (`zot mcp serve`). When adding a new CLI command that should also be agent-callable via MCP clients, mirror it here. The MCP surface is optional (`pip install zotero-cli-cc[mcp]`).
+Exposes the CLI functionality as MCP tools (`zot mcp serve`). When adding a new CLI command that should also be agent-callable via MCP clients, mirror it here. The MCP surface is optional (`pip install zotero-cli-ai[mcp]`).
 
 ### Config & profiles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to zotero-cli-cc
+# Contributing to zotero-cli
 
 Thanks for your interest in contributing!
 
 ## License of contributions
 
-zotero-cli-cc is **dual-licensed** under the GNU AGPL-3.0-or-later and a
+zotero-cli is **dual-licensed** under the GNU AGPL-3.0-or-later and a
 separate commercial license (see [LICENSE](LICENSE) and
 [LICENSE-COMMERCIAL](LICENSE-COMMERCIAL)).
 

--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,7 +1,7 @@
-Commercial License — zotero-cli-cc
+Commercial License — zotero-cli
 ===================================
 
-zotero-cli-cc is dual-licensed.
+zotero-cli is dual-licensed.
 
 1. Open-source license
 ----------------------
@@ -14,7 +14,7 @@ version.
 2. Commercial license
 ----------------------
 If the AGPL's obligations are not suitable for your use — for example, embedding
-zotero-cli-cc in a closed-source or commercial product without disclosing your
+zotero-cli in a closed-source or commercial product without disclosing your
 own source — a separate commercial license is available from the copyright
 holder. The commercial license grants use of this software without the AGPL's
 copyleft and network-source-disclosure requirements, under negotiated terms.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/v/zotero-cli-cc?color=blue" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/v/zotero-cli-ai?color=blue" alt="PyPI version"></a>
   <a href="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-cc" alt="Python versions"></a>
+  <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-ai" alt="Python versions"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue" alt="License"></a>
   <a href="https://agents365-ai.github.io/zotero-cli/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue" alt="Docs"></a>
 </p>
@@ -31,12 +31,12 @@
 ## Install
 
 ```bash
-uv tool install zotero-cli-cc      # recommended
-pipx install zotero-cli-cc         # or
-pip install zotero-cli-cc          # or
+uv tool install zotero-cli-ai      # recommended
+pipx install zotero-cli-ai         # or
+pip install zotero-cli-ai          # or
 ```
 
-> **Note:** the PyPI package is `zotero-cli-cc` (`zotero-cli` is an unrelated older project); the installed command is `zot`.
+> **Note:** the PyPI package is `zotero-cli-ai` (`zotero-cli` is an unrelated older project); the installed command is `zot`.
 
 ## 60-second quickstart
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 <p align="center">
   <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/v/zotero-cli-ai?color=blue" alt="PyPI version"></a>
-  <a href="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/Agents365-ai/zotero-cli-ai/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-ai" alt="Python versions"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue" alt="License"></a>
-  <a href="https://agents365-ai.github.io/zotero-cli/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue" alt="Docs"></a>
+  <a href="https://agents365-ai.github.io/zotero-cli-ai/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue" alt="Docs"></a>
 </p>
 
-[中文](README_CN.md) | [Documentation](https://agents365-ai.github.io/zotero-cli/)
+[中文](README_CN.md) | [Documentation](https://agents365-ai.github.io/zotero-cli-ai/)
 
 `zotero-cli` is a Zotero CLI for any AI agent.
 
@@ -65,25 +65,25 @@ When stdout is not a TTY, `zot` automatically emits a stable JSON envelope so ag
 
 ## Documentation
 
-Full docs live at **<https://agents365-ai.github.io/zotero-cli/>**.
+Full docs live at **<https://agents365-ai.github.io/zotero-cli-ai/>**.
 
 | Topic | Link |
 | --- | --- |
-| Installation & setup | [Getting started](https://agents365-ai.github.io/zotero-cli/getting-started/installation/) |
-| Search, list, read | [Search guide](https://agents365-ai.github.io/zotero-cli/guide/search/) |
-| Notes, tags, citations | [Notes & tags](https://agents365-ai.github.io/zotero-cli/guide/notes-tags/), [Citations](https://agents365-ai.github.io/zotero-cli/guide/citations/) |
-| Add / update / delete items | [Item management](https://agents365-ai.github.io/zotero-cli/guide/item-management/) |
-| Collections | [Collections](https://agents365-ai.github.io/zotero-cli/guide/collections/) |
-| Workspaces + RAG | [Workspaces](https://agents365-ai.github.io/zotero-cli/guide/workspace/) |
-| PDF extraction | [PDF](https://agents365-ai.github.io/zotero-cli/guide/pdf/) |
-| Preprint → published | [update-status](https://agents365-ai.github.io/zotero-cli/guide/update-status/) |
-| MCP setup & tools | [MCP](https://agents365-ai.github.io/zotero-cli/mcp/setup/) |
-| Full CLI reference | [CLI reference](https://agents365-ai.github.io/zotero-cli/reference/cli/) |
+| Installation & setup | [Getting started](https://agents365-ai.github.io/zotero-cli-ai/getting-started/installation/) |
+| Search, list, read | [Search guide](https://agents365-ai.github.io/zotero-cli-ai/guide/search/) |
+| Notes, tags, citations | [Notes & tags](https://agents365-ai.github.io/zotero-cli-ai/guide/notes-tags/), [Citations](https://agents365-ai.github.io/zotero-cli-ai/guide/citations/) |
+| Add / update / delete items | [Item management](https://agents365-ai.github.io/zotero-cli-ai/guide/item-management/) |
+| Collections | [Collections](https://agents365-ai.github.io/zotero-cli-ai/guide/collections/) |
+| Workspaces + RAG | [Workspaces](https://agents365-ai.github.io/zotero-cli-ai/guide/workspace/) |
+| PDF extraction | [PDF](https://agents365-ai.github.io/zotero-cli-ai/guide/pdf/) |
+| Preprint → published | [update-status](https://agents365-ai.github.io/zotero-cli-ai/guide/update-status/) |
+| MCP setup & tools | [MCP](https://agents365-ai.github.io/zotero-cli-ai/mcp/setup/) |
+| Full CLI reference | [CLI reference](https://agents365-ai.github.io/zotero-cli-ai/reference/cli/) |
 | Agent contract (envelope, exit codes, schema) | [`docs/agent-interface.md`](docs/agent-interface.md) |
-| Comparison with similar tools | [Comparison](https://agents365-ai.github.io/zotero-cli/comparison/) |
+| Comparison with similar tools | [Comparison](https://agents365-ai.github.io/zotero-cli-ai/comparison/) |
 | Roadmap | [`ROADMAP.md`](ROADMAP.md) |
 
-**Why zotero-cli?** The only actively maintained Python CLI that reads Zotero's local SQLite database directly, with a clean read/write split: SQLite for fast offline reads, Web API for safe writes that Zotero stays aware of. See the [comparison page](https://agents365-ai.github.io/zotero-cli/comparison/) for a feature-by-feature breakdown against similar tools.
+**Why zotero-cli?** The only actively maintained Python CLI that reads Zotero's local SQLite database directly, with a clean read/write split: SQLite for fast offline reads, Web API for safe writes that Zotero stays aware of. See the [comparison page](https://agents365-ai.github.io/zotero-cli-ai/comparison/) for a feature-by-feature breakdown against similar tools.
 
 ## Support
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,13 +6,13 @@
 
 <p align="center">
   <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/v/zotero-cli-ai?color=blue" alt="PyPI version"></a>
-  <a href="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/Agents365-ai/zotero-cli-ai/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-ai" alt="Python versions"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue" alt="License"></a>
-  <a href="https://agents365-ai.github.io/zotero-cli/zh/"><img src="https://img.shields.io/badge/文档-GitHub%20Pages-blue" alt="文档"></a>
+  <a href="https://agents365-ai.github.io/zotero-cli-ai/zh/"><img src="https://img.shields.io/badge/文档-GitHub%20Pages-blue" alt="文档"></a>
 </p>
 
-[English](README.md) | [文档](https://agents365-ai.github.io/zotero-cli/zh/)
+[English](README.md) | [文档](https://agents365-ai.github.io/zotero-cli-ai/zh/)
 
 `zotero-cli` 是一个适配任意 AI Agent 的 Zotero 命令行工具。
 
@@ -65,25 +65,25 @@ cp -r skill/zotero-cli ~/.claude/skills/
 
 ## 文档
 
-完整文档：**<https://agents365-ai.github.io/zotero-cli/zh/>**
+完整文档：**<https://agents365-ai.github.io/zotero-cli-ai/zh/>**
 
 | 主题 | 链接 |
 | --- | --- |
-| 安装与配置 | [快速开始](https://agents365-ai.github.io/zotero-cli/zh/getting-started/installation/) |
-| 搜索、列表、阅读 | [搜索指南](https://agents365-ai.github.io/zotero-cli/zh/guide/search/) |
-| 笔记、标签、引用 | [笔记与标签](https://agents365-ai.github.io/zotero-cli/zh/guide/notes-tags/)、[引用导出](https://agents365-ai.github.io/zotero-cli/zh/guide/citations/) |
-| 增 / 改 / 删条目 | [条目管理](https://agents365-ai.github.io/zotero-cli/zh/guide/item-management/) |
-| 分类（Collection） | [Collections](https://agents365-ai.github.io/zotero-cli/zh/guide/collections/) |
-| 工作空间 + RAG | [Workspace](https://agents365-ai.github.io/zotero-cli/zh/guide/workspace/) |
-| PDF 提取 | [PDF](https://agents365-ai.github.io/zotero-cli/zh/guide/pdf/) |
-| 预印本 → 已发表 | [update-status](https://agents365-ai.github.io/zotero-cli/zh/guide/update-status/) |
-| MCP 配置与工具 | [MCP](https://agents365-ai.github.io/zotero-cli/zh/mcp/setup/) |
-| 完整 CLI 参考 | [CLI Reference](https://agents365-ai.github.io/zotero-cli/zh/reference/cli/) |
+| 安装与配置 | [快速开始](https://agents365-ai.github.io/zotero-cli-ai/zh/getting-started/installation/) |
+| 搜索、列表、阅读 | [搜索指南](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/search/) |
+| 笔记、标签、引用 | [笔记与标签](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/notes-tags/)、[引用导出](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/citations/) |
+| 增 / 改 / 删条目 | [条目管理](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/item-management/) |
+| 分类（Collection） | [Collections](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/collections/) |
+| 工作空间 + RAG | [Workspace](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/workspace/) |
+| PDF 提取 | [PDF](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/pdf/) |
+| 预印本 → 已发表 | [update-status](https://agents365-ai.github.io/zotero-cli-ai/zh/guide/update-status/) |
+| MCP 配置与工具 | [MCP](https://agents365-ai.github.io/zotero-cli-ai/zh/mcp/setup/) |
+| 完整 CLI 参考 | [CLI Reference](https://agents365-ai.github.io/zotero-cli-ai/zh/reference/cli/) |
 | Agent 契约（envelope、退出码、schema） | [`docs/agent-interface.md`](docs/agent-interface.md) |
-| 同类工具对比 | [Comparison](https://agents365-ai.github.io/zotero-cli/zh/comparison/) |
+| 同类工具对比 | [Comparison](https://agents365-ai.github.io/zotero-cli-ai/zh/comparison/) |
 | 开发路线图 | [`ROADMAP.md`](ROADMAP.md) |
 
-**为什么选 zotero-cli？** 当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI；读写分离架构 —— SQLite 提供快速离线读，Web API 提供让 Zotero 感知的安全写。完整功能对比见[对比页面](https://agents365-ai.github.io/zotero-cli/zh/comparison/)。
+**为什么选 zotero-cli？** 当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI；读写分离架构 —— SQLite 提供快速离线读，Web API 提供让 Zotero 感知的安全写。完整功能对比见[对比页面](https://agents365-ai.github.io/zotero-cli-ai/zh/comparison/)。
 
 ## 社区
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,9 +5,9 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/v/zotero-cli-cc?color=blue" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/v/zotero-cli-ai?color=blue" alt="PyPI version"></a>
   <a href="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml"><img src="https://github.com/Agents365-ai/zotero-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://pypi.org/project/zotero-cli-cc/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-cc" alt="Python versions"></a>
+  <a href="https://pypi.org/project/zotero-cli-ai/"><img src="https://img.shields.io/pypi/pyversions/zotero-cli-ai" alt="Python versions"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue" alt="License"></a>
   <a href="https://agents365-ai.github.io/zotero-cli/zh/"><img src="https://img.shields.io/badge/文档-GitHub%20Pages-blue" alt="文档"></a>
 </p>
@@ -31,12 +31,12 @@
 ## 安装
 
 ```bash
-uv tool install zotero-cli-cc      # 推荐
-pipx install zotero-cli-cc         # 或者
-pip install zotero-cli-cc          # 或者
+uv tool install zotero-cli-ai      # 推荐
+pipx install zotero-cli-ai         # 或者
+pip install zotero-cli-ai          # 或者
 ```
 
-> **注意：** PyPI 包名为 `zotero-cli-cc`（`zotero-cli` 是无关的早期项目），安装后的命令为 `zot`。
+> **注意：** PyPI 包名为 `zotero-cli-ai`（`zotero-cli` 是无关的早期项目），安装后的命令为 `zot`。
 
 ## 60 秒上手
 

--- a/docs/en/comparison.md
+++ b/docs/en/comparison.md
@@ -1,6 +1,6 @@
 # Comparison with Similar Tools
 
-| Feature | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
+| Feature | **zotero-cli-ai** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Direct SQLite Read** | **✅** | ❌ | ❌ (cache only) | ❌ | ❌ | ❌ (plugin) | ✅ |
 | **Offline Read** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -23,7 +23,7 @@
 | **Language** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
 | **Active** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
 
-## Why zotero-cli-cc?
+## Why zotero-cli-ai?
 
 > **The only actively maintained Python CLI that reads Zotero's local SQLite database directly.**
 

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -10,19 +10,19 @@
 === "uv (recommended)"
 
     ```bash
-    uv tool install zotero-cli-cc
+    uv tool install zotero-cli-ai
     ```
 
 === "pipx"
 
     ```bash
-    pipx install zotero-cli-cc
+    pipx install zotero-cli-ai
     ```
 
 === "pip"
 
     ```bash
-    pip install zotero-cli-cc
+    pip install zotero-cli-ai
     ```
 
 ## Upgrade
@@ -30,27 +30,27 @@
 === "uv"
 
     ```bash
-    uv tool upgrade zotero-cli-cc
+    uv tool upgrade zotero-cli-ai
     ```
 
 === "pipx"
 
     ```bash
-    pipx upgrade zotero-cli-cc
+    pipx upgrade zotero-cli-ai
     ```
 
 === "pip"
 
     ```bash
-    pip install -U zotero-cli-cc
+    pip install -U zotero-cli-ai
     ```
 
 ## MCP Support
 
-To use zotero-cli-cc as an MCP server (for Claude Desktop, Cursor, LM Studio):
+To use zotero-cli-ai as an MCP server (for Claude Desktop, Cursor, LM Studio):
 
 ```bash
-pip install zotero-cli-cc[mcp]
+pip install zotero-cli-ai[mcp]
 ```
 
 ## Verify Installation

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -43,7 +43,7 @@ This is what Claude Code uses behind the scenes when you ask it about papers.
 Install the zotero-cli skill so Claude Code automatically recognizes literature-related requests:
 
 ```bash
-cp -r skill/zotero-cli-cc ~/.claude/skills/
+cp -r skill/zotero-cli ~/.claude/skills/
 ```
 
 Then in any Claude Code session, use natural language:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,12 +4,12 @@ hide:
 ---
 
 <p align="center">
-  <img src="assets/banner_official.png" alt="zotero-cli-cc banner" width="720">
+  <img src="assets/banner_official.png" alt="zotero-cli banner" width="720">
 </p>
 
 # zot — A Zotero CLI for Any AI Agent
 
-`zotero-cli-cc` is a Zotero CLI for any AI agent.
+`zotero-cli` is a Zotero CLI for any AI agent.
 
 **Core Features:**
 

--- a/docs/en/mcp/claude-code.md
+++ b/docs/en/mcp/claude-code.md
@@ -9,10 +9,10 @@
 
 ## Install the Skill
 
-Copy the zotero-cli-cc skill so Claude Code automatically recognizes literature-related requests:
+Copy the zotero-cli skill so Claude Code automatically recognizes literature-related requests:
 
 ```bash
-cp -r skill/zotero-cli-cc ~/.claude/skills/
+cp -r skill/zotero-cli ~/.claude/skills/
 ```
 
 ## How It Works

--- a/docs/en/mcp/setup.md
+++ b/docs/en/mcp/setup.md
@@ -1,11 +1,11 @@
 # MCP Server Setup
 
-zotero-cli-cc supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) and can be used in MCP-compatible AI clients.
+zotero-cli-ai supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) and can be used in MCP-compatible AI clients.
 
 ## Install MCP Support
 
 ```bash
-pip install zotero-cli-cc[mcp]
+pip install zotero-cli-ai[mcp]
 ```
 
 ## Start the Server

--- a/docs/zh/comparison.md
+++ b/docs/zh/comparison.md
@@ -1,6 +1,6 @@
 # 同类工具对比
 
-| 特性 | **zotero-cli-cc** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
+| 特性 | **zotero-cli-ai** | [pyzotero-cli](https://github.com/chriscarrollsmith/pyzotero-cli) | [zotero-cli](https://github.com/jbaiter/zotero-cli) | [zotero-cli-tool](https://github.com/dhondta/zotero-cli) | [zotero-mcp](https://github.com/54yyyu/zotero-mcp) | [cookjohn/zotero-mcp](https://github.com/cookjohn/zotero-mcp) | [ZoteroBridge](https://github.com/Combjellyshen/ZoteroBridge) |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **直读 SQLite** | **✅** | ❌ | ❌（仅缓存） | ❌ | ❌ | ❌（插件） | ✅ |
 | **离线读** | **✅** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -23,7 +23,7 @@
 | **语言** | Python | Python | Python | Python | Python | TypeScript | TypeScript |
 | **活跃度** | ✅ 2026 | ✅ 2025 | ❌ 2024 | ✅ 2026 | ✅ 2026 | ✅ 2026 | ✅ 2026 |
 
-## 为什么选 zotero-cli-cc？
+## 为什么选 zotero-cli-ai？
 
 > **当前唯一仍在维护、直接读取 Zotero 本地 SQLite 的 Python CLI。**
 

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -10,19 +10,19 @@
 === "uv（推荐）"
 
     ```bash
-    uv tool install zotero-cli-cc
+    uv tool install zotero-cli-ai
     ```
 
 === "pipx"
 
     ```bash
-    pipx install zotero-cli-cc
+    pipx install zotero-cli-ai
     ```
 
 === "pip"
 
     ```bash
-    pip install zotero-cli-cc
+    pip install zotero-cli-ai
     ```
 
 ## 升级
@@ -30,27 +30,27 @@
 === "uv"
 
     ```bash
-    uv tool upgrade zotero-cli-cc
+    uv tool upgrade zotero-cli-ai
     ```
 
 === "pipx"
 
     ```bash
-    pipx upgrade zotero-cli-cc
+    pipx upgrade zotero-cli-ai
     ```
 
 === "pip"
 
     ```bash
-    pip install -U zotero-cli-cc
+    pip install -U zotero-cli-ai
     ```
 
 ## MCP 支持
 
-如需将 zotero-cli-cc 用作 MCP 服务器（适用于 Claude Desktop、Cursor、LM Studio）：
+如需将 zotero-cli-ai 用作 MCP 服务器（适用于 Claude Desktop、Cursor、LM Studio）：
 
 ```bash
-pip install zotero-cli-cc[mcp]
+pip install zotero-cli-ai[mcp]
 ```
 
 ## 验证安装

--- a/docs/zh/getting-started/quickstart.md
+++ b/docs/zh/getting-started/quickstart.md
@@ -43,7 +43,7 @@ zot --json search "single cell RNA"
 安装 zotero-cli skill，让 Claude Code 自动识别文献相关请求：
 
 ```bash
-cp -r skill/zotero-cli-cc ~/.claude/skills/
+cp -r skill/zotero-cli ~/.claude/skills/
 ```
 
 然后在任何 Claude Code 会话中使用自然语言：

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -4,12 +4,12 @@ hide:
 ---
 
 <p align="center">
-  <img src="../assets/banner_official.png" alt="zotero-cli-cc banner" width="720">
+  <img src="../assets/banner_official.png" alt="zotero-cli banner" width="720">
 </p>
 
 # zot — 适配任意 AI Agent 的 Zotero 命令行工具
 
-`zotero-cli-cc` 是一个适配任意 AI Agent 的 Zotero CLI 工具。
+`zotero-cli` 是一个适配任意 AI Agent 的 Zotero CLI 工具。
 
 **核心特性：**
 

--- a/docs/zh/mcp/claude-code.md
+++ b/docs/zh/mcp/claude-code.md
@@ -8,10 +8,10 @@
 
 ## 安装 Skill
 
-复制 zotero-cli-cc skill，让 Claude Code 自动识别文献相关请求：
+复制 zotero-cli skill，让 Claude Code 自动识别文献相关请求：
 
 ```bash
-cp -r skill/zotero-cli-cc ~/.claude/skills/
+cp -r skill/zotero-cli ~/.claude/skills/
 ```
 
 ## 工作原理

--- a/docs/zh/mcp/setup.md
+++ b/docs/zh/mcp/setup.md
@@ -1,11 +1,11 @@
 # MCP 服务器配置
 
-zotero-cli-cc 支持 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)，可在兼容 MCP 的 AI 客户端中使用。
+zotero-cli-ai 支持 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)，可在兼容 MCP 的 AI 客户端中使用。
 
 ## 安装 MCP 支持
 
 ```bash
-pip install zotero-cli-cc[mcp]
+pip install zotero-cli-ai[mcp]
 ```
 
 ## 启动服务器

--- a/extension/zot-cli-bridge/README.md
+++ b/extension/zot-cli-bridge/README.md
@@ -43,7 +43,7 @@ zot bridge status        # verify -> Bridge OK
 ### Manual
 
 1. Download the latest `zot-cli-bridge.xpi` from the
-   [Releases page](https://github.com/Agents365-ai/zotero-cli/releases)
+   [Releases page](https://github.com/Agents365-ai/zotero-cli-ai/releases)
    (or build it locally — see below).
 2. In Zotero: **Tools → Plugins → ⚙ → Install plugin from file…**, pick the
    `.xpi`, restart Zotero.

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.4.0",
   "description": "Exposes Zotero Find Full Text, attachment rename, and local file import over the local HTTP server for the zot CLI.",
   "author": "Agents365-ai",
-  "homepage_url": "https://github.com/Agents365-ai/zotero-cli",
+  "homepage_url": "https://github.com/Agents365-ai/zotero-cli-ai",
   "icons": {
     "48": "icon.png",
     "96": "icon.png"
@@ -12,7 +12,7 @@
   "applications": {
     "zotero": {
       "id": "zot-cli-bridge@zotero-cli-cc.org",
-      "update_url": "https://github.com/Agents365-ai/zotero-cli/releases/download/bridge/update.json",
+      "update_url": "https://github.com/Agents365-ai/zotero-cli-ai/releases/download/bridge/update.json",
       "strict_min_version": "7.999",
       "strict_max_version": "9.*"
     }

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -3,8 +3,8 @@
   "name": "Zot CLI Bridge",
   "version": "0.4.0",
   "description": "Exposes Zotero Find Full Text, attachment rename, and local file import over the local HTTP server for the zot CLI.",
-  "author": "zotero-cli-cc",
-  "homepage_url": "https://github.com/Agents365-ai/zotero-cli-cc",
+  "author": "Agents365-ai",
+  "homepage_url": "https://github.com/Agents365-ai/zotero-cli",
   "icons": {
     "48": "icon.png",
     "96": "icon.png"
@@ -12,7 +12,7 @@
   "applications": {
     "zotero": {
       "id": "zot-cli-bridge@zotero-cli-cc.org",
-      "update_url": "https://github.com/Agents365-ai/zotero-cli-cc/releases/download/bridge/update.json",
+      "update_url": "https://github.com/Agents365-ai/zotero-cli/releases/download/bridge/update.json",
       "strict_min_version": "7.999",
       "strict_max_version": "9.*"
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: zot — Zotero CLI for Any AI Agent
-site_url: https://agents365-ai.github.io/zotero-cli
-repo_url: https://github.com/Agents365-ai/zotero-cli
-repo_name: Agents365-ai/zotero-cli
+site_url: https://agents365-ai.github.io/zotero-cli-ai
+repo_url: https://github.com/Agents365-ai/zotero-cli-ai
+repo_name: Agents365-ai/zotero-cli-ai
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "zotero-cli-cc"
+name = "zotero-cli-ai"
 version = "0.10.0"
 description = "Zotero CLI for any AI agent — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"

--- a/src/zotero_cli_cc/__init__.py
+++ b/src/zotero_cli_cc/__init__.py
@@ -1,9 +1,9 @@
-"""zotero-cli-cc: Zotero CLI for any AI agent."""
+"""zotero-cli-ai: Zotero CLI for any AI agent."""
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 try:
-    __version__ = _pkg_version("zotero-cli-cc")
+    __version__ = _pkg_version("zotero-cli-ai")
 except PackageNotFoundError:  # running from a source tree without install
     __version__ = "0.0.0+unknown"

--- a/src/zotero_cli_cc/commands/mcp.py
+++ b/src/zotero_cli_cc/commands/mcp.py
@@ -18,7 +18,7 @@ def serve_cmd() -> None:
         from zotero_cli_cc.mcp_server import mcp as mcp_server
     except ImportError:
         click.echo(
-            "Error: MCP support not installed.\nInstall with: pip install zotero-cli-cc[mcp]",
+            "Error: MCP support not installed.\nInstall with: pip install zotero-cli-ai[mcp]",
             err=True,
         )
         raise SystemExit(1)

--- a/src/zotero_cli_cc/commands/pdf.py
+++ b/src/zotero_cli_cc/commands/pdf.py
@@ -199,7 +199,7 @@ def pdf_cmd(
                     "runtime_error",
                     str(e),
                     output_json=json_out,
-                    hint="Install the pdfplumber extra: pip install 'zotero-cli-cc[pdfplumber]'",
+                    hint="Install the pdfplumber extra: pip install 'zotero-cli-ai[pdfplumber]'",
                     context="pdf",
                 )
             if not extracted:

--- a/src/zotero_cli_cc/core/bridge_install.py
+++ b/src/zotero_cli_cc/core/bridge_install.py
@@ -51,7 +51,7 @@ def bridge_source_dir() -> Path:
         return candidate
 
     raise BridgeInstallError(
-        "Cannot locate the bundled zot-cli-bridge plugin files. Reinstall zotero-cli-cc.",
+        "Cannot locate the bundled zot-cli-bridge plugin files. Reinstall zotero-cli-ai.",
         code="bridge_error",
     )
 
@@ -83,7 +83,7 @@ def build_xpi(dest: Path | None = None, source_dir: Path | None = None) -> Path:
     missing = [f for f in _PLUGIN_FILES if not (source_dir / f).exists()]
     if missing:
         raise BridgeInstallError(
-            f"Plugin assets incomplete (missing {', '.join(missing)}). Reinstall zotero-cli-cc.",
+            f"Plugin assets incomplete (missing {', '.join(missing)}). Reinstall zotero-cli-ai.",
             code="bridge_error",
         )
 

--- a/src/zotero_cli_cc/core/metadata_resolver.py
+++ b/src/zotero_cli_cc/core/metadata_resolver.py
@@ -22,7 +22,7 @@ import httpx
 
 CROSSREF_API_BASE = "https://api.crossref.org/works"
 REQUEST_TIMEOUT = 15.0
-USER_AGENT_BASE = "zotero-cli-ai (https://github.com/Agents365-ai/zotero-cli)"
+USER_AGENT_BASE = "zotero-cli-ai (https://github.com/Agents365-ai/zotero-cli-ai)"
 
 
 class MetadataResolveError(Exception):

--- a/src/zotero_cli_cc/core/metadata_resolver.py
+++ b/src/zotero_cli_cc/core/metadata_resolver.py
@@ -22,7 +22,7 @@ import httpx
 
 CROSSREF_API_BASE = "https://api.crossref.org/works"
 REQUEST_TIMEOUT = 15.0
-USER_AGENT_BASE = "zotero-cli-cc (https://github.com/Agents365-ai/zotero-cli-cc)"
+USER_AGENT_BASE = "zotero-cli-ai (https://github.com/Agents365-ai/zotero-cli)"
 
 
 class MetadataResolveError(Exception):

--- a/src/zotero_cli_cc/core/pdf_extractor.py
+++ b/src/zotero_cli_cc/core/pdf_extractor.py
@@ -34,7 +34,7 @@ def _import_pymupdf() -> Any:
     except ImportError as e:
         raise PdfExtractionError(
             "The 'pymupdf' extractor requires the optional dependency. "
-            "Install it with: pip install 'zotero-cli-cc[pymupdf]'"
+            "Install it with: pip install 'zotero-cli-ai[pymupdf]'"
         ) from e
     return pymupdf
 
@@ -105,7 +105,7 @@ class BasePdfExtractor(ABC):
         """
         raise PdfExtractionError(
             f"table extraction is not supported by the '{self.name()}' extractor; "
-            "use the 'pdfplumber' extractor (pip install 'zotero-cli-cc[pdfplumber]')"
+            "use the 'pdfplumber' extractor (pip install 'zotero-cli-ai[pdfplumber]')"
         )
 
 
@@ -295,7 +295,7 @@ def _import_pdfplumber() -> Any:
     except ImportError as e:
         raise PdfExtractionError(
             "The 'pdfplumber' extractor requires the optional dependency. "
-            "Install it with: pip install 'zotero-cli-cc[pdfplumber]'"
+            "Install it with: pip install 'zotero-cli-ai[pdfplumber]'"
         ) from e
     return pdfplumber
 

--- a/src/zotero_cli_cc/core/version_check.py
+++ b/src/zotero_cli_cc/core/version_check.py
@@ -1,4 +1,4 @@
-"""Check PyPI for newer versions of zotero-cli-cc."""
+"""Check PyPI for newer versions of zotero-cli-ai."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from urllib.request import urlopen
 _CACHE_DIR = Path.home() / ".config" / "zot"
 _CACHE_FILE = _CACHE_DIR / ".version_check"
 _CHECK_INTERVAL = 86400  # 24 hours
-_PYPI_URL = "https://pypi.org/pypi/zotero-cli-cc/json"
+_PYPI_URL = "https://pypi.org/pypi/zotero-cli-ai/json"
 _TIMEOUT = 3  # seconds
 
 
@@ -28,10 +28,10 @@ def upgrade_command(executable: str | None = None) -> str:
     """
     exe = (executable if executable is not None else sys.executable).replace("\\", "/")
     if "/uv/tools/" in exe:
-        return "uv tool upgrade zotero-cli-cc"
+        return "uv tool upgrade zotero-cli-ai"
     if "/pipx/venvs/" in exe:
-        return "pipx upgrade zotero-cli-cc"
-    return "pip install -U zotero-cli-cc"
+        return "pipx upgrade zotero-cli-ai"
+    return "pip install -U zotero-cli-ai"
 
 
 def check_for_update(current_version: str) -> str | None:

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -288,7 +288,7 @@ def _handle_tables(key: str, library: str = "user") -> dict:
         return {
             "error": str(e),
             "context": "tables",
-            "hint": "Install the pdfplumber extra: pip install 'zotero-cli-cc[pdfplumber]'",
+            "hint": "Install the pdfplumber extra: pip install 'zotero-cli-ai[pdfplumber]'",
         }
     return {"key": key, "tables": tables, "total": len(tables)}
 

--- a/tests/test_metadata_resolver.py
+++ b/tests/test_metadata_resolver.py
@@ -115,7 +115,7 @@ class TestResolveDoi:
         called_url = mock_get.call_args[0][0]
         assert called_url == "https://api.crossref.org/works/10.1/x"
         headers = mock_get.call_args.kwargs["headers"]
-        assert "zotero-cli-cc" in headers["User-Agent"]
+        assert "zotero-cli-ai" in headers["User-Agent"]
 
     @patch("zotero_cli_cc.core.metadata_resolver.httpx.get")
     def test_404_returns_none(self, mock_get: MagicMock) -> None:

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -112,26 +112,26 @@ class TestCheckForUpdate:
 
 class TestUpgradeCommand:
     def test_uv_tool_install(self):
-        exe = "/Users/me/.local/share/uv/tools/zotero-cli-cc/bin/python"
-        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-cc"
+        exe = "/Users/me/.local/share/uv/tools/zotero-cli-ai/bin/python"
+        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-ai"
 
     def test_pipx_install(self):
-        exe = "/Users/me/.local/pipx/venvs/zotero-cli-cc/bin/python"
-        assert upgrade_command(exe) == "pipx upgrade zotero-cli-cc"
+        exe = "/Users/me/.local/pipx/venvs/zotero-cli-ai/bin/python"
+        assert upgrade_command(exe) == "pipx upgrade zotero-cli-ai"
 
     def test_conda_install_falls_back_to_pip(self):
         exe = "/Users/me/mambaforge/bin/python"
-        assert upgrade_command(exe) == "pip install -U zotero-cli-cc"
+        assert upgrade_command(exe) == "pip install -U zotero-cli-ai"
 
     def test_system_pip_falls_back_to_pip(self):
         exe = "/usr/bin/python3"
-        assert upgrade_command(exe) == "pip install -U zotero-cli-cc"
+        assert upgrade_command(exe) == "pip install -U zotero-cli-ai"
 
     def test_windows_uv_tool_path(self):
-        exe = r"C:\Users\me\AppData\Roaming\uv\tools\zotero-cli-cc\Scripts\python.exe"
-        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-cc"
+        exe = r"C:\Users\me\AppData\Roaming\uv\tools\zotero-cli-ai\Scripts\python.exe"
+        assert upgrade_command(exe) == "uv tool upgrade zotero-cli-ai"
 
     def test_uses_sys_executable_by_default(self):
         with patch("zotero_cli_cc.core.version_check.sys") as mock_sys:
-            mock_sys.executable = "/opt/uv/tools/zotero-cli-cc/bin/python"
-            assert upgrade_command() == "uv tool upgrade zotero-cli-cc"
+            mock_sys.executable = "/opt/uv/tools/zotero-cli-ai/bin/python"
+            assert upgrade_command() == "uv tool upgrade zotero-cli-ai"

--- a/uv.lock
+++ b/uv.lock
@@ -2269,7 +2269,7 @@ wheels = [
 ]
 
 [[package]]
-name = "zotero-cli-cc"
+name = "zotero-cli-ai"
 version = "0.10.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

Renames the PyPI distribution `zotero-cli-cc` → `zotero-cli-ai` (the name is available on PyPI; `zotero-cli` is an unrelated older project).

**Unchanged on purpose** (verified in the diff):
- `zot` command, `zotero_cli_cc` Python module (distribution name ≠ import name)
- Zotero bridge plugin ID `zot-cli-bridge@zotero-cli-cc.org` (plugin IDs must stay stable across updates)
- `~/.cache/zotero-cli-cc` idempotency cache dir (avoids orphaning the retry-safety cache)

**Changed**
- `pyproject.toml` name + `uv.lock`
- README/README_CN: install commands, PyPI badges, explanatory note
- `version_check`: PyPI URL + upgrade commands; `__init__` distribution lookup
- pip-install hints in pdf/mcp/bridge error messages; User-Agent string
- docs (installation, mcp setup, comparison, index, quickstart, claude-code), CONTRIBUTING, LICENSE-COMMERCIAL, CLAUDE.md, CHANGELOG
- bridge manifest: author + repo URLs

## Test plan
- `uv sync` reinstalls as `zotero-cli-ai==0.10.0`; `__version__` resolves via the new name
- ruff / format / mypy clean; targeted tests (version_check, metadata_resolver, bridge_install, cli_config, mcp_server): 138 passed
- `uv build` produces `zotero_cli_ai-0.10.0` wheel+sdist

## Release note
Before the next tag, register a **pending trusted publisher** on PyPI for `zotero-cli-ai` (repo `Agents365-ai/zotero-cli`, workflow `publish.yml`, environment `pypi`) — otherwise the publish workflow cannot create the new package. PyPI badges in the README will show the version once the first `zotero-cli-ai` release is published.