### PR TITLE
feat(note): convert markdown to HTML when adding notes

### DIFF
--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -40,7 +40,7 @@ In JSON mode, commands use the standard shapes below.
   "ok": true,
   "data": { "key": "ABC123", "title": "..." },
   "meta": {
-    "schema_version": "1.9.0",
+    "schema_version": "1.10.0",
     "cli_version": "0.3.0",
     "request_id": "a1b2c3d4e5f6",
     "latency_ms": 412
@@ -70,7 +70,7 @@ Mutating command envelopes may include `data.sync_required`; when present, it is
     "retryable": false,
     "hint": "Run 'zot search' to find valid item keys"
   },
-  "meta": { "request_id": "...", "schema_version": "1.9.0" }
+  "meta": { "request_id": "...", "schema_version": "1.10.0" }
 }
 ```
 
@@ -493,7 +493,7 @@ JSON output envelopes the extracted content:
     "text": "...",
     "meta": { "extractor": "pymupdf", "cached": true }
   },
-  "meta": { "schema_version": "1.9.0", ... }
+  "meta": { "schema_version": "1.10.0", ... }
 }
 ```
 
@@ -604,7 +604,7 @@ Ranked JSON output:
       }
     ]
   },
-  "meta": { "schema_version": "1.9.0", ... }
+  "meta": { "schema_version": "1.10.0", ... }
 }
 ```
 
@@ -630,7 +630,7 @@ zot ask "what dataset was used?" --collection papers --evidence-k 8
     ],
     "answer_instructions": "Answer the question using ONLY the evidence below. Cite each claim with its cite_key in parentheses, e.g. (ABCD1234). ..."
   },
-  "meta": { "schema_version": "1.9.0", ... }
+  "meta": { "schema_version": "1.10.0", ... }
 }
 ```
 

