### PR TITLE
bridge: support Zotero 10 (bump strict_max_version, v0.4.1)

### DIFF
--- a/extension/zot-cli-bridge/README.md
+++ b/extension/zot-cli-bridge/README.md
@@ -1,6 +1,6 @@
 # Zot CLI Bridge — Zotero plugin
 
-A tiny Zotero 7 plugin that exposes Zotero's built-in **"Find Full Text"** over
+A tiny Zotero plugin (Zotero 7–10) that exposes Zotero's built-in **"Find Full Text"** over
 the desktop's local HTTP server, so the [`zot`](../..) CLI (and AI agents
 driving it) can trigger PDF retrieval without leaving the terminal.
 
@@ -51,7 +51,7 @@ zot bridge status        # verify -> Bridge OK
 
    ```bash
    curl http://127.0.0.1:23119/zot-cli/ping
-   # {"ok": true, "bridge_version": "0.4.0", "zotero_version": "9.x.y", ...}
+   # {"ok": true, "bridge_version": "0.4.1", "zotero_version": "10.x.y", ...}
    ```
 
 You can now run `zot find-pdf <item-key>` and `zot attach <key> --file <path> --via-bridge` from the parent repo.

--- a/extension/zot-cli-bridge/manifest.json
+++ b/extension/zot-cli-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zot CLI Bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Exposes Zotero Find Full Text, attachment rename, and local file import over the local HTTP server for the zot CLI.",
   "author": "Agents365-ai",
   "homepage_url": "https://github.com/Agents365-ai/zotero-cli-ai",
@@ -14,7 +14,7 @@
       "id": "zot-cli-bridge@zotero-cli-cc.org",
       "update_url": "https://github.com/Agents365-ai/zotero-cli-ai/releases/download/bridge/update.json",
       "strict_min_version": "7.999",
-      "strict_max_version": "9.*"
+      "strict_max_version": "10.0.*"
     }
   }
 }


### PR DESCRIPTION
Zotero 10 stable builds enforce `strict_max_version`; the bridge pinned to `9.*` gets disabled on upgrade (confirmed on a live 10.0 install: `/zot-cli/ping` → "No endpoint found").

Per [Zotero 10 for Developers](https://www.zotero.org/support/dev/zotero_10_for_developers), plugins that don't use removed APIs only need the manifest bump. Verified `bootstrap.js` against the full removal list: no `ZoteroPane` singular getters, no `collectionTreeRow`, no `CookieSandbox`, no `Zotero.FullText` APIs, no direct DB access. Endpoints register via `Zotero.Server.Endpoints` (unchanged), and the local-server hardening (Host allowlist, browser-UA/Origin drop) doesn't affect the CLI client (`zot-cli/local-bridge` UA, no Origin).

- `strict_max_version`: `9.*` → `10.0.*` (official recommendation); min stays `7.999` so 7/8/9 keep working
- bridge version `0.4.0` → `0.4.1`
- README: version examples + support range

Note: the `update_url` target (release `bridge`) doesn't exist yet — auto-update never worked. After this merges I'll create that release with the 0.4.1 XPI + `update.json` so future compat bumps can ship without manual reinstalls.