### PR TITLE
chore: release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-17
+
 ### Changed
 
 - **The `workspace` concept is gone** — it lasted one release as a synonym for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-ai"
-version = "0.12.0"
+version = "0.13.0"
 description = "Zotero CLI for any AI agent — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-ai"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release PR for v0.13.0 — workspace 概念移除，检索收敛为 search --ranked / ask --collection（#95）。

- CHANGELOG: 0.13.0 section
- pyproject.toml: 0.12.0 → 0.13.0
- uv.lock refreshed

合并后打 `v0.13.0` tag 触发 PyPI 发布。