--- a/docs/en/guide/notes-tags.md
+++ b/docs/en/guide/notes-tags.md
@@ -17,6 +17,23 @@ zot note ABC123 --add "This paper proposes a new attention mechanism"
 !!! note "Write operations require API credentials"
     See [Setup](../getting-started/setup.md#api-credentials) to configure your API key.
 
+### Markdown handling
+
+Zotero stores notes as HTML, so `--add` converts Markdown to HTML before submitting:
+
+- YAML frontmatter (`--- ... ---`) at the top of the note is stripped.
+- Obsidian callouts (`> [!type] text`) become blockquotes with the text in bold.
+- Headings, emphasis, lists, links, code, and tables render as Zotero formatting.
+
+Pass `--raw` to store the content verbatim (e.g. when you already have HTML):
+
+```bash
+zot note ABC123 --add "<p>Already <strong>HTML</strong>.</p>" --raw
+```
+
+!!! warning "Do not POST raw `**` Markdown"
+    The Zotero API escapes Markdown emphasis it does not interpret: posting `**bold**` stores `\*\*bold\*\*`, which Zotero renders as literal text. Always let `--add` convert, or pass `--raw` with HTML.
+
 ## Update a Note
 
 Notes can be updated via the MCP tools (`note_update`). See [MCP Tools Reference](../mcp/tools.md).

--- a/docs/en/mcp/tools.md
+++ b/docs/en/mcp/tools.md
@@ -37,8 +37,8 @@
 | `delete` | Delete items (trash) | `keys` |
 | `update` | Update metadata | `key`, `title?`, `date?`, `fields?` |
 | `attach` | Upload file attachment | `parent_key`, `file_path`, `via_bridge?` |
-| `note_add` | Add note to item | `key`, `content` |
-| `note_update` | Update existing note | `note_key`, `content` |
+| `note_add` | Add note to item (Markdown auto-converted to HTML; pass `raw=True` for verbatim) | `key`, `content`, `raw?` |
+| `note_update` | Update existing note (Markdown auto-converted to HTML; pass `raw=True` for verbatim) | `note_key`, `content`, `raw?` |
 | `tag_add` | Add tags to items | `keys`, `tags` |
 | `tag_remove` | Remove tags from items | `keys`, `tags` |
 | `collection_create` | Create collection | `name`, `parent_key?` |

--- a/docs/zh/guide/notes-tags.md
+++ b/docs/zh/guide/notes-tags.md
@@ -17,6 +17,23 @@ zot note ABC123 --add "这篇论文提出了一种新的注意力机制"
 !!! note "写入操作需要 API 凭据"
     请参阅 [配置](../getting-started/setup.md#api) 来设置 API 密钥。
 
+### Markdown 处理
+
+Zotero 以 HTML 存储笔记，因此 `--add` 会在提交前把 Markdown 转换为 HTML：
+
+- 笔记开头的 YAML frontmatter（`--- ... ---`）会被剥离。
+- Obsidian callout（`> [!type] text`）会转换为加粗文本的 blockquote。
+- 标题、强调、列表、链接、代码和表格会渲染为 Zotero 格式。
+
+传入 `--raw` 可以原样存储内容（例如当你已经有 HTML 时）：
+
+```bash
+zot note ABC123 --add "<p>Already <strong>HTML</strong>.</p>" --raw
+```
+
+!!! warning "不要直接提交 `**` Markdown"
+    Zotero API 会把它无法解释的 Markdown 强调字符转义：提交 `**bold**` 会存储为 `\*\*bold\*\*`，在 Zotero 中渲染为字面文本。请始终让 `--add` 完成转换，或配合 `--raw` 传入 HTML。
+
 ## 更新笔记
 
 可以通过 MCP 工具（`note_update`）更新笔记。参见 [MCP 工具参考](../mcp/tools.md)。

--- a/docs/zh/mcp/tools.md
+++ b/docs/zh/mcp/tools.md
@@ -37,8 +37,8 @@
 | `delete` | 删除条目（移入回收站） | `keys` |
 | `update` | 更新元数据 | `key`, `title?`, `date?`, `fields?` |
 | `attach` | 上传附件 | `parent_key`, `file_path`, `via_bridge?` |
-| `note_add` | 添加笔记 | `key`, `content` |
-| `note_update` | 更新笔记 | `note_key`, `content` |
+| `note_add` | 添加笔记（Markdown 自动转 HTML；传 `raw=True` 原样存储） | `key`, `content`, `raw?` |
+| `note_update` | 更新笔记（Markdown 自动转 HTML；传 `raw=True` 原样存储） | `note_key`, `content`, `raw?` |
 | `tag_add` | 添加标签 | `keys`, `tags` |
 | `tag_remove` | 删除标签 | `keys`, `tags` |
 | `collection_create` | 创建集合 | `name`, `parent_key?` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyzotero>=1.5",
     "pypdfium2>=4.30",
     "rich>=13.0",
+    "markdown-it-py>=2.2.0",
     "tomli>=2.0; python_version < '3.11'",
     "markdownify>=1.2.2",
     "requests>=2.31",

--- a/src/zotero_cli_cc/commands/note.py
+++ b/src/zotero_cli_cc/commands/note.py
@@ -6,6 +6,7 @@ import click
 
 from zotero_cli_cc.commands._helpers import build_writer, open_reader
 from zotero_cli_cc.config import load_config
+from zotero_cli_cc.core.markdown import md_to_zotero_html
 from zotero_cli_cc.core.writer import SYNC_REMINDER, ZoteroWriteError
 from zotero_cli_cc.exit_codes import emit_error
 from zotero_cli_cc.formatter import envelope_ok, format_notes
@@ -13,7 +14,8 @@ from zotero_cli_cc.formatter import envelope_ok, format_notes
 
 @click.command("note")
 @click.argument("key")
-@click.option("--add", "content", default=None, help="Add a new note")
+@click.option("--add", "content", default=None, help="Add a new note (Markdown, converted to HTML)")
+@click.option("--raw", is_flag=True, help="Store note content verbatim, skipping Markdown-to-HTML conversion")
 @click.option("--dry-run", is_flag=True, help="Preview the note addition without executing (only with --add)")
 @click.option("--idempotency-key", default=None, help="Key so retries are safe; same key returns the original result")
 @click.pass_context
@@ -21,15 +23,23 @@ def note_cmd(
     ctx: click.Context,
     key: str,
     content: str | None,
+    raw: bool,
     dry_run: bool,
     idempotency_key: str | None,
 ) -> None:
-    """View or add notes for an item. `--add` MUTATES LIBRARY.
+    """View a note or add one to an item. `--add` MUTATES LIBRARY.
+
+    \b
+    Zotero stores notes as HTML, so `--add` converts Markdown to HTML before
+    submitting: YAML frontmatter is stripped and Obsidian callouts
+    (> [!type] ...) become bold blockquotes. Use `--raw` to store the content
+    verbatim instead.
 
     \b
     Examples:
       zot note ABC123                            View notes
-      zot note ABC123 --add "Key finding: ..."   Add a note
+      zot note ABC123 --add "Key finding: ..."   Add a note (Markdown -> HTML)
+      zot note ABC123 --add "<p>...</p>" --raw   Add verbatim HTML
       zot note ABC123 --add "..." --dry-run      Preview addition
       zot --json note ABC123                     JSON output
     """
@@ -37,12 +47,13 @@ def note_cmd(
     json_out = ctx.obj.get("json", False)
 
     if content:
+        payload = content if raw else md_to_zotero_html(content)
         if dry_run:
-            data = {"would": {"parent": key, "content_preview": content[:200]}}
+            data = {"would": {"parent": key, "content_preview": payload[:200]}}
             if json_out:
                 click.echo(json.dumps(envelope_ok(data, extra={"dry_run": True}), indent=2, ensure_ascii=False))
             else:
-                click.echo(f"[dry-run] Would add note to '{key}': {content[:80]}...")
+                click.echo(f"[dry-run] Would add note to '{key}': {payload[:80]}...")
             return
 
         from zotero_cli_cc.core.idempotency import get_cached, store_cached
@@ -59,7 +70,7 @@ def note_cmd(
 
         writer = build_writer(ctx, cfg, json_out, context="note")
         try:
-            note_key = writer.add_note(key, content)
+            note_key = writer.add_note(key, payload)
         except ZoteroWriteError as e:
             emit_error(
                 e.code,

--- a/src/zotero_cli_cc/core/markdown.py
+++ b/src/zotero_cli_cc/core/markdown.py
@@ -1,0 +1,77 @@
+"""Markdown helpers for the Zotero note write path.
+
+Zotero stores notes as HTML (``itemNotes.note``) and the Web API round-trips
+HTML verbatim, but treats content with no HTML tags as plain text and
+server-converts it, escaping markdown metacharacters it does not interpret
+(e.g. ``**bold**`` is stored as ``\\*\\*bold\\*\\*`` and rendered literally).
+To get correct rendering, ``zot note --add`` converts the caller's markdown
+to HTML before POSTing. These helpers strip Obsidian-only syntax (YAML
+frontmatter, callouts) and render the rest with markdown-it (CommonMark).
+"""
+
+from __future__ import annotations
+
+import re
+
+from markdown_it import MarkdownIt
+
+_RENDERER = MarkdownIt("commonmark", {"html": True}).enable(["table", "strikethrough"])
+
+# Leading `--- ... ---` (or `...`) block. Only a *closing* fence is matched;
+# whether to strip at all is decided in strip_yaml_frontmatter.
+_FRONTMATTER_RE = re.compile(
+    r"\A---[ \t]*\r?\n"
+    r"(?P<body>.*?)"
+    r"\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|\Z)",
+    re.DOTALL,
+)
+
+_CALLOUT_RE = re.compile(r"^>\s*\[!([A-Za-z][A-Za-z0-9_-]*)\]\s*(.*)$")
+
+
+def strip_yaml_frontmatter(md: str) -> str:
+    """Drop a leading YAML frontmatter block, if present.
+
+    Follows Obsidian's rule: the block must start the document and contain at
+    least one ``key: value`` pair. A note that merely opens with a horizontal
+    rule (``---`` alone) is left untouched.
+    """
+    m = _FRONTMATTER_RE.match(md)
+    if m is None:
+        return md
+    if not re.search(r"^\s*\S+\s*:", m.group("body"), re.M):
+        return md
+    return md[m.end() :]
+
+
+def convert_obsidian_callouts(md: str) -> str:
+    """Lower Obsidian callout markers to bold blockquote labels.
+
+    ``> [!type] rest`` becomes ``> **rest**`` (or ``> **type**`` when there is
+    no rest), keeping any following ``> body`` lines as normal blockquote
+    lines. Zotero has no callout concept, so the marker must not survive as
+    literal text.
+    """
+    out: list[str] = []
+    for line in md.split("\n"):
+        m = _CALLOUT_RE.match(line)
+        if m is None:
+            out.append(line)
+            continue
+        label = m.group(2).strip() or m.group(1)
+        out.append(f"> **{label}**")
+    return "\n".join(out)
+
+
+def md_to_zotero_html(md: str) -> str:
+    """Convert markdown to HTML for Zotero's note field.
+
+    Content that already starts with ``<`` is treated as HTML and returned
+    unchanged (the MCP tools accept HTML or markdown). Anything else is
+    treated as markdown: YAML frontmatter is stripped, Obsidian callouts are
+    lowered to bold blockquotes, and the remainder is rendered to HTML.
+    """
+    if md.lstrip().startswith("<"):
+        return md
+    prepared = convert_obsidian_callouts(strip_yaml_frontmatter(md))
+    return str(_RENDERER.render(prepared)).strip()

--- a/src/zotero_cli_cc/formatter.py
+++ b/src/zotero_cli_cc/formatter.py
@@ -18,7 +18,7 @@ from rich.tree import Tree
 from zotero_cli_cc import __version__
 from zotero_cli_cc.models import Collection, DuplicateGroup, ErrorInfo, Item, Note
 
-SCHEMA_VERSION = "1.9.0"
+SCHEMA_VERSION = "1.10.0"
 
 _request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_id", default=None)
 _request_start: contextvars.ContextVar[float | None] = contextvars.ContextVar("_request_start", default=None)

--- a/src/zotero_cli_cc/mcp_server.py
+++ b/src/zotero_cli_cc/mcp_server.py
@@ -15,6 +15,7 @@ from zotero_cli_cc.config import (
     load_config,
     load_pdf_config,
 )
+from zotero_cli_cc.core.markdown import md_to_zotero_html
 from zotero_cli_cc.core.pdf_cache import PdfCache
 from zotero_cli_cc.core.pdf_extractor import PdfExtractionError, get_extractor
 from zotero_cli_cc.core.rank import build_ask_evidence, make_snippet, rank, resolve_collection_key
@@ -448,19 +449,19 @@ def _handle_duplicates(strategy: str = "both", threshold: float = 0.85, limit: i
 # ---------------------------------------------------------------------------
 
 
-def _handle_note_add(key: str, content: str, library: str = "user") -> dict:
+def _handle_note_add(key: str, content: str, library: str = "user", raw: bool = False) -> dict:
     try:
         writer = _get_writer(library)
-        note_key = writer.add_note(key, content)
+        note_key = writer.add_note(key, content if raw else md_to_zotero_html(content))
         return {"note_key": note_key}
     except ZoteroWriteError as e:
         return {"error": str(e), "context": "note_add"}
 
 
-def _handle_note_update(note_key: str, content: str, library: str = "user") -> dict:
+def _handle_note_update(note_key: str, content: str, library: str = "user", raw: bool = False) -> dict:
     try:
         writer = _get_writer(library)
-        writer.update_note(note_key, content)
+        writer.update_note(note_key, content if raw else md_to_zotero_html(content))
         return {"note_key": note_key, "updated": True}
     except ZoteroWriteError as e:
         return {"error": str(e), "context": "note_update"}
@@ -1127,27 +1128,37 @@ def duplicates(strategy: str = "both", threshold: float = 0.85, limit: int = 50,
 
 
 @mcp.tool()
-def note_add(key: str, content: str, library: str = "user") -> dict:
+def note_add(key: str, content: str, library: str = "user", raw: bool = False) -> dict:
     """Add a note to a Zotero item.
+
+    Zotero stores notes as HTML, so Markdown content is converted to HTML
+    before submitting (YAML frontmatter is stripped, Obsidian callouts become
+    bold blockquotes). Pass ``raw=True`` to store the content verbatim.
 
     Args:
         key: The Zotero item key to attach the note to.
-        content: The note content (HTML or plain text).
+        content: The note content (Markdown, or HTML if raw=True).
         library: Library — 'user' (default) or 'group:<id>'.
+        raw: Store content verbatim without Markdown-to-HTML conversion.
     """
-    return _handle_note_add(key, content, library=library)
+    return _handle_note_add(key, content, library=library, raw=raw)
 
 
 @mcp.tool()
-def note_update(note_key: str, content: str, library: str = "user") -> dict:
+def note_update(note_key: str, content: str, library: str = "user", raw: bool = False) -> dict:
     """Update an existing note in the Zotero library.
+
+    Zotero stores notes as HTML, so Markdown content is converted to HTML
+    before submitting (YAML frontmatter is stripped, Obsidian callouts become
+    bold blockquotes). Pass ``raw=True`` to pass the content verbatim.
 
     Args:
         note_key: The Zotero note key to update.
-        content: The new note content (HTML or plain text).
+        content: The new note content (Markdown, or HTML if raw=True).
         library: Library — 'user' (default) or 'group:<id>'.
+        raw: Store content verbatim without Markdown-to-HTML conversion.
     """
-    return _handle_note_update(note_key, content, library=library)
+    return _handle_note_update(note_key, content, library=library, raw=raw)
 
 
 @mcp.tool()

--- a/tests/test_cli_note.py
+++ b/tests/test_cli_note.py
@@ -30,7 +30,7 @@ def test_note_read_json(test_db_path):
 
 
 @patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
-def test_note_add(mock_writer_cls, test_db_path):
+def test_note_add_converts_markdown_to_html(mock_writer_cls, test_db_path):
     mock_writer = MagicMock()
     mock_writer_cls.return_value = mock_writer
     mock_writer.add_note.return_value = "NEWNOTE"
@@ -38,7 +38,7 @@ def test_note_add(mock_writer_cls, test_db_path):
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["note", "ATTN001", "--add", "New note"],
+        ["note", "ATTN001", "--add", "**New note**"],
         env={
             "ZOT_DATA_DIR": str(test_db_path.parent),
             "ZOT_LIBRARY_ID": "123",
@@ -47,14 +47,35 @@ def test_note_add(mock_writer_cls, test_db_path):
         },
     )
     assert result.exit_code == 0
-    mock_writer.add_note.assert_called_once()
+    mock_writer.add_note.assert_called_once_with("ATTN001", "<p><strong>New note</strong></p>")
 
 
-def test_note_add_dry_run(test_db_path):
+@patch("zotero_cli_cc.commands._helpers.ZoteroWriter")
+def test_note_add_raw_stores_verbatim(mock_writer_cls, test_db_path):
+    mock_writer = MagicMock()
+    mock_writer_cls.return_value = mock_writer
+    mock_writer.add_note.return_value = "NEWNOTE"
+
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["note", "ATTN001", "--add", "New note", "--dry-run"],
+        ["note", "ATTN001", "--add", "<p>New note</p>", "--raw"],
+        env={
+            "ZOT_DATA_DIR": str(test_db_path.parent),
+            "ZOT_LIBRARY_ID": "123",
+            "ZOT_API_KEY": "abc",
+            "ZOT_FORMAT": "table",
+        },
+    )
+    assert result.exit_code == 0
+    mock_writer.add_note.assert_called_once_with("ATTN001", "<p>New note</p>")
+
+
+def test_note_add_dry_run_previews_converted_html(test_db_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["note", "ATTN001", "--add", "# Heading\n**bold**", "--dry-run"],
         env={
             "ZOT_DATA_DIR": str(test_db_path.parent),
             "ZOT_LIBRARY_ID": "123",
@@ -64,3 +85,5 @@ def test_note_add_dry_run(test_db_path):
     )
     assert result.exit_code == 0
     assert "Would add note" in result.output
+    assert "<h1>Heading</h1>" in result.output
+    assert "<strong>bold</strong>" in result.output

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,78 @@
+"""Unit tests for core.markdown (Zotero note write-path conversion)."""
+
+from zotero_cli_cc.core.markdown import (
+    convert_obsidian_callouts,
+    md_to_zotero_html,
+    strip_yaml_frontmatter,
+)
+
+
+class TestStripYamlFrontmatter:
+    def test_strips_frontmatter(self):
+        md = "---\ntitle: My paper\ntags: [cd]\n---\n# Heading"
+        assert strip_yaml_frontmatter(md) == "# Heading"
+
+    def test_strips_crlf_frontmatter(self):
+        md = "---\r\ntitle: x\r\n---\r\n# H"
+        assert strip_yaml_frontmatter(md) == "# H"
+
+    def test_strips_end_dot_fence(self):
+        md = "---\ntitle: x\n...\n# H"
+        assert strip_yaml_frontmatter(md) == "# H"
+
+    def test_keeps_missing_key_value(self):
+        # A leading `---` that is a horizontal rule, not frontmatter.
+        md = "---\nsome text\n---"
+        assert strip_yaml_frontmatter(md) == md
+
+    def test_keeps_plain_note(self):
+        md = "Just a note.\n"
+        assert strip_yaml_frontmatter(md) == md
+
+
+class TestConvertObsidianCallouts:
+    def test_callout_with_title(self):
+        assert convert_obsidian_callouts("> [!note] 核心发现:重点\n> 正文") == "> **核心发现:重点**\n> 正文"
+
+    def test_callout_without_title(self):
+        assert convert_obsidian_callouts("> [!warning]\n> body") == "> **warning**\n> body"
+
+    def test_leaves_plain_blockquote(self):
+        assert convert_obsidian_callouts("> normal quote") == "> normal quote"
+
+
+class TestMdToZoteroHtml:
+    def test_emphasis_and_heading(self):
+        out = md_to_zotero_html("# H\n**bold** *italic*")
+        assert "<h1>H</h1>" in out
+        assert "<strong>bold</strong>" in out
+        assert "<em>italic</em>" in out
+
+    def test_no_backslash_escaped_asterisks(self):
+        out = md_to_zotero_html("**bold**")
+        assert "\\*" not in out
+
+    def test_strips_frontmatter_and_callout(self):
+        out = md_to_zotero_html("---\ntitle: x\n---\n> [!note] 重点\n> 正文")
+        assert "title: x" not in out
+        assert "[!note]" not in out
+        assert "<strong>重点</strong>" in out
+
+    def test_table_renders(self):
+        out = md_to_zotero_html("| a | b |\n|---|---|\n| 1 | 2 |")
+        assert "<table>" in out
+        assert "<th>a</th>" in out
+
+    def test_html_passthrough(self):
+        html = '<div class="zotero-note"><p><strong>y</strong></p></div>'
+        assert md_to_zotero_html(html) == html
+
+    def test_html_passthrough_with_leading_space(self):
+        html = "  <p>x</p>"
+        assert md_to_zotero_html(html) == html
+
+    def test_plain_text_becomes_paragraph(self):
+        assert md_to_zotero_html("hello world") == "<p>hello world</p>"
+
+    def test_empty(self):
+        assert md_to_zotero_html("") == ""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -627,7 +627,7 @@ class TestGetWriter:
 
 class TestHandleNoteAdd:
     @patch("zotero_cli_cc.mcp_server._get_writer")
-    def test_adds_note(self, mock_get_writer):
+    def test_adds_note_converts_markdown(self, mock_get_writer):
         from zotero_cli_cc.mcp_server import _handle_note_add
 
         writer = MagicMock()
@@ -636,12 +636,24 @@ class TestHandleNoteAdd:
 
         result = _handle_note_add("ABC123", "Some note content")
         assert result["note_key"] == "NOTE2"
-        writer.add_note.assert_called_once_with("ABC123", "Some note content")
+        writer.add_note.assert_called_once_with("ABC123", "<p>Some note content</p>")
+
+    @patch("zotero_cli_cc.mcp_server._get_writer")
+    def test_adds_note_raw_skips_conversion(self, mock_get_writer):
+        from zotero_cli_cc.mcp_server import _handle_note_add
+
+        writer = MagicMock()
+        writer.add_note.return_value = "NOTE2"
+        mock_get_writer.return_value = writer
+
+        result = _handle_note_add("ABC123", "<p>Already HTML</p>", raw=True)
+        assert result["note_key"] == "NOTE2"
+        writer.add_note.assert_called_once_with("ABC123", "<p>Already HTML</p>")
 
 
 class TestHandleNoteUpdate:
     @patch("zotero_cli_cc.mcp_server._get_writer")
-    def test_updates_note(self, mock_get_writer):
+    def test_updates_note_converts_markdown(self, mock_get_writer):
         from zotero_cli_cc.mcp_server import _handle_note_update
 
         writer = MagicMock()
@@ -650,7 +662,19 @@ class TestHandleNoteUpdate:
         result = _handle_note_update("NOTE1", "Updated content")
         assert result["note_key"] == "NOTE1"
         assert result["updated"] is True
-        writer.update_note.assert_called_once_with("NOTE1", "Updated content")
+        writer.update_note.assert_called_once_with("NOTE1", "<p>Updated content</p>")
+
+    @patch("zotero_cli_cc.mcp_server._get_writer")
+    def test_updates_note_raw_skips_conversion(self, mock_get_writer):
+        from zotero_cli_cc.mcp_server import _handle_note_update
+
+        writer = MagicMock()
+        mock_get_writer.return_value = writer
+
+        result = _handle_note_update("NOTE1", "<p>Updated content</p>", raw=True)
+        assert result["note_key"] == "NOTE1"
+        assert result["updated"] is True
+        writer.update_note.assert_called_once_with("NOTE1", "<p>Updated content</p>")
 
 
 class TestHandleTagAdd:

--- a/uv.lock
+++ b/uv.lock
@@ -2122,6 +2122,7 @@ version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "markdown-it-py" },
     { name = "markdownify" },
     { name = "pypdfium2" },
     { name = "pyzotero" },
@@ -2161,6 +2162,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
+    { name = "markdown-it-py", specifier = ">=2.2.0" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8" },


### PR DESCRIPTION
## Problem

`zot note KEY --add "<markdown>"` stored content verbatim, but Zotero 7 mis-rendered it in two ways:

1. Obsidian syntax was stored as-is: YAML frontmatter rendered as a horizontal rule plus a heading; callouts (`> [!note] text`) rendered as a blockquote with a literal `[!note]` prefix.
2. The Zotero Web API escapes markdown emphasis it does not interpret: posting `**bold**` stores `\*\*bold\*\*`, which Zotero 7 renders as literal text.

Root cause confirmed against a real library: Zotero stores notes as HTML (`itemNotes.note`). Posting content with no HTML tags triggers server-side conversion that escapes emphasis markers; posting HTML round-trips verbatim and renders correctly.

## Changes

- New `core/markdown.py`: strips YAML frontmatter (per Obsidian's key-value rule), lowers Obsidian callouts to bold blockquotes, and renders markdown to HTML via `markdown-it-py` (already a `rich` dependency, no new packages). Already-HTML input passes through unchanged.
- `zot note --add` converts markdown to HTML by default; new `--raw` flag stores content verbatim. `--dry-run` previews the converted HTML.
- MCP `note_add`/`note_update` gain a `raw` param (default converts).
- `SCHEMA_VERSION` bumped 1.9.0 → 1.10.0 (new `--raw`/`raw` schema params); docs updated (en/zh).
- Tests: new `tests/test_markdown.py`; CLI and MCP tests cover conversion and raw paths.

## Read path

`zot note` (read) intentionally does not un-escape `\*`: the read path already mirrors Zotero's own HTML-to-markdown export, and `\*` is legitimate markdown for a literal asterisk. New notes round-trip cleanly (markdown → HTML → markdown); legacy mangled notes can be repaired by re-adding through the fixed `--add`.

## Verification

- `ruff check`, `ruff format --check`, `mypy`, and the full `pytest` suite pass (755 passed, 1 skipped).
- Live smoke test on a real item: a markdown note (heading, bold, italic, callout, list) was added, read back as clean markdown, and the stored HTML was verified as `<h1>`/`<strong>`/`<blockquote><strong>`/`<ul>` with no `\*\*` and no `[!note]`.