### PR TITLE
chore: release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-17
+
 ### Changed
 
 - **PyPI distribution renamed** `zotero-cli-cc` → `zotero-cli-ai`. Install or
@@ -16,6 +18,23 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   further updates; `zotero-cli` is an unrelated older project.
 - Project branding unified as "zotero-cli — A Zotero CLI for Any AI Agent"
   (was positioned as Claude Code-only).
+
+### Fixed
+
+- **`zot config profile set` was a silent no-op** on configs written by `zot`
+  itself (single-quoted TOML values weren't matched); `save_config` now emits
+  properly escaped double-quoted TOML, and `config.toml` is written `0600`
+  with the config dir at `0700` (#89).
+- **`update-status` and `pdf` broke the JSON agent contract** — prose mixed
+  into stdout. All machine output now goes through the JSON envelope, prose
+  to stderr (#89).
+- **Library-scale reads could exceed `SQLITE_MAX_VARIABLE_NUMBER`** — the
+  remaining `IN (...)` clauses are batched, with a Python-side sort fallback
+  for very large sorted queries; database paths containing `?`, `#` or `%`
+  no longer corrupt the SQLite URI (#89).
+- **`zot open` on Windows** uses `os.startfile` instead of `shell=True`;
+  MinerU split chunks go to a temporary directory instead of polluting
+  Zotero storage (#89).
 
 ## [0.10.0] - 2026-07-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-ai"
-version = "0.10.0"
+version = "0.11.0"
 description = "Zotero CLI for any AI agent — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2270,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-ai"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release PR for v0.11.0 — first release under the new `zotero-cli-ai` distribution name.

- CHANGELOG: 0.11.0 section (rename + rebrand as Changed, #89 hardening as Fixed)
- pyproject.toml: 0.10.0 → 0.11.0
- uv.lock refreshed

After merge: tag `v0.11.0` to trigger the PyPI publish workflow (pending trusted publisher is registered).