### PR TITLE
bridge: add update.json update manifest

### DIFF
--- a/extension/zot-cli-bridge/update.json
+++ b/extension/zot-cli-bridge/update.json
@@ -1,0 +1,18 @@
+{
+  "addons": {
+    "zot-cli-bridge@zotero-cli-cc.org": {
+      "updates": [
+        {
+          "version": "0.4.1",
+          "update_link": "https://github.com/Agents365-ai/zotero-cli-ai/releases/download/bridge/zot-cli-bridge.xpi",
+          "applications": {
+            "zotero": {
+              "strict_min_version": "7.999",
+              "strict_max_version": "10.0.*"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The bridge manifest's `update_url` (`releases/download/bridge/update.json`) has been a 404 since 0.4.0 — the release was never created, so auto-update never worked. This puts the update manifest under version control; after merge I'll create the `bridge` release with this file + the 0.4.1 XPI as assets, making future compat bumps (like the Zotero 10 one) auto-deliverable.