### PR TITLE
chore: release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-19
+
 ### Changed
 
 - **Ranked retrieval now uses Zotero 10's FTS5 full-text index** — Zotero 10
@@ -23,6 +25,12 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Bridge plugin supports Zotero 10** — the bundled `zot-cli-bridge`
+  extension's manifest pinned `strict_max_version: 9.*`, so Zotero 10 (which
+  enforces it on stable builds) disabled the plugin and the `/zot-cli/*`
+  endpoints went dead. Bumped to `10.0.*` (bridge v0.4.1); the plugin uses
+  none of the APIs removed in Zotero 10. Reinstall the XPI (`zot bridge
+  install`) after upgrading Zotero.
 - **Local reads against a running Zotero 10** — Zotero 10 holds
   `PRAGMA locking_mode=EXCLUSIVE` with `journal_mode=WAL` on zotero.sqlite for
   the app's whole lifetime, so no external process can open the database even

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-cli-ai"
-version = "0.13.0"
+version = "0.14.0"
 description = "Zotero CLI for any AI agent — SQLite reads + Web API writes"
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2118,7 +2118,7 @@ wheels = [
 
 [[package]]
 name = "zotero-cli-ai"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Zotero 10 compatibility release:

- **Changed**: ranked retrieval on Zotero 10's FTS5 index (fulltext.sqlite, bm25, CJK bigram routing) — legacy fulltextWords path dropped, pre-10 data dirs degrade to metadata-only with a warning (#100)
- **Fixed**: WAL-safe local reads under Zotero 10's exclusive DB lock (live reads when closed, DB+WAL snapshot while running) (#99)
- **Fixed**: bridge plugin compat bump to `10.0.*` (v0.4.1) (#98)

Merge → tag `v0.14.0` → publish.yml pushes to PyPI